### PR TITLE
Fix fields not getting saved when modified by "Replace all" and color indicator in FieldList

### DIFF
--- a/Window.cpp
+++ b/Window.cpp
@@ -895,7 +895,7 @@ void Window::setModified(bool enabled)
 		int fieldId = item->data(0, Qt::UserRole).toInt();
 		if(fieldId >= 0) {
 			Field *curField = fieldArchive->field(fieldId, false);
-			if(curField && curField->isOpen()) {
+			if(curField) {
 				if(enabled && curField->isModified()) {
 					item->setForeground(0, QColor(0xd1,0x1d,0x1d));
 				} else if(!enabled && item->foreground(0).color() == QColor(0xd1,0x1d,0x1d)) {

--- a/widgets/Search.cpp
+++ b/widgets/Search.cpp
@@ -872,6 +872,7 @@ void Search::replaceAll()
 	bool modified = false;
 	while(fieldArchive->searchText(text, fieldID, textID, from, size, sorting, scope)) {
 		if(fieldArchive->replaceText(text, after, fieldID, textID, from)) {
+			fieldArchive->field(fieldID)->setModified(true);
 			modified = true;
 		}
 		from += after.size();


### PR DESCRIPTION
When editing text via the  _Replace all_ button in the _Texts_ section of the _Find_ dialog, only the currently selected field gets marked as modified (provided it actually contained the text to be replaced). Thus only that field gets saved to disc.
The first commit fixes this by simply setting every field modified by `replaceText()` as modified.

Additionally when saving, only the color of the currently selected field in the `FieldList` is changed to green instead of the color of every modified field.
I am not entirely sure whether this is intended behavior or not and if this is the right way to fix it, but the open/closed state of a field should not make a difference when determining the color in the `FieldList`, especially since the save routine closes them all, right?