### PR TITLE
Convert SIGNALS and SLOTS to Qt5 signals and slots

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,8 +26,11 @@ jobs:
         include:
         - aqt_version: '==2.0.0'
           qt_tools: desktop,tools_ninja,qt.tools.ninja
+        - qt: 5.15.2
+          qt_String: "Qt5"
         - qt: 6.2.0
           qt_modules: qt5compat
+          qt_String: "Qt6"
         - os: ubuntu-latest
           package_extension: 'tar.xz'
           package_suffix: 'linux64'
@@ -152,15 +155,16 @@ jobs:
       run: |
         export VERSION=continuous
         export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:${{ env.ff7tk_installation_path }}/lib
+        export PATH=$PATH:${{ env.qt_installation_path }}/Qt/${{ matrix.qt }}/gcc_64/libexec
         linuxdeploy --appdir="${{ env.makoureactor_appbundle_path }}" --plugin=qt --output appimage \
           -e "${{ env.makoureactor_installation_path }}"/bin/Makou_Reactor \
           -d "${{ env.makoureactor_installation_path }}"/share/applications/Makou_Reactor.desktop \
           -i "${{ env.makoureactor_installation_path }}"/share/icons/hicolor/256x256/apps/Makou_Reactor.png
-        mv *.AppImage makoureactor-continuous-${{ matrix.package_suffix }}.AppImage
+        mv *.AppImage makoureactor-continuous-${{ matrix.qt_String }}-${{ matrix.package_suffix }}.AppImage
 
     - name: Prepare Upload
       shell: bash
-      run: mv ../build-makoureactor/*.${{ matrix.package_extension }} makoureactor-continuous-${{ matrix.package_suffix }}.${{ matrix.package_extension }}
+      run: mv ../build-makoureactor/*.${{ matrix.package_extension }} makoureactor-continuous-${{ matrix.qt_String }}-${{ matrix.package_suffix }}.${{ matrix.package_extension }}
 
     - name: Upload
       uses: actions/upload-artifact@v2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -570,7 +570,6 @@ endif()
 target_include_directories(${CLI_TARGET} PRIVATE "${CMAKE_SOURCE_DIR}/src")
 target_link_libraries(${CLI_TARGET} PRIVATE
     ZLIB::ZLIB
-    ff7tk::ff7tkWidgets
     ff7tk::ff7tkFormats
     ff7tk::ff7tkUtils
 )

--- a/lang/CMakeLists.txt
+++ b/lang/CMakeLists.txt
@@ -27,7 +27,7 @@ set(LANGS
 CACHE INTERNAL "")
 list(TRANSFORM LANGS REPLACE ".+" "${RELEASE_NAME}_\\0.ts" OUTPUT_VARIABLE TS_FILES)
 
-qt_create_translation(QM_FILES ${CMAKE_SOURCE_DIR} ${TS_FILES})
+qt_create_translation(QM_FILES ${CMAKE_SOURCE_DIR} ${TS_FILES} OPTIONS -locations none)
 
 add_custom_target(translations ALL DEPENDS ${QM_FILES})
 

--- a/lang/Makou_Reactor_fr.ts
+++ b/lang/Makou_Reactor_fr.ts
@@ -4,12 +4,10 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../src/widgets/AboutDialog.cpp" line="28"/>
         <source>By Jérôme &amp;lt;myst6re&amp;gt; Arzel &lt;br/&gt;&lt;a href=&quot;https://github.com/myst6re/makoureactor/&quot;&gt;github.com/myst6re/makoureactor&lt;/a&gt;</source>
         <translation>Par Jérôme &amp;lt;myst6re&amp;gt; Arzel &lt;br/&gt;&lt;a href=&quot;https://github.com/myst6re/makoureactor/&quot;&gt;github.com/myst6re/makoureactor&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/AboutDialog.cpp" line="34"/>
         <source>Thanks to:&lt;ul style=&quot;margin:0&quot;&gt;&lt;li&gt;Squall78&lt;/li&gt;&lt;li&gt;Synergy Blades&lt;/li&gt;&lt;li&gt;TrueOdin&lt;/li&gt;&lt;li&gt;Akari&lt;/li&gt;&lt;li&gt;Asa&lt;/li&gt;&lt;li&gt;Aali&lt;/li&gt;&lt;li&gt;DLPB&lt;/li&gt;&lt;/ul&gt;</source>
         <translation>Merci à&amp;nbsp;:&lt;ul style=&quot;margin:0&quot;&gt;&lt;li&gt;Squall78&lt;/li&gt;&lt;li&gt;Synergy Blades&lt;/li&gt;&lt;li&gt;TrueOdin&lt;/li&gt;&lt;li&gt;Akari&lt;/li&gt;&lt;li&gt;Asa&lt;/li&gt;&lt;li&gt;Aali&lt;/li&gt;&lt;li&gt;DLPB&lt;/li&gt;&lt;/ul&gt;</translation>
     </message>
@@ -17,7 +15,6 @@
 <context>
     <name>AnimEditorDialog</name>
     <message>
-        <location filename="../src/widgets/AnimEditorDialog.cpp" line="25"/>
         <source>Animation Selector</source>
         <oldsource>Sélection d&apos;une animation</oldsource>
         <translation>Sélection d&apos;une animation</translation>
@@ -26,7 +23,6 @@
 <context>
     <name>ApercuBG</name>
     <message>
-        <location filename="../src/widgets/ApercuBG.cpp" line="82"/>
         <source>Error</source>
         <oldsource>Erreur</oldsource>
         <translation>Erreur</translation>
@@ -47,22 +43,18 @@
 <context>
     <name>ArchivePreview</name>
     <message>
-        <location filename="../src/widgets/ArchivePreview.cpp" line="103"/>
         <source>Image %1</source>
         <translation>Image %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ArchivePreview.cpp" line="116"/>
         <source>Palette %1</source>
         <translation>Palette %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ArchivePreview.cpp" line="131"/>
         <source>Save Background</source>
         <translation>Enregistrer le background</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ArchivePreview.cpp" line="133"/>
         <source>PNG image (*.png);;JPG image (*.jpg);;BMP image (*.bmp);;Portable Pixmap (*.ppm)</source>
         <translation>Image PNG (*.png);;Image JPG (*.jpg);;Image BMP (*.bmp);;Portable Pixmap (*.ppm)</translation>
     </message>
@@ -70,22 +62,18 @@
 <context>
     <name>Arguments</name>
     <message>
-        <location filename="../src/Arguments.cpp" line="47"/>
         <source>Input file or directory.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Arguments.cpp" line="116"/>
         <source>Warning: cannot open file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Arguments.cpp" line="150"/>
         <source>Command to execute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Arguments.cpp" line="155"/>
         <source>
 List of available commands:
   export  Export various assets from archive to files
@@ -95,38 +83,30 @@ List of available commands:
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Arguments.cpp" line="175"/>
         <source>Please specify a command</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Arguments.cpp" line="186"/>
         <source>Unknown command type:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ArgumentsExport.cpp" line="79"/>
         <source>Error: you cannot specify both background and bg-layer parameters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ArgumentsExport.cpp" line="86"/>
-        <location filename="../src/ArgumentsPatch.cpp" line="83"/>
         <source>Error: too much parameters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ArgumentsExport.cpp" line="92"/>
         <source>Error: --psf-lib-path is required with --music psf</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ArgumentsExport.cpp" line="103"/>
         <source>Error: target directory does not exist:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ArgumentsPatch.cpp" line="31"/>
         <source>Output file (optional).</source>
         <translation type="unfinished"></translation>
     </message>
@@ -134,7 +114,6 @@ List of available commands:
 <context>
     <name>ArgumentsExport</name>
     <message>
-        <location filename="../src/ArgumentsExport.cpp" line="32"/>
         <source>Output directory.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -142,82 +121,67 @@ List of available commands:
 <context>
     <name>BGDialog</name>
     <message>
-        <location filename="../src/widgets/BGDialog.cpp" line="53"/>
         <source>Z :</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/widgets/BGDialog.cpp" line="63"/>
         <source>Sections (layer 1)</source>
         <oldsource>Sections (Layer 1)</oldsource>
         <translation>Sections (couche 1)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/BGDialog.cpp" line="65"/>
         <source>Repair</source>
         <oldsource>Réparer</oldsource>
         <translation>Réparer</translation>
     </message>
     <message>
-        <location filename="../src/widgets/BGDialog.cpp" line="149"/>
         <source>Parameter %1</source>
         <oldsource>Paramètre %1</oldsource>
         <translation>Paramètre %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/BGDialog.cpp" line="159"/>
         <source>Section %1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/widgets/BGDialog.cpp" line="330"/>
         <source>Save Background</source>
         <translation>Enregistrer le background</translation>
     </message>
     <message>
-        <location filename="../src/widgets/BGDialog.cpp" line="332"/>
         <source>PNG image (*.png);;JPG image (*.jpg);;BMP image (*.bmp);;Portable Pixmap (*.ppm)</source>
         <translation>Image PNG (*.png);;Image JPG (*.jpg);;Image BMP (*.bmp);;Portable Pixmap (*.ppm)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/BGDialog.cpp" line="344"/>
         <source>Background Repaired</source>
         <oldsource>Background Repair</oldsource>
         <translation>Décor réparé</translation>
     </message>
     <message>
-        <location filename="../src/widgets/BGDialog.cpp" line="348"/>
         <source>Repair Failed</source>
         <translation>Réparation impossible</translation>
     </message>
     <message>
-        <location filename="../src/widgets/BGDialog.cpp" line="348"/>
         <source>The errors were not corrected.</source>
         <translation>Les erreurs n&apos;ont pas été corrigées.</translation>
     </message>
     <message>
-        <location filename="../src/widgets/BGDialog.cpp" line="62"/>
         <source>Layers</source>
         <translation>Couches</translation>
     </message>
     <message>
-        <location filename="../src/widgets/BGDialog.cpp" line="24"/>
         <source>Background</source>
         <translation>Décor</translation>
     </message>
     <message>
-        <location filename="../src/widgets/BGDialog.cpp" line="175"/>
         <source>Layer %1</source>
         <translation>Couche %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/BGDialog.cpp" line="221"/>
         <source>State %1</source>
         <oldsource>État %1</oldsource>
         <translation>État %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/BGDialog.cpp" line="344"/>
         <source>Errors were found and repaired, save to apply the changes.</source>
         <translation>Des erreurs ont été trouvées et réparées, sauvegardez l&apos;écran pour appliquer les changements.</translation>
     </message>
@@ -225,67 +189,54 @@ List of available commands:
 <context>
     <name>CLI</name>
     <message>
-        <location filename="../src/CLI.cpp" line="46"/>
         <source>Retry? [Yn] </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/CLI.cpp" line="55"/>
         <source>y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/CLI.cpp" line="125"/>
         <source>An error occured when exporting</source>
         <translation type="unfinished">Une erreur s&apos;est produite lors de l&apos;exportation</translation>
     </message>
     <message>
-        <location filename="../src/CLI.cpp" line="290"/>
         <source>Nothing found!</source>
         <translation type="unfinished">Rien trouvé !</translation>
     </message>
     <message>
-        <location filename="../src/CLI.cpp" line="293"/>
         <source>The file already exists</source>
         <translation type="unfinished">Le fichier existe déjà</translation>
     </message>
     <message>
-        <location filename="../src/CLI.cpp" line="296"/>
         <source>The file is inaccessible</source>
         <translation type="unfinished">Le fichier est inaccessible</translation>
     </message>
     <message>
-        <location filename="../src/CLI.cpp" line="299"/>
         <source>Can not create temporary file</source>
         <translation type="unfinished">Impossible de créer un fichier temporaire</translation>
     </message>
     <message>
-        <location filename="../src/CLI.cpp" line="302"/>
         <source>Unable to remove the file, check write permissions.</source>
         <translation type="unfinished">Impossible de supprimer le fichier, vérifiez les droits d&apos;écriture.</translation>
     </message>
     <message>
-        <location filename="../src/CLI.cpp" line="305"/>
         <source>Failed to rename the file, check write permissions.</source>
         <translation type="unfinished">Impossible de renommer le fichier, vérifiez les droits d&apos;écriture.</translation>
     </message>
     <message>
-        <location filename="../src/CLI.cpp" line="308"/>
         <source>Failed to copy the file, check write permissions.</source>
         <translation type="unfinished">Impossible de copier le fichier, vérifiez les droits d&apos;écriture.</translation>
     </message>
     <message>
-        <location filename="../src/CLI.cpp" line="311"/>
         <source>Invalid file</source>
         <translation type="unfinished">Fichier invalide</translation>
     </message>
     <message>
-        <location filename="../src/CLI.cpp" line="314"/>
         <source>This error should not appear, thank you for reporting it</source>
         <translation type="unfinished">Cette erreur ne devrais pas s&apos;afficher, merci de le signaler</translation>
     </message>
     <message>
-        <location filename="../src/CLI.cpp" line="319"/>
         <source>Error</source>
         <translation type="unfinished">Erreur</translation>
     </message>
@@ -293,7 +244,6 @@ List of available commands:
 <context>
     <name>ColorDisplay</name>
     <message>
-        <location filename="../src/widgets/ColorDisplay.cpp" line="173"/>
         <source>Choose a new color</source>
         <translation>Choisir une nouvelle couleur</translation>
     </message>
@@ -301,114 +251,91 @@ List of available commands:
 <context>
     <name>ConfigWindow</name>
     <message>
-        <location filename="../src/widgets/ConfigWindow.cpp" line="28"/>
         <source>Configuration</source>
         <translation>Configuration</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ConfigWindow.cpp" line="30"/>
         <source>Dependencies</source>
         <oldsource>Dépendances</oldsource>
         <translation>Dépendances</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ConfigWindow.cpp" line="35"/>
         <source>Final Fantasy VII Installs</source>
         <oldsource>Final Fantasy VII installés</oldsource>
         <translation>Final Fantasy VII installés</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ConfigWindow.cpp" line="39"/>
         <source>Delete</source>
         <translation>Supprimer</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ConfigWindow.cpp" line="41"/>
         <source>kernel2.bin</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ConfigWindow.cpp" line="43"/>
-        <location filename="../src/widgets/ConfigWindow.cpp" line="46"/>
-        <location filename="../src/widgets/ConfigWindow.cpp" line="49"/>
         <source>Change</source>
         <oldsource>Changer</oldsource>
         <translation>Changer</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ConfigWindow.cpp" line="44"/>
         <source>window.bin</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ConfigWindow.cpp" line="47"/>
         <source>char.lgp</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ConfigWindow.cpp" line="71"/>
         <source>Theme</source>
         <translation>Thème</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ConfigWindow.cpp" line="73"/>
         <source>Dark mode</source>
         <translation>Mode sombre</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ConfigWindow.cpp" line="78"/>
         <source>OpenGL</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ConfigWindow.cpp" line="80"/>
         <source>Disable OpenGL</source>
         <oldsource>Désactiver OpenGL</oldsource>
         <translation>Désactiver OpenGL</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ConfigWindow.cpp" line="85"/>
         <source>Text Editor</source>
         <oldsource>Editeur de texte</oldsource>
         <translation>Editeur de texte</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ConfigWindow.cpp" line="88"/>
         <source>Defaults</source>
         <translation>Valeurs par défaut</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ConfigWindow.cpp" line="94"/>
         <source>Latin</source>
         <translation>Latin</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ConfigWindow.cpp" line="95"/>
         <source>Japanese</source>
         <translation>Japonais</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ConfigWindow.cpp" line="122"/>
         <source>Dialog Background</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ConfigWindow.cpp" line="481"/>
         <source>You must restart %1 to apply all changes.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ConfigWindow.cpp" line="51"/>
         <source>Edit...</source>
         <translation>Modifier...</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ConfigWindow.cpp" line="126"/>
         <source>Encoding</source>
         <translation>Encodage</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ConfigWindow.cpp" line="133"/>
         <source>Autosize: margin right</source>
         <translation>Taille auto. : marge à droite</translation>
     </message>
@@ -417,19 +344,14 @@ List of available commands:
         <translation type="vanished">Divers</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ConfigWindow.cpp" line="295"/>
         <source>Edit</source>
         <translation>Modifier</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ConfigWindow.cpp" line="298"/>
-        <location filename="../src/widgets/ConfigWindow.cpp" line="302"/>
         <source>Add</source>
         <translation>Ajouter</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ConfigWindow.cpp" line="322"/>
-        <location filename="../src/widgets/ConfigWindow.cpp" line="332"/>
         <source>EXE files (*.exe)</source>
         <translation>Fichiers EXE (*.exe)</translation>
     </message>
@@ -447,29 +369,24 @@ List of available commands:
         <translation type="vanished">Caractères japonais</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ConfigWindow.cpp" line="135"/>
         <source>{SPACED CHARACTERS} width</source>
         <oldsource>Largeur {SPACED CHARACTERS}</oldsource>
         <translation>Largeur {SPACED CHARACTERS}</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ConfigWindow.cpp" line="137"/>
         <source>{CHOICE} width</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ConfigWindow.cpp" line="139"/>
         <source>Tabulation width</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ConfigWindow.cpp" line="143"/>
         <source>Script Editor</source>
         <oldsource>Editeur de script</oldsource>
         <translation>Editeur de script</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ConfigWindow.cpp" line="145"/>
         <source>Expand lines by default</source>
         <oldsource>Lignes expansées par défaut</oldsource>
         <translation>Lignes expansées par défaut</translation>
@@ -480,43 +397,34 @@ List of available commands:
         <translation type="vanished">Ne pas vérifier strictement le format des fichiers</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ConfigWindow.cpp" line="322"/>
-        <location filename="../src/widgets/ConfigWindow.cpp" line="332"/>
         <source>Find ff7.exe</source>
         <oldsource>Chercher ff7.exe</oldsource>
         <translation>Chercher ff7.exe</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ConfigWindow.cpp" line="377"/>
         <source>Find kernel2.bin</source>
         <oldsource>Chercher kernel2.bin</oldsource>
         <translation>Chercher kernel2.bin</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ConfigWindow.cpp" line="377"/>
-        <location filename="../src/widgets/ConfigWindow.cpp" line="384"/>
         <source>Bin Files (*.bin);;All Files (*)</source>
         <translation>Bin Files (*.bin);;All Files (*)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ConfigWindow.cpp" line="384"/>
         <source>Find window.bin</source>
         <oldsource>Chercher window.bin</oldsource>
         <translation>Chercher window.bin</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ConfigWindow.cpp" line="393"/>
         <source>Find char.lgp</source>
         <oldsource>Chercher char.lgp</oldsource>
         <translation>Chercher char.lgp</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ConfigWindow.cpp" line="393"/>
         <source>Lgp Archives (*.lgp);;All Files (*)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ConfigWindow.cpp" line="481"/>
         <source>Information</source>
         <translation>Information</translation>
     </message>
@@ -524,62 +432,50 @@ List of available commands:
 <context>
     <name>EncounterTableWidget</name>
     <message>
-        <location filename="../src/widgets/EncounterTableWidget.cpp" line="35"/>
         <source>-</source>
         <translation>-</translation>
     </message>
     <message>
-        <location filename="../src/widgets/EncounterTableWidget.cpp" line="37"/>
         <source>+</source>
         <translation>+</translation>
     </message>
     <message>
-        <location filename="../src/widgets/EncounterTableWidget.cpp" line="42"/>
         <source>Battle ID</source>
         <oldsource>ID Combat</oldsource>
         <translation>ID Combat</translation>
     </message>
     <message>
-        <location filename="../src/widgets/EncounterTableWidget.cpp" line="43"/>
         <source>Probability</source>
         <oldsource>Probabilité</oldsource>
         <translation>Probabilité</translation>
     </message>
     <message>
-        <location filename="../src/widgets/EncounterTableWidget.cpp" line="45"/>
         <source>Back Attack 1</source>
         <translation>Attaque par l&apos;arrière 1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/EncounterTableWidget.cpp" line="45"/>
         <source>Back Attack 2</source>
         <translation>Attaque par l&apos;arrière 2</translation>
     </message>
     <message>
-        <location filename="../src/widgets/EncounterTableWidget.cpp" line="45"/>
         <source>Side Attack</source>
         <translation>Attaque de côté</translation>
     </message>
     <message>
-        <location filename="../src/widgets/EncounterTableWidget.cpp" line="45"/>
         <source>Attack From Both Sides</source>
         <translation>Attaque des deux côtés</translation>
     </message>
     <message>
-        <location filename="../src/widgets/EncounterTableWidget.cpp" line="49"/>
         <source>Battle %1</source>
         <oldsource>Combat %1</oldsource>
         <translation>Combat %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/EncounterTableWidget.cpp" line="123"/>
         <source>Battle rate: %1/255</source>
         <oldsource>Fréquence des combats : %1/255</oldsource>
         <translation>Fréquence des combats : %1/255</translation>
     </message>
     <message>
-        <location filename="../src/widgets/EncounterTableWidget.cpp" line="143"/>
-        <location filename="../src/widgets/EncounterTableWidget.cpp" line="151"/>
         <source>Remaining probability points: %1</source>
         <oldsource>Points de probabilité restants : %1</oldsource>
         <translation>Points de probabilité restants : %1</translation>
@@ -588,24 +484,20 @@ List of available commands:
 <context>
     <name>EncounterWidget</name>
     <message>
-        <location filename="../src/widgets/EncounterWidget.cpp" line="23"/>
         <source>Encounters</source>
         <translation>Rencontres aléatoires</translation>
     </message>
     <message>
-        <location filename="../src/widgets/EncounterWidget.cpp" line="25"/>
         <source>Encounters 1</source>
         <oldsource>Rencontres 1</oldsource>
         <translation>Rencontres 1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/EncounterWidget.cpp" line="26"/>
         <source>Encounters 2</source>
         <oldsource>Rencontres 2</oldsource>
         <translation>Rencontres 2</translation>
     </message>
     <message>
-        <location filename="../src/widgets/EncounterWidget.cpp" line="30"/>
         <source>&lt;b&gt;Encounters:&lt;/b&gt; There are two groups of independent encounters, by default it is the group 1 that is active, but the opcode BTLTB (in scripts) can modify to the group 2.&lt;br/&gt;&lt;b&gt;Battle Rate:&lt;/b&gt; The lower the percentage, the higher the fighting will be frequent.</source>
         <oldsource>&lt;b&gt;Les rencontres :&lt;/b&gt; Il y a deux groupes de rencontres aléatoires indépendants, par défaut c&apos;est le groupe 1 qui est actif, mais la commande BTLTB (dans les scripts) permet de passer au groupe 2.&lt;br/&gt;&lt;b&gt;Fréquence des combats :&lt;/b&gt; Plus la valeur est basse, plus les combats seront fréquents.</oldsource>
         <translation>&lt;b&gt;Les rencontres :&lt;/b&gt; Il y a deux groupes de rencontres aléatoires indépendants, par défaut c&apos;est le groupe 1 qui est actif, mais la commande BTLTB (dans les scripts) permet de passer au groupe 2.&lt;br/&gt;&lt;b&gt;Fréquence des combats :&lt;/b&gt; Plus la valeur est basse, plus les combats seront fréquents.</translation>
@@ -614,23 +506,19 @@ List of available commands:
 <context>
     <name>FieldList</name>
     <message>
-        <location filename="../src/widgets/FieldList.cpp" line="29"/>
         <source>File</source>
         <oldsource>Fichier</oldsource>
         <translation>Fichier</translation>
     </message>
     <message>
-        <location filename="../src/widgets/FieldList.cpp" line="29"/>
         <source>Id</source>
         <translation>Id</translation>
     </message>
     <message>
-        <location filename="../src/widgets/FieldList.cpp" line="40"/>
         <source>Quick search</source>
         <translation>Recherche rapide</translation>
     </message>
     <message>
-        <location filename="../src/widgets/FieldList.cpp" line="41"/>
         <source>Search...</source>
         <translation>Rechercher...</translation>
     </message>
@@ -643,100 +531,76 @@ List of available commands:
         <translation type="vanished">Fichier DAT (*.DAT)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/FieldList.cpp" line="46"/>
         <source>Rename field</source>
         <translation>Renommer écran</translation>
     </message>
     <message>
-        <location filename="../src/widgets/FieldList.cpp" line="49"/>
         <source>Add field</source>
         <translation>Ajouter écran</translation>
     </message>
     <message>
-        <location filename="../src/widgets/FieldList.cpp" line="52"/>
         <source>Delete field</source>
         <translation>Supprimer écran</translation>
     </message>
     <message>
-        <location filename="../src/widgets/FieldList.cpp" line="73"/>
         <source>&amp;Field List Toolbar</source>
         <translation>Barre d&apos;o&amp;utils écrans</translation>
     </message>
     <message>
-        <location filename="../src/widgets/FieldList.cpp" line="76"/>
         <source>Add a field</source>
         <translation>Ajouter un écran</translation>
     </message>
     <message>
-        <location filename="../src/widgets/FieldList.cpp" line="78"/>
         <source>Remove a field</source>
         <translation>Supprimer un écran</translation>
     </message>
     <message>
-        <location filename="../src/widgets/FieldList.cpp" line="246"/>
-        <location filename="../src/widgets/FieldList.cpp" line="289"/>
         <source>Not implemented for PS.</source>
         <translation>Pas implémenté pour la PS.</translation>
     </message>
     <message>
-        <location filename="../src/widgets/FieldList.cpp" line="255"/>
         <source>Choose a name</source>
         <translation>Choisissez un nom</translation>
     </message>
     <message>
-        <location filename="../src/widgets/FieldList.cpp" line="256"/>
         <source>Field name:</source>
         <translation>Nom écran :</translation>
     </message>
     <message>
-        <location filename="../src/widgets/FieldList.cpp" line="211"/>
-        <location filename="../src/widgets/FieldList.cpp" line="263"/>
         <source>Name not filled</source>
         <translation>Nom vide</translation>
     </message>
     <message>
-        <location filename="../src/widgets/FieldList.cpp" line="212"/>
-        <location filename="../src/widgets/FieldList.cpp" line="264"/>
         <source>Please set a new field name.</source>
         <translation>Veuillez écrire un nouveau nom d&apos;écran.</translation>
     </message>
     <message>
-        <location filename="../src/widgets/FieldList.cpp" line="216"/>
-        <location filename="../src/widgets/FieldList.cpp" line="267"/>
         <source>Name already present in archive</source>
         <translation>Nom déjà présent dans l&apos;archive</translation>
     </message>
     <message>
-        <location filename="../src/widgets/FieldList.cpp" line="217"/>
-        <location filename="../src/widgets/FieldList.cpp" line="268"/>
         <source>Please choose another name.</source>
         <translation>Veuillez choisir un autre nom.</translation>
     </message>
     <message>
-        <location filename="../src/widgets/FieldList.cpp" line="303"/>
         <source>Are you sure you want to remove %1?
 Other maps can refer to it!</source>
         <translation>Êtes-vous sûr de vouloir supprimer %1 ?
 D&apos;autres écrans peuvent y référer !</translation>
     </message>
     <message>
-        <location filename="../src/widgets/FieldList.cpp" line="306"/>
         <source>the selected field</source>
         <translation>l&apos;écran sélectionné</translation>
     </message>
     <message>
-        <location filename="../src/widgets/FieldList.cpp" line="307"/>
         <source>the selected fields</source>
         <translation>les écrans sélectionnés</translation>
     </message>
     <message>
-        <location filename="../src/widgets/FieldList.cpp" line="309"/>
         <source>Delete</source>
         <translation>Supprimer</translation>
     </message>
     <message>
-        <location filename="../src/widgets/FieldList.cpp" line="246"/>
-        <location filename="../src/widgets/FieldList.cpp" line="289"/>
         <source>Error</source>
         <translation>Erreur</translation>
     </message>
@@ -760,7 +624,6 @@ D&apos;autres écrans peuvent y référer !</translation>
 <context>
     <name>FieldSaveIO</name>
     <message>
-        <location filename="../src/core/field/FieldIO.cpp" line="66"/>
         <source>Cannot save field map %1</source>
         <oldsource>Cannot save field %1</oldsource>
         <translation>Impossible de sauvegarder l&apos;écran %1</translation>
@@ -769,37 +632,30 @@ D&apos;autres écrans peuvent y référer !</translation>
 <context>
     <name>FontManager</name>
     <message>
-        <location filename="../src/widgets/FontManager.cpp" line="25"/>
         <source>Font Manager</source>
         <translation>Gestionnaire de polices de caractères</translation>
     </message>
     <message>
-        <location filename="../src/widgets/FontManager.cpp" line="56"/>
         <source>Japanese</source>
         <translation>Japonais</translation>
     </message>
     <message>
-        <location filename="../src/widgets/FontManager.cpp" line="115"/>
         <source>&amp;Displayed name:</source>
         <translation>Nom &amp;affiché :</translation>
     </message>
     <message>
-        <location filename="../src/widgets/FontManager.cpp" line="116"/>
         <source>&amp;File name:</source>
         <translation>Nom du &amp;fichier :</translation>
     </message>
     <message>
-        <location filename="../src/widgets/FontManager.cpp" line="132"/>
         <source>This name already exist or is invalid, please choose another.</source>
         <translation>Ce nom existe déjà ou est invalide, merci d&apos;en choisir un autre.</translation>
     </message>
     <message>
-        <location filename="../src/widgets/FontManager.cpp" line="149"/>
         <source>Remove font</source>
         <translation>Supprimer la police de caractères</translation>
     </message>
     <message>
-        <location filename="../src/widgets/FontManager.cpp" line="150"/>
         <source>Do you want to remove the selected font?</source>
         <translation>Voulez-vous supprimer la police de caractères sélectionnée ?</translation>
     </message>
@@ -812,17 +668,14 @@ D&apos;autres écrans peuvent y référer !</translation>
         <translation type="obsolete">Supprimer</translation>
     </message>
     <message>
-        <location filename="../src/widgets/FontManager.cpp" line="56"/>
         <source>Latin</source>
         <translation>Latin</translation>
     </message>
     <message>
-        <location filename="../src/widgets/FontManager.cpp" line="111"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/widgets/FontManager.cpp" line="132"/>
         <source>Choose another name</source>
         <oldsource>Choisissez un autre nom</oldsource>
         <translation>Sélectionnez un autre nom</translation>
@@ -831,55 +684,45 @@ D&apos;autres écrans peuvent y référer !</translation>
 <context>
     <name>FontWidget</name>
     <message>
-        <location filename="../src/widgets/FontWidget.cpp" line="30"/>
         <source>Grey</source>
         <oldsource>Gris</oldsource>
         <translation>Gris</translation>
     </message>
     <message>
-        <location filename="../src/widgets/FontWidget.cpp" line="30"/>
         <source>Violet</source>
         <translation>Violet</translation>
     </message>
     <message>
-        <location filename="../src/widgets/FontWidget.cpp" line="30"/>
         <source>Cyan</source>
         <translation>Cyan</translation>
     </message>
     <message>
-        <location filename="../src/widgets/FontWidget.cpp" line="46"/>
         <source>Export...</source>
         <oldsource>Exporter...</oldsource>
         <translation>Exporter...</translation>
     </message>
     <message>
-        <location filename="../src/widgets/FontWidget.cpp" line="47"/>
         <source>Import...</source>
         <oldsource>Importer...</oldsource>
         <translation>Importer...</translation>
     </message>
     <message>
-        <location filename="../src/widgets/FontWidget.cpp" line="30"/>
         <source>Blue</source>
         <translation>Bleu</translation>
     </message>
     <message>
-        <location filename="../src/widgets/FontWidget.cpp" line="30"/>
         <source>Red</source>
         <translation>Rouge</translation>
     </message>
     <message>
-        <location filename="../src/widgets/FontWidget.cpp" line="30"/>
         <source>Green</source>
         <translation>Vert</translation>
     </message>
     <message>
-        <location filename="../src/widgets/FontWidget.cpp" line="30"/>
         <source>Yellow</source>
         <translation>Jaune</translation>
     </message>
     <message>
-        <location filename="../src/widgets/FontWidget.cpp" line="30"/>
         <source>White</source>
         <translation>Blanc</translation>
     </message>
@@ -888,33 +731,26 @@ D&apos;autres écrans peuvent y référer !</translation>
         <translation type="vanished">À partir d&apos;une image...</translation>
     </message>
     <message>
-        <location filename="../src/widgets/FontWidget.cpp" line="48"/>
         <source>Cancel Changes</source>
         <translation>Annuler les modifications</translation>
     </message>
     <message>
-        <location filename="../src/widgets/FontWidget.cpp" line="64"/>
         <source>Text:</source>
         <translation>Texte :</translation>
     </message>
     <message>
-        <location filename="../src/widgets/FontWidget.cpp" line="66"/>
         <source>Width:</source>
         <translation>Largeur :</translation>
     </message>
     <message>
-        <location filename="../src/widgets/FontWidget.cpp" line="68"/>
         <source>Left padding:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/FontWidget.cpp" line="117"/>
         <source>Table %1</source>
         <translation>Table %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/FontWidget.cpp" line="219"/>
-        <location filename="../src/widgets/FontWidget.cpp" line="295"/>
         <source>FF7 font file (*.bin)</source>
         <oldsource>Fichier police FF7 (*.bin)</oldsource>
         <translation>Fichier police FF7 (*.bin)</translation>
@@ -925,63 +761,47 @@ D&apos;autres écrans peuvent y référer !</translation>
         <translation type="vanished">Fichier police FF8 (*.tdw)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/FontWidget.cpp" line="221"/>
         <source>Image File (*.png)</source>
         <oldsource>Fichier image PNG (*.png)</oldsource>
         <translation>Fichier image PNG (*.png)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/FontWidget.cpp" line="222"/>
         <source>Image File (*.jpg)</source>
         <oldsource>Image File (*.jpg))</oldsource>
         <translation>Fichier image JPG (*.jpg)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/FontWidget.cpp" line="223"/>
         <source>Image File (*.bmp)</source>
         <oldsource>Fichier image BMP (*.bmp)</oldsource>
         <translation>Fichier image BMP (*.bmp)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/FontWidget.cpp" line="227"/>
         <source>Translation file %1 (*.txt)</source>
         <oldsource>Fichier traduction %1 (*.txt)</oldsource>
         <translation>Fichier traduction %1 (*.txt)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/FontWidget.cpp" line="231"/>
         <source>Export font</source>
         <translation>Exporter police de caractère</translation>
     </message>
     <message>
-        <location filename="../src/widgets/FontWidget.cpp" line="244"/>
-        <location filename="../src/widgets/FontWidget.cpp" line="247"/>
-        <location filename="../src/widgets/FontWidget.cpp" line="270"/>
-        <location filename="../src/widgets/FontWidget.cpp" line="313"/>
-        <location filename="../src/widgets/FontWidget.cpp" line="317"/>
         <source>Error</source>
         <oldsource>Erreur</oldsource>
         <translation>Erreur</translation>
     </message>
     <message>
-        <location filename="../src/widgets/FontWidget.cpp" line="244"/>
-        <location filename="../src/widgets/FontWidget.cpp" line="270"/>
-        <location filename="../src/widgets/FontWidget.cpp" line="317"/>
         <source>Error opening file (%1)</source>
         <translation>Erreur d&apos;ouverture du fichier. (%1)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/FontWidget.cpp" line="247"/>
         <source>Error saving file</source>
         <translation>Erreur d&apos;enregistrement</translation>
     </message>
     <message>
-        <location filename="../src/widgets/FontWidget.cpp" line="299"/>
         <source>Import font</source>
         <translation>Importer police de caractère</translation>
     </message>
     <message>
-        <location filename="../src/widgets/FontWidget.cpp" line="313"/>
         <source>Invalid file</source>
         <translation>Fichier invalide</translation>
     </message>
@@ -989,124 +809,102 @@ D&apos;autres écrans peuvent y référer !</translation>
 <context>
     <name>GrpScriptList</name>
     <message>
-        <location filename="../src/widgets/GrpScriptList.cpp" line="26"/>
         <source>Id</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/widgets/GrpScriptList.cpp" line="26"/>
         <source>Type</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/widgets/GrpScriptList.cpp" line="26"/>
         <source>Group</source>
         <translation>Groupe</translation>
     </message>
     <message>
-        <location filename="../src/widgets/GrpScriptList.cpp" line="37"/>
         <source>Rename group</source>
         <oldsource>Renommer groupe</oldsource>
         <translation>Renommer groupe</translation>
     </message>
     <message>
-        <location filename="../src/widgets/GrpScriptList.cpp" line="40"/>
         <source>Add group</source>
         <oldsource>Ajouter groupe</oldsource>
         <translation>Ajouter groupe</translation>
     </message>
     <message>
-        <location filename="../src/widgets/GrpScriptList.cpp" line="43"/>
         <source>Delete group</source>
         <oldsource>Supprimer groupe</oldsource>
         <translation>Supprimer groupe</translation>
     </message>
     <message>
-        <location filename="../src/widgets/GrpScriptList.cpp" line="47"/>
         <source>Cut group</source>
         <oldsource>Couper groupe</oldsource>
         <translation>Couper groupe</translation>
     </message>
     <message>
-        <location filename="../src/widgets/GrpScriptList.cpp" line="51"/>
         <source>Copy group</source>
         <oldsource>Copier groupe</oldsource>
         <translation>Copier groupe</translation>
     </message>
     <message>
-        <location filename="../src/widgets/GrpScriptList.cpp" line="55"/>
         <source>Paste group</source>
         <oldsource>Coller groupe</oldsource>
         <translation>Coller groupe</translation>
     </message>
     <message>
-        <location filename="../src/widgets/GrpScriptList.cpp" line="63"/>
         <source>Move down</source>
         <oldsource>Down a group</oldsource>
         <translation>Descendre un groupe</translation>
     </message>
     <message>
-        <location filename="../src/widgets/GrpScriptList.cpp" line="110"/>
         <source>Up</source>
         <translation>Déplacer vers le haut</translation>
     </message>
     <message>
-        <location filename="../src/widgets/GrpScriptList.cpp" line="112"/>
         <source>Down</source>
         <translation>Déplacer vers le bas</translation>
     </message>
     <message>
-        <location filename="../src/widgets/GrpScriptList.cpp" line="107"/>
         <source>Remove a group</source>
         <translation>Supprimer un groupe</translation>
     </message>
     <message>
-        <location filename="../src/widgets/GrpScriptList.cpp" line="319"/>
         <source>Delete</source>
         <translation>Supprimer</translation>
     </message>
     <message>
-        <location filename="../src/widgets/GrpScriptList.cpp" line="319"/>
         <source>Are you sure you want to remove %1?
 Some scripts can refer to it!</source>
         <translation>Voulez-vous vraiment supprimer %1 ?
 Certains scripts peuvent y faire référence !</translation>
     </message>
     <message>
-        <location filename="../src/widgets/GrpScriptList.cpp" line="102"/>
         <source>&amp;Group Editor</source>
         <oldsource>Édition des &amp;groupes</oldsource>
         <translation>Édition des &amp;groupes</translation>
     </message>
     <message>
-        <location filename="../src/widgets/GrpScriptList.cpp" line="59"/>
         <source>Move up</source>
         <translation>Monter un groupe</translation>
     </message>
     <message>
-        <location filename="../src/widgets/GrpScriptList.cpp" line="105"/>
         <source>Add a group</source>
         <oldsource>Ajouter un groupe</oldsource>
         <translation>Ajouter un groupe</translation>
     </message>
     <message>
-        <location filename="../src/widgets/GrpScriptList.cpp" line="255"/>
         <source>You have more than 16 models in this field, the game may crash.</source>
         <translation>Vous avez plus de 16 modèles dans cet écran, le jeu est susceptible de planter.</translation>
     </message>
     <message>
-        <location filename="../src/widgets/GrpScriptList.cpp" line="261"/>
         <source>You have more than 48 groups in this field, the game may crash.</source>
         <translation>Vous avez plus de 48 groupes dans cet écran, le jeu est susceptible de planter.</translation>
     </message>
     <message>
-        <location filename="../src/widgets/GrpScriptList.cpp" line="322"/>
         <source>the group selected</source>
         <oldsource>le groupe sélectionné</oldsource>
         <translation>le groupe sélectionné</translation>
     </message>
     <message>
-        <location filename="../src/widgets/GrpScriptList.cpp" line="323"/>
         <source>the selected groups</source>
         <oldsource>les groupes sélectionnés</oldsource>
         <translation>les groupes sélectionnés</translation>
@@ -1115,53 +913,42 @@ Certains scripts peuvent y faire référence !</translation>
 <context>
     <name>GrpScriptWizardPageType</name>
     <message>
-        <location filename="../src/widgets/GrpScriptWizard.cpp" line="69"/>
-        <location filename="../src/widgets/GrpScriptWizard.cpp" line="102"/>
         <source>Empty</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/GrpScriptWizard.cpp" line="70"/>
         <source>3D Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/GrpScriptWizard.cpp" line="71"/>
         <source>Line</source>
         <translation type="unfinished">Ligne</translation>
     </message>
     <message>
-        <location filename="../src/widgets/GrpScriptWizard.cpp" line="72"/>
         <source>Animation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/GrpScriptWizard.cpp" line="73"/>
         <source>Other</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/GrpScriptWizard.cpp" line="96"/>
         <source>Main Character</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/GrpScriptWizard.cpp" line="97"/>
         <source>Non Playable Character</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/GrpScriptWizard.cpp" line="98"/>
         <source>Item</source>
         <translation type="unfinished">Objet</translation>
     </message>
     <message>
-        <location filename="../src/widgets/GrpScriptWizard.cpp" line="99"/>
         <source>Save Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/GrpScriptWizard.cpp" line="103"/>
         <source>Position debugging</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1169,107 +956,86 @@ Certains scripts peuvent y faire référence !</translation>
 <context>
     <name>ImportDialog</name>
     <message>
-        <location filename="../src/widgets/ImportDialog.cpp" line="23"/>
-        <location filename="../src/widgets/ImportDialog.cpp" line="25"/>
         <source>Import</source>
         <oldsource>Importer</oldsource>
         <translation>Importer</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ImportDialog.cpp" line="26"/>
         <source>Scripts/Texts</source>
         <oldsource>Scripts/Textes</oldsource>
         <translation>Scripts/Textes</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ImportDialog.cpp" line="27"/>
         <source>Sounds/Tutorials</source>
         <oldsource>Musiques/Tutoriels</oldsource>
         <translation>Musiques/Tutoriels</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ImportDialog.cpp" line="28"/>
         <source>Camera</source>
         <oldsource>Caméra</oldsource>
         <translation>Caméra</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ImportDialog.cpp" line="29"/>
         <source>Walkmesh</source>
         <translation>Walkmesh</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ImportDialog.cpp" line="30"/>
         <source>Encounters</source>
         <translation>Combats aléatoires</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ImportDialog.cpp" line="31"/>
         <source>Triggers/gateways</source>
         <translation>Déclencheurs/Liens entre les écrans</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ImportDialog.cpp" line="32"/>
         <source>Model loader</source>
         <translation>Liste des modèles 3D</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ImportDialog.cpp" line="33"/>
         <source>Background</source>
         <translation>Background</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ImportDialog.cpp" line="35"/>
         <source>File is not compressed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ImportDialog.cpp" line="55"/>
         <source> (partial: models and animations are not linked properly)</source>
         <translation> (partiel : les modèles et les animations ne sont pas reliés correctement)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ImportDialog.cpp" line="56"/>
         <source> (partial: Z-depth might be a little broken)</source>
         <translation> (partiel : la profondeur Z sera potentiellement incorrecte)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ImportDialog.cpp" line="61"/>
-        <location filename="../src/widgets/ImportDialog.cpp" line="71"/>
         <source>Change</source>
         <oldsource>Changer</oldsource>
         <translation>Changer</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ImportDialog.cpp" line="65"/>
         <source>MIM file:</source>
         <oldsource>Fichier MIM :</oldsource>
         <translation>Fichier MIM :</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ImportDialog.cpp" line="75"/>
         <source>BSX file:</source>
         <translation>Fichier BSX :</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ImportDialog.cpp" line="155"/>
         <source>Select the associated BSX file</source>
         <translation>Sélectionnez le fichier BSX associé</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ImportDialog.cpp" line="156"/>
         <source>BSX File (*.BSX);;All Files (*)</source>
         <oldsource>BSX File (*.BSX);;All Files(*)</oldsource>
         <translation>Fichier BSX (*.BSX);;Tous les fichiers (*)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ImportDialog.cpp" line="166"/>
         <source>Select the associated MIM file</source>
         <oldsource>Sélectionner le fichier MIM associé</oldsource>
         <translation>Sélectionner le fichier MIM associé</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ImportDialog.cpp" line="167"/>
         <source>MIM File (*.MIM);;All Files (*)</source>
         <oldsource>MIM File (*.MIM);;All Files(*)</oldsource>
         <translation>Fichier MIM (*.MIM);;Tous les fichiers (*)</translation>
@@ -1278,7 +1044,6 @@ Certains scripts peuvent y faire référence !</translation>
 <context>
     <name>KeyEditorDialog</name>
     <message>
-        <location filename="../src/widgets/KeyEditorDialog.cpp" line="24"/>
         <source>Keys</source>
         <translation>Touches</translation>
     </message>
@@ -1417,18 +1182,15 @@ Certains scripts peuvent y faire référence !</translation>
 <context>
     <name>LgpItemModel</name>
     <message>
-        <location filename="../src/widgets/LgpWidget.cpp" line="512"/>
         <source>?</source>
         <translation>?</translation>
     </message>
     <message>
-        <location filename="../src/widgets/LgpWidget.cpp" line="587"/>
         <source>Name</source>
         <oldsource>Nom</oldsource>
         <translation>Nom</translation>
     </message>
     <message>
-        <location filename="../src/widgets/LgpWidget.cpp" line="588"/>
         <source>Size</source>
         <translation>Taille</translation>
     </message>
@@ -1436,161 +1198,115 @@ Certains scripts peuvent y faire référence !</translation>
 <context>
     <name>LgpWidget</name>
     <message>
-        <location filename="../src/widgets/LgpWidget.cpp" line="679"/>
         <source>LGP archive manager</source>
         <translation>Gestionnaire d&apos;archive LGP</translation>
     </message>
     <message>
-        <location filename="../src/widgets/LgpWidget.cpp" line="690"/>
-        <location filename="../src/widgets/LgpWidget.cpp" line="838"/>
-        <location filename="../src/widgets/LgpWidget.cpp" line="1056"/>
         <source>Rename</source>
         <translation>Renommer</translation>
     </message>
     <message>
-        <location filename="../src/widgets/LgpWidget.cpp" line="692"/>
         <source>Replace</source>
         <translation>Remplacer</translation>
     </message>
     <message>
-        <location filename="../src/widgets/LgpWidget.cpp" line="694"/>
         <source>Extract</source>
         <translation>Extraire</translation>
     </message>
     <message>
-        <location filename="../src/widgets/LgpWidget.cpp" line="696"/>
         <source>Extract All</source>
         <translation>Extraire tout</translation>
     </message>
     <message>
-        <location filename="../src/widgets/LgpWidget.cpp" line="698"/>
         <source>Add</source>
         <translation>Ajouter</translation>
     </message>
     <message>
-        <location filename="../src/widgets/LgpWidget.cpp" line="700"/>
         <source>Delete</source>
         <translation>Supprimer</translation>
     </message>
     <message>
-        <location filename="../src/widgets/LgpWidget.cpp" line="838"/>
-        <location filename="../src/widgets/LgpWidget.cpp" line="1057"/>
         <source>New Name:</source>
         <translation>Nouveau nom :</translation>
     </message>
     <message>
-        <location filename="../src/widgets/LgpWidget.cpp" line="845"/>
-        <location filename="../src/widgets/LgpWidget.cpp" line="848"/>
-        <location filename="../src/widgets/LgpWidget.cpp" line="851"/>
-        <location filename="../src/widgets/LgpWidget.cpp" line="888"/>
-        <location filename="../src/widgets/LgpWidget.cpp" line="1002"/>
-        <location filename="../src/widgets/LgpWidget.cpp" line="1041"/>
-        <location filename="../src/widgets/LgpWidget.cpp" line="1046"/>
-        <location filename="../src/widgets/LgpWidget.cpp" line="1067"/>
-        <location filename="../src/widgets/LgpWidget.cpp" line="1091"/>
-        <location filename="../src/widgets/LgpWidget.cpp" line="1119"/>
         <source>Error</source>
         <translation>Erreur</translation>
     </message>
     <message>
-        <location filename="../src/widgets/LgpWidget.cpp" line="845"/>
-        <location filename="../src/widgets/LgpWidget.cpp" line="1042"/>
         <source>The name &apos;%1&apos; is invalid, don&apos;t put special characters.</source>
         <translation>Le nom &apos;%1&apos; est invalide, ne mettez pas de caractères spéciaux.</translation>
     </message>
     <message>
-        <location filename="../src/widgets/LgpWidget.cpp" line="848"/>
-        <location filename="../src/widgets/LgpWidget.cpp" line="1047"/>
         <source>A file named &apos;%1&apos; already exists, please choose another name.</source>
         <translation>Un fichier nommé &apos;%1&apos; existe déjà, veuillez choisir un autre nom.</translation>
     </message>
     <message>
-        <location filename="../src/widgets/LgpWidget.cpp" line="851"/>
         <source>Can not Rename the file</source>
         <translation>Impossible de renommer le fichier</translation>
     </message>
     <message>
-        <location filename="../src/widgets/LgpWidget.cpp" line="871"/>
-        <location filename="../src/widgets/LgpWidget.cpp" line="907"/>
         <source>%1 file (*.%1)</source>
         <translation>Fichier %1 (*.%1)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/LgpWidget.cpp" line="873"/>
-        <location filename="../src/widgets/LgpWidget.cpp" line="909"/>
-        <location filename="../src/widgets/LgpWidget.cpp" line="1020"/>
         <source>All files (*)</source>
         <translation>Tous les fichiers (*)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/LgpWidget.cpp" line="880"/>
-        <location filename="../src/widgets/LgpWidget.cpp" line="1021"/>
         <source>New File</source>
         <translation>Nouveau fichier</translation>
     </message>
     <message>
-        <location filename="../src/widgets/LgpWidget.cpp" line="888"/>
         <source>Can not modify the archive!</source>
         <translation>Impossible de modifier l&apos;archive !</translation>
     </message>
     <message>
-        <location filename="../src/widgets/LgpWidget.cpp" line="916"/>
         <source>Extract file</source>
         <translation>Extraire un fichier</translation>
     </message>
     <message>
-        <location filename="../src/widgets/LgpWidget.cpp" line="931"/>
         <source>Write error</source>
         <translation>Erreur d&apos;écriture</translation>
     </message>
     <message>
-        <location filename="../src/widgets/LgpWidget.cpp" line="931"/>
         <source>Can not write to file (message: %1).</source>
         <translation>Impossible d&apos;écrire dans le fichier (message : %1).</translation>
     </message>
     <message>
-        <location filename="../src/widgets/LgpWidget.cpp" line="936"/>
         <source>Opening error</source>
         <translation>Erreur d&apos;ouverture</translation>
     </message>
     <message>
-        <location filename="../src/widgets/LgpWidget.cpp" line="936"/>
         <source>Can not open the file (message: %1).</source>
         <translation>Impossible d&apos;ouvrir le fichier (message : %1).</translation>
     </message>
     <message>
-        <location filename="../src/widgets/LgpWidget.cpp" line="949"/>
         <source>Extract all</source>
         <translation>Extraire tout</translation>
     </message>
     <message>
-        <location filename="../src/widgets/LgpWidget.cpp" line="956"/>
         <source>Extracting...</source>
         <translation>Extraction...</translation>
     </message>
     <message>
-        <location filename="../src/widgets/LgpWidget.cpp" line="956"/>
         <source>Cancel</source>
         <translation>Annuler</translation>
     </message>
     <message>
-        <location filename="../src/widgets/LgpWidget.cpp" line="1068"/>
         <source>Can not add the file &apos;%1&apos;</source>
         <translation>Impossible d&apos;ajouter le fichier &apos;%1&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/LgpWidget.cpp" line="1081"/>
         <source>Delete?</source>
         <oldsource>Delete ?</oldsource>
         <translation>Supprimer ?</translation>
     </message>
     <message>
-        <location filename="../src/widgets/LgpWidget.cpp" line="1082"/>
         <source>Are you sure you want to delete this file from the archive?</source>
         <translation>Êtes-vous sûr de vouloir supprimer ce fichier de l&apos;archive ?</translation>
     </message>
     <message>
-        <location filename="../src/widgets/LgpWidget.cpp" line="1091"/>
         <source>Cannot delete the file!</source>
         <translation>Impossible de supprimer le fichier !</translation>
     </message>
@@ -1598,34 +1314,28 @@ Certains scripts peuvent y faire référence !</translation>
 <context>
     <name>MassExportDialog</name>
     <message>
-        <location filename="../src/widgets/MassExportDialog.cpp" line="25"/>
         <source>Mass Export</source>
         <oldsource>Exporter en masse</oldsource>
         <translation>Exporter en masse</translation>
     </message>
     <message>
-        <location filename="../src/widgets/MassExportDialog.cpp" line="32"/>
         <source>Current</source>
         <oldsource>Courant</oldsource>
         <translation>Courant</translation>
     </message>
     <message>
-        <location filename="../src/widgets/MassExportDialog.cpp" line="33"/>
         <source>+</source>
         <translation>+</translation>
     </message>
     <message>
-        <location filename="../src/widgets/MassExportDialog.cpp" line="34"/>
         <source>-</source>
         <translation>-</translation>
     </message>
     <message>
-        <location filename="../src/widgets/MassExportDialog.cpp" line="41"/>
         <source>Export fields</source>
         <translation>Exporter les écrans</translation>
     </message>
     <message>
-        <location filename="../src/widgets/MassExportDialog.cpp" line="44"/>
         <source>Export backgrounds</source>
         <oldsource>Exporter les décors</oldsource>
         <translation>Exporter les décors</translation>
@@ -1646,118 +1356,97 @@ Certains scripts peuvent y faire référence !</translation>
         <translation type="vanished">Image BMP</translation>
     </message>
     <message>
-        <location filename="../src/widgets/MassExportDialog.cpp" line="46"/>
         <source>Flatten PNG image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/MassExportDialog.cpp" line="47"/>
         <source>Flatten JPG image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/MassExportDialog.cpp" line="48"/>
         <source>Flatten BMP image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/MassExportDialog.cpp" line="49"/>
         <source>Multi-layers PNG images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/MassExportDialog.cpp" line="50"/>
         <source>Multi-layers JPG images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/MassExportDialog.cpp" line="51"/>
         <source>Multi-layers BMP images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/MassExportDialog.cpp" line="53"/>
         <source>Export musics</source>
         <oldsource>Export sounds</oldsource>
         <translation>Exporter les musiques</translation>
     </message>
     <message>
-        <location filename="../src/widgets/MassExportDialog.cpp" line="55"/>
         <source>AKAO music</source>
         <oldsource>AKAO sound</oldsource>
         <translation>Musique AKAO</translation>
     </message>
     <message>
-        <location filename="../src/widgets/MassExportDialog.cpp" line="56"/>
         <source>PSF MIDI</source>
         <translation>PSF MIDI</translation>
     </message>
     <message>
-        <location filename="../src/widgets/MassExportDialog.cpp" line="58"/>
         <source>Export texts</source>
         <oldsource>Exporter les textes</oldsource>
         <translation>Exporter les textes</translation>
     </message>
     <message>
-        <location filename="../src/widgets/MassExportDialog.cpp" line="60"/>
         <source>XML Text</source>
         <oldsource>Texte XML</oldsource>
         <translation>Texte XML</translation>
     </message>
     <message>
-        <location filename="../src/widgets/MassExportDialog.cpp" line="61"/>
         <source>Simple text TXT</source>
         <oldsource>Texte simple TXT</oldsource>
         <translation>Texte simple TXT</translation>
     </message>
     <message>
-        <location filename="../src/widgets/MassExportDialog.cpp" line="67"/>
         <source>Choose...</source>
         <oldsource>Choisir...</oldsource>
         <translation>Choisir...</translation>
     </message>
     <message>
-        <location filename="../src/widgets/MassExportDialog.cpp" line="69"/>
         <source>Overwrite existing files</source>
         <oldsource>Écraser les fichiers existants</oldsource>
         <translation>Écraser les fichiers existants</translation>
     </message>
     <message>
-        <location filename="../src/widgets/MassExportDialog.cpp" line="73"/>
         <source>Export</source>
         <oldsource>Exporter</oldsource>
         <translation>Exporter</translation>
     </message>
     <message>
-        <location filename="../src/widgets/MassExportDialog.cpp" line="83"/>
         <source>Export directory:</source>
         <oldsource>Emplacement de l&apos;export :</oldsource>
         <translation>Emplacement de l&apos;export :</translation>
     </message>
     <message>
-        <location filename="../src/widgets/MassExportDialog.cpp" line="102"/>
         <source>PC</source>
         <translation>PC</translation>
     </message>
     <message>
-        <location filename="../src/widgets/MassExportDialog.cpp" line="102"/>
         <source>PS</source>
         <translation>PS</translation>
     </message>
     <message>
-        <location filename="../src/widgets/MassExportDialog.cpp" line="104"/>
         <source>FIELD File %1</source>
         <oldsource>Fichier FIELD %1</oldsource>
         <translation>Fichier FIELD %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/MassExportDialog.cpp" line="105"/>
         <source>Uncompressed FIELD %1</source>
         <oldsource>Fichier décompressé FIELD %1</oldsource>
         <translation>Fichier décompressé FIELD %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/MassExportDialog.cpp" line="124"/>
         <source>Choose a directory</source>
         <oldsource>Choisir un dossier</oldsource>
         <translation>Choisir un dossier</translation>
@@ -1766,103 +1455,85 @@ Certains scripts peuvent y faire référence !</translation>
 <context>
     <name>MassImportDialog</name>
     <message>
-        <location filename="../src/widgets/MassImportDialog.cpp" line="25"/>
         <source>Mass Import</source>
         <oldsource>Importer en masse</oldsource>
         <translation>Importer en masse</translation>
     </message>
     <message>
-        <location filename="../src/widgets/MassImportDialog.cpp" line="28"/>
         <source>Import fields</source>
         <translation>Importer des écrans</translation>
     </message>
     <message>
-        <location filename="../src/widgets/MassImportDialog.cpp" line="31"/>
         <source>Import sounds</source>
         <oldsource>Importer les sons</oldsource>
         <translation>Importer les sons</translation>
     </message>
     <message>
-        <location filename="../src/widgets/MassImportDialog.cpp" line="33"/>
         <source>AKAO sound</source>
         <oldsource>Son AKAO</oldsource>
         <translation>Son AKAO</translation>
     </message>
     <message>
-        <location filename="../src/widgets/MassImportDialog.cpp" line="35"/>
         <source>Import text</source>
         <oldsource>Importer les textes</oldsource>
         <translation>Importer les textes</translation>
     </message>
     <message>
-        <location filename="../src/widgets/MassImportDialog.cpp" line="37"/>
         <source>XML Text</source>
         <oldsource>Texte XML</oldsource>
         <translation>Texte XML</translation>
     </message>
     <message>
-        <location filename="../src/widgets/MassImportDialog.cpp" line="38"/>
         <source>Simple text TXT</source>
         <oldsource>Texte simple TXT</oldsource>
         <translation>Texte simple TXT</translation>
     </message>
     <message>
-        <location filename="../src/widgets/MassImportDialog.cpp" line="42"/>
         <source>Choose...</source>
         <oldsource>Choisir...</oldsource>
         <translation>Choisir...</translation>
     </message>
     <message>
-        <location filename="../src/widgets/MassImportDialog.cpp" line="49"/>
         <source>Current</source>
         <oldsource>Courant</oldsource>
         <translation>Courant</translation>
     </message>
     <message>
-        <location filename="../src/widgets/MassImportDialog.cpp" line="50"/>
         <source>+</source>
         <translation>+</translation>
     </message>
     <message>
-        <location filename="../src/widgets/MassImportDialog.cpp" line="51"/>
         <source>-</source>
         <translation>-</translation>
     </message>
     <message>
-        <location filename="../src/widgets/MassImportDialog.cpp" line="58"/>
         <source>Import</source>
         <oldsource>Importer</oldsource>
         <translation>Importer</translation>
     </message>
     <message>
-        <location filename="../src/widgets/MassImportDialog.cpp" line="67"/>
         <source>Source directory:</source>
         <translation>Emplacement de la source :</translation>
     </message>
     <message>
-        <location filename="../src/widgets/MassImportDialog.cpp" line="85"/>
         <source>PC</source>
         <translation>PC</translation>
     </message>
     <message>
-        <location filename="../src/widgets/MassImportDialog.cpp" line="85"/>
         <source>PS</source>
         <translation>PS</translation>
     </message>
     <message>
-        <location filename="../src/widgets/MassImportDialog.cpp" line="87"/>
         <source>FIELD File %1</source>
         <oldsource>Fichier FIELD %1</oldsource>
         <translation>Fichier FIELD %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/MassImportDialog.cpp" line="88"/>
         <source>Uncompressed FIELD %1</source>
         <oldsource>Fichier décompressé FIELD %1</oldsource>
         <translation>Fichier décompressé FIELD %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/MassImportDialog.cpp" line="107"/>
         <source>Choose a directory</source>
         <oldsource>Choisir un dossier</oldsource>
         <translation>Choisir un dossier</translation>
@@ -1871,17 +1542,14 @@ Certains scripts peuvent y faire référence !</translation>
 <context>
     <name>MiscWidget</name>
     <message>
-        <location filename="../src/widgets/MiscWidget.cpp" line="24"/>
         <source>Miscellaneous</source>
         <translation>Divers</translation>
     </message>
     <message>
-        <location filename="../src/widgets/MiscWidget.cpp" line="34"/>
         <source>Field name:</source>
         <translation>Nom écran :</translation>
     </message>
     <message>
-        <location filename="../src/widgets/MiscWidget.cpp" line="36"/>
         <source>Author:</source>
         <oldsource>Auteur :</oldsource>
         <translation>Auteur :</translation>
@@ -1890,22 +1558,18 @@ Certains scripts peuvent y faire référence !</translation>
 <context>
     <name>ModelColorsLayout</name>
     <message>
-        <location filename="../src/widgets/ModelColorsLayout.cpp" line="67"/>
         <source>Color</source>
         <translation>Couleur</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ModelColorsLayout.cpp" line="68"/>
         <source>X</source>
         <translation>X</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ModelColorsLayout.cpp" line="69"/>
         <source>Y</source>
         <translation>Y</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ModelColorsLayout.cpp" line="70"/>
         <source>Z</source>
         <translation>Z</translation>
     </message>
@@ -1913,8 +1577,6 @@ Certains scripts peuvent y faire référence !</translation>
 <context>
     <name>ModelManager</name>
     <message>
-        <location filename="../src/widgets/ModelManager.cpp" line="25"/>
-        <location filename="../src/widgets/ModelManager.cpp" line="32"/>
         <source>Field Models</source>
         <translation>Modèles 3D</translation>
     </message>
@@ -1922,71 +1584,56 @@ Certains scripts peuvent y faire référence !</translation>
 <context>
     <name>ModelManagerPC</name>
     <message>
-        <location filename="../src/widgets/ModelManagerPC.cpp" line="40"/>
         <source>Cut</source>
         <translation>Couper</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ModelManagerPC.cpp" line="41"/>
         <source>Copy</source>
         <oldsource>Copier</oldsource>
         <translation>Copier</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ModelManagerPC.cpp" line="42"/>
         <source>Paste</source>
         <translation>Coller</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ModelManagerPC.cpp" line="61"/>
         <source>Animation</source>
         <translation>Animations</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ModelManagerPC.cpp" line="64"/>
         <source>Name (unused)</source>
         <translation>Nom (non utilisé)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ModelManagerPC.cpp" line="66"/>
         <source>Unknown</source>
         <translation>Inconnu</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ModelManagerPC.cpp" line="68"/>
         <source>Model size</source>
         <translation>Taille modèle</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ModelManagerPC.cpp" line="70"/>
         <source>Global light</source>
         <oldsource>Light</oldsource>
         <translation>Lumière globale</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ModelManagerPC.cpp" line="72"/>
         <source>Directional light</source>
         <translation>Lumière directionnelle</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ModelManagerPC.cpp" line="147"/>
-        <location filename="../src/widgets/ModelManagerPC.cpp" line="354"/>
         <source>Add a field model</source>
         <translation>Ajouter un modèle 3D</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ModelManagerPC.cpp" line="61"/>
         <source>Id</source>
         <translation>Id</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ModelManagerPC.cpp" line="61"/>
         <source>?</source>
         <translation>?</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ModelManagerPC.cpp" line="157"/>
-        <location filename="../src/widgets/ModelManagerPC.cpp" line="385"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
@@ -1994,28 +1641,23 @@ Certains scripts peuvent y faire référence !</translation>
 <context>
     <name>ModelManagerPS</name>
     <message>
-        <location filename="../src/widgets/ModelManagerPS.cpp" line="26"/>
         <source>Animation</source>
         <oldsource>Animations</oldsource>
         <translation>Animations</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ModelManagerPS.cpp" line="29"/>
         <source>Unknown</source>
         <translation>Inconnu</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ModelManagerPS.cpp" line="31"/>
         <source>Model size</source>
         <translation>Taille modèle</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ModelManagerPS.cpp" line="33"/>
         <source>Global light</source>
         <translation>Lumière globale</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ModelManagerPS.cpp" line="35"/>
         <source>Directional light</source>
         <translation>Lumière directionnelle</translation>
     </message>
@@ -2027,42 +1669,31 @@ Certains scripts peuvent y faire référence !</translation>
 <context>
     <name>Opcode</name>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4880"/>
         <source> (No%1)</source>
         <oldsource> (n°%1)</oldsource>
         <translation> (n°%1)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4882"/>
         <source>? (No%1)</source>
         <oldsource>? (n°%1)</oldsource>
         <translation>? (n°%1)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4894"/>
         <source>(no text)</source>
         <oldsource>(Pas de texte)</oldsource>
         <translation>(Pas de texte)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4900"/>
-        <location filename="../src/core/field/Opcode.cpp" line="4916"/>
-        <location filename="../src/core/field/Opcode.cpp" line="4922"/>
-        <location filename="../src/core/field/Opcode.cpp" line="4928"/>
-        <location filename="../src/core/field/Opcode.cpp" line="4938"/>
-        <location filename="../src/core/field/Opcode.cpp" line="4944"/>
         <source>No%1</source>
         <oldsource>n°%1</oldsource>
         <translation>n°%1</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4934"/>
         <source>%1 (#%2)</source>
         <oldsource>%1 (n°%2)</oldsource>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4952"/>
         <source>%1 (disc %2)</source>
         <oldsource>%1 (disque %2)</oldsource>
         <translation>%1 (disque %2)</translation>
@@ -2088,25 +1719,21 @@ Certains scripts peuvent y faire référence !</translation>
         <translation type="vanished">Jouer un effet sonore sur le canal 4</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5009"/>
         <source>Resumes music and sound effects</source>
         <oldsource>Reprendre la musique et les effets sonores</oldsource>
         <translation>Reprendre la musique et les effets sonores</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5011"/>
         <source>Pauses music and sound effects</source>
         <oldsource>Mettre en pause la musique et les effets sonores</oldsource>
         <translation>Mettre en pause la musique et les effets sonores</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5017"/>
         <source>Resumes only sound effects</source>
         <oldsource>Reprendre uniquement les effets sonores</oldsource>
         <translation>Reprendre uniquement les effets sonores</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5019"/>
         <source>Pauses only sound effects</source>
         <oldsource>Mettre en pause uniquement les effets sonores</oldsource>
         <translation>Mettre en pause uniquement les effets sonores</translation>
@@ -2152,97 +1779,81 @@ Certains scripts peuvent y faire référence !</translation>
         <translation type="vanished">Volume transitions (canal 4)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5037"/>
         <source>Pan control (channel #1)</source>
         <oldsource>Contrôle spatial (canal 1)</oldsource>
         <translation>Contrôle spatial (canal 1)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5039"/>
         <source>Pan control (channel #2)</source>
         <oldsource>Contrôle spatial (canal 2)</oldsource>
         <translation>Contrôle spatial (canal 2)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5041"/>
         <source>Pan control (channel #3)</source>
         <oldsource>Contrôle spatial (canal 3)</oldsource>
         <translation>Contrôle spatial (canal 3)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5043"/>
         <source>Pan control (channel #4)</source>
         <oldsource>Contrôle spatial (canal 4)</oldsource>
         <translation>Contrôle spatial (canal 4)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5045"/>
         <source>Pan transitions (channel #1)</source>
         <oldsource>Transitions spatiales (canal 1)</oldsource>
         <translation>Transitions spatiales (canal 1)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5047"/>
         <source>Pan transitions (channel #2)</source>
         <oldsource>Transitions spatiales (canal 2)</oldsource>
         <translation>Transitions spatiales (canal 2)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5049"/>
         <source>Pan transitions (channel #3)</source>
         <oldsource>Transitions spatiales (canal 3)</oldsource>
         <translation>Transitions spatiales (canal 3)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5051"/>
         <source>Pan transitions (channel #4)</source>
         <oldsource>Transitions spatiales (canal 4)</oldsource>
         <translation>Transitions spatiales (canal 4)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5053"/>
         <source>Tempo control (channel #1)</source>
         <oldsource>Contrôle du tempo (canal 1)</oldsource>
         <translation>Contrôle du tempo (canal 1)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5055"/>
         <source>Tempo control (channel #2)</source>
         <oldsource>Contrôle du tempo (canal 2)</oldsource>
         <translation>Contrôle du tempo (canal 2)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5057"/>
         <source>Tempo control (channel #3)</source>
         <oldsource>Contrôle du tempo (canal 3)</oldsource>
         <translation>Contrôle du tempo (canal 3)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5059"/>
         <source>Tempo control (channel #4)</source>
         <oldsource>Contrôle du tempo (canal 4)</oldsource>
         <translation>Contrôle du tempo (canal 4)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5061"/>
         <source>Tempo transitions (channel #1)</source>
         <oldsource>Tempo transitions (canal 1)</oldsource>
         <translation>Transitions tempo (canal 1)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5063"/>
         <source>Tempo transitions (channel #2)</source>
         <oldsource>Tempo transitions (canal 2)</oldsource>
         <translation>Transitions tempo (canal 2)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5065"/>
         <source>Tempo transitions (channel #3)</source>
         <oldsource>Tempo transitions (canal 3)</oldsource>
         <translation>Transitions tempo (canal 3)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5067"/>
         <source>Tempo transitions (channel #4)</source>
         <oldsource>Tempo transitions (canal 4)</oldsource>
         <translation>Transitions tempo (canal 4)</translation>
@@ -2258,25 +1869,21 @@ Certains scripts peuvent y faire référence !</translation>
         <translation type="vanished">Transitions du volume transitions sur tous les canaux</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5073"/>
         <source>Pan control for all channels</source>
         <oldsource>Contrôle spatial sur tous les canaux</oldsource>
         <translation>Contrôle spatial sur tous les canaux</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5075"/>
         <source>Pan transitions for all channels</source>
         <oldsource>Transitions spatiales sur tous les canaux</oldsource>
         <translation>Transitions spatiales sur tous les canaux</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5077"/>
         <source>Tempo control for all channels</source>
         <oldsource>Contrôle du tempo sur tous les canaux</oldsource>
         <translation>Contrôle du tempo sur tous les canaux</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5079"/>
         <source>Tempo transitions for all channels</source>
         <oldsource>Tempo transitions sur tous les canaux</oldsource>
         <translation>Transitions tempo  sur tous les canaux</translation>
@@ -2287,228 +1894,181 @@ Certains scripts peuvent y faire référence !</translation>
         <translation type="vanished">Transition sur le volume de la musique</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5095"/>
         <source>Music tempo transition</source>
         <oldsource>Transition sur le tempo de la musique</oldsource>
         <translation>Transition sur le tempo de la musique</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5109"/>
         <source>AKAO: %1?</source>
         <oldsource>AKAO : %1?</oldsource>
         <translation>AKAO : %1?</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5147"/>
         <source>%1 and %2 and %3</source>
         <oldsource>%1 et %2 et %3</oldsource>
         <translation>%1 et %2 et %3</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3108"/>
         <source>Check if %1 and store the result in var[15][111]</source>
         <translation>Vérifier si %1 et enregistrer le résultat dans var[15][111]</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3154"/>
         <source>Enables</source>
         <translation>Permettre</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3154"/>
         <source>Disables</source>
         <translation>Interdire</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3173"/>
         <source>Add %2 HP to party member #%1</source>
         <translation>Augmenter de %2 HPs le membre n°%1 de l&apos;équipe</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3187"/>
         <source>Remove %2 HP to party member #%1</source>
         <translation>Diminuer de %2 HPs le membre n°%1 de l&apos;équipe</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3222"/>
         <source>No Background/Border</source>
         <translation>Pas de fond, ni de bordure</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3233"/>
         <source>Set the window #%1 mode: %2 (%3 the closing of the window by the player)</source>
         <translation>Décoration de la fenêtre n°%1 : %2 (%3 la fermeture de la fenêtre par le joueur)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3237"/>
         <source>prevent</source>
         <translation>empêcher</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3244"/>
         <source>Reset the window #%1</source>
         <translation>Remettre la fenêtre n°%1 à zéro</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3251"/>
         <source>Close the window #%1 (stronger)</source>
         <translation>Fermer la fenêtre n°%1 (plus fort)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3258"/>
         <source>Number of row in the window #%1 = %2</source>
         <translation>Configurer le nombre de lignes de texte à %2 dans la fenêtre n°%1</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3266"/>
         <source>Get windows %1 color to %2 (R), %3 (G) and %4 (B)</source>
         <translation>Obtenir la couleur du côté %1 des fenêtres et en stocker les composantes dans %2 (R), %3 (V) et %4 (B)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3278"/>
         <source>Set windows %1 color: RGB(%2, %3, %4)</source>
         <translation>Changer la couleur du côté %1 des fenêtres : RVB(%2, %3, %4)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3358"/>
         <source>Perform no operation...</source>
         <translation>Ne rien faire...</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3410"/>
         <source>Scroll to playable character</source>
         <translation>Centrer sur le personnage jouable</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3428"/>
         <source>Wait for scroll</source>
         <translation>Attendre la fin du dernier centrage pour continuer</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3478"/>
         <source>Wait for fade</source>
         <translation>Attendre la fin du voilage de l&apos;écran pour continuer</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3492"/>
         <source>Retrieves the field ID number of the last field in %1</source>
         <translation>Stocker l&apos;id de l&apos;écran précédent dans %1</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3499"/>
         <source>Scroll to party member #%2 (speed=%1 frames, type=%3)</source>
         <translation>Centrer sur le personnage n°%2 de l&apos;équipe actuelle (vitesse=%1 img, type=%3)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3508"/>
         <source>Start battle #%1</source>
         <translation>Commencer le combat n°%1</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3515"/>
         <source>%1 random battle</source>
         <translation>%1 les combats aléatoires</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2535"/>
-        <location filename="../src/core/field/Opcode.cpp" line="3533"/>
         <source>The party cannot escape the battle</source>
         <translation>Impossible de fuir</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2544"/>
-        <location filename="../src/core/field/Opcode.cpp" line="3542"/>
         <source>Do not show battle rewards</source>
         <translation>Ne pas afficher d&apos;écran de récompense</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3561"/>
         <source>Get direction of the party member #%1 to %2</source>
         <translation>Obtenir la direction du personnage n°%1 de l&apos;équipe actuelle et la stocker dans %2</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3569"/>
         <source>Get group ID of the party member #%1 to %2</source>
         <translation>Obtenir l&apos;id du personnage n°%1 de l&apos;équipe actuelle et le stocker dans %2</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3658"/>
         <source>%1 talk script for the current field model</source>
         <translation>%1 la possibilité de parler à l&apos;objet 3D</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3692"/>
         <source>Bit %2 ON in %1</source>
         <translation>Mettre le bit %2 à 1 dans %1</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3702"/>
         <source>Bit %2 OFF in %1</source>
         <translation>Mettre le bit %2 à 0 dans %1</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3712"/>
         <source>Toggle bit %2 in %1</source>
         <translation>Inverser la valeur du bit %2 dans %1</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3910"/>
         <source>Set random value to %1 (8-bit)</source>
         <translation>Affecter une valeur aléatoire à %1 (8 bits)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4014"/>
         <source>%1 field model</source>
         <translation>%1 l&apos;objet 3D</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4092"/>
         <source>Wait for animation</source>
         <translation>Attendre que l&apos;animation soit terminée pour continuer</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4144"/>
         <source>Set the field model move speed: %1</source>
         <translation>Configurer la vitesse des déplacements de l&apos;objet 3D : %1</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4313"/>
         <source>Wait for offset object</source>
         <translation>Attendre la fin de l&apos;exécution de l&apos;Offset Object pour continuer</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4319"/>
-        <location filename="../src/core/field/Opcode.cpp" line="4477"/>
         <source>Set range of the talk circle for the field model: %1</source>
         <translation>Modifier la distance nécessaire pour parler avec l&apos;objet 3D : %1</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4333"/>
         <source>%1 contact with field model</source>
         <translation>%1 la possibilité de toucher l&apos;objet 3D</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4340"/>
         <source>Add %1 to the current party</source>
         <translation>Ajouter %1 à l&apos;équipe actuelle</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4347"/>
         <source>Remove %1 from the current party</source>
         <translation>Retirer %1 de l&apos;équipe actuelle</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4365"/>
         <source>If %1 is in the current party (%2)</source>
         <translation>Si %1 est dans l&apos;équipe actuelle (%2)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4391"/>
         <source>not available</source>
         <translation>n&apos;existe plus</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4391"/>
         <source>available</source>
         <translation>existe</translation>
     </message>
@@ -2517,433 +2077,346 @@ Certains scripts peuvent y faire référence !</translation>
         <translation type="vanished">Effacer</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4432"/>
         <source>Gateways %1</source>
         <translation>%1 les changements de décor par le joueur</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4439"/>
         <source>Set line (X1=%1, Y1=%2, Z1=%3, X2=%4, Y2=%5, Z2=%6)</source>
         <translation>Modifier la ligne (X1=%1, Y1=%2, Z1=%3, X2=%4, Y2=%5, Z2=%6)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4491"/>
         <source>Preload the field map %1</source>
         <translation>Commencer à charger l&apos;écran %1</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4505"/>
         <source>%1 (param1=%2, param2=%3, param3=%4, param4=%5, param5=%6)</source>
         <oldsource>%1 (16-bit) (param1=%2, param2=%3, param3=%4, param4=%5, param5=%6)</oldsource>
         <translation>%1 (param1=%2, param2=%3, param3=%4, param4=%5, param5=%6)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4530"/>
         <source>stay</source>
         <translation>rester immobile</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4532"/>
         <source>walk</source>
         <translation>marcher</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4533"/>
         <source>run</source>
         <translation>courir</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4540"/>
         <source>Break field model animation</source>
         <translation>Stoppe l&apos;animation de l&apos;objet 3D</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4547"/>
         <source>Wait for rotation</source>
         <translation>Attendre que la rotation soit terminée pour continuer</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4568"/>
         <source>Show the state #%2 of the background parameter #%1</source>
         <translation>Afficher l&apos;état n°%2 du paramètre n°%1</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4595"/>
         <source>Show previous state of the background parameter #%1</source>
         <translation>Afficher l&apos;état précédent du paramètre n°%1</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4750"/>
         <source>Play music #%1</source>
         <translation>Jouer musique n°%1</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4767"/>
         <source>%1 (param1 (8-bit)=%2, param2=%3, param3=%4, param4=%5, param5=%6)</source>
         <oldsource>%1 (8-bit) (param1=%2, param2=%3, param3=%4, param4=%5, param5=%6)</oldsource>
         <translation>%1 (param1 (8 bits)=%2, param2=%3, param3=%4, param4=%5, param5=%6)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4796"/>
         <source>Unlock</source>
         <translation>Déverrouiller</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4796"/>
         <source>Lock</source>
         <comment>test</comment>
         <translation>Verrouiller</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4802"/>
         <source>Set the music #%1 for next battle</source>
         <translation>Choisir musique n°%1 comme musique de combat</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4819"/>
         <source>Set next movie: %1</source>
         <translation>Choisir prochaine cinématique : %1</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4827"/>
         <source>Play movie</source>
         <translation>Jouer la cinématique choisie</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5203"/>
-        <location filename="../src/core/field/Opcode.cpp" line="5204"/>
         <source>reverse</source>
         <oldsource>inverse</oldsource>
         <translation>inverse</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4974"/>
         <source>Play music [param1: music ID, 0-based]</source>
         <translation>Jouer musique [param1 : music id, à partir de 0]</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2098"/>
         <source>Return and execute script #%2 from the current entity (Priority %1/6)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2139"/>
         <source>Get party to memory: %1 | %2 | %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2151"/>
         <source>Unused opcode 0x%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2177"/>
         <source>PNAME - Disable right menu (%1, bank=%2, size=%3)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2186"/>
         <source>%1 = Game Speed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2193"/>
         <source>Set field message speed: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2265"/>
         <source>SPECIAL - Unknown %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2441"/>
         <source>Write bytes to address 0x%1 (length=%2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2593"/>
         <source>%1 Field Model blinking</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2607"/>
         <source>Field Model graphic filter - Change the state of the eye/mouth texture (eye 1=%1, eye 2=%2, mouth=%3, 3D object ID=%4)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2617"/>
         <source>Field Model graphic filter - %1 blending</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2624"/>
         <source>Field Model graphic filter - Change the ambient color of the model: RGB(%1, %2, %3) RGB(%4, %5, %6) (flags=%7)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2638"/>
         <source>Field Model graphic filter - UNKNOWN4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2645"/>
         <source>Field Model graphic filter - LIGHT</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2652"/>
         <source>Field Model graphic filter - UNKNOWN7</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2659"/>
         <source>Field Model graphic filter - UNKNOWN8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2666"/>
         <source>Field Model graphic filter - UNKNOWN9</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2673"/>
         <source>Field Model graphic filter - SBOBJ</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2680"/>
         <source>Field Model graphic filter - UNKNOWNB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2687"/>
         <source>Field Model graphic filter - UNKNOWNC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2694"/>
         <source>Field Model graphic filter - SHINE</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2701"/>
         <source>Field Model graphic filter - RESET</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2723"/>
         <source>Field Model graphic filter - Unknown %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2731"/>
         <source>Wait for Field Model graphic filter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3036"/>
-        <location filename="../src/core/field/Opcode.cpp" line="3070"/>
         <source>%1 (char ID)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3335"/>
         <source>%4 = amount of materia %1 in the inventory (AP=%2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3346"/>
         <source>Shake (type=%1, xAmplitude=%2, xFrames=%3, yAmplitude=%2, yFrames=%3)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3452"/>
         <source>Scroll to location (?=%1, ?=%2, enable=%3)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3948"/>
         <source>SETX[%1][%2 + %3] = %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3960"/>
         <source>%1 = GETX[%2][%3 + %4]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4705"/>
         <source>Copy palette 2 (sourceTile=%1, targetTile=%2, sourcePal=%3, targetPal=%4, color count=%3 + 1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4719"/>
         <source>Copy partially palette 2 %1 (sourceTile=%1, targetTile=%2, sourcePal=%3, targetPal=%4, first color=%5)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4735"/>
         <source>Add RGB(%6, %5, %4) on the colors in a palette (2) (sourceTile=%1, targetTile=%2, first color=%3, color count=%7)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4781"/>
         <source>Play temporary music #%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4847"/>
         <source>Set next field music for when we will be back to the map: #%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4854"/>
         <source>CMUSC (music #%1, operation=%2, param1=%3, param2=%4)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4977"/>
         <source>Play music and resume from last position [param1: music ID, 0-based]</source>
         <translation>Jouer musique et reprendre de la dernière position [param1 : musique id, à partir de 0]</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4980"/>
         <source>Play a sound effect (will be terminated if another effect is played on channel) [param1: panning, param2: effect ID]</source>
         <translation>Jouer un effet sonore (sera arrêté si un autre effet est joué sur le canal) [param1 : panoramique, param2 : effet id]</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4985"/>
         <source>Play a sound effect (will be terminated if another effect is played on channel) [param1: panning, param2: effect ID, param3: ?]</source>
         <translation>Jouer un effet sonore (sera arrêté si un autre effet est joué sur le canal) [param1 : panoramique, param2 : effet id, param3 : ?]</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4990"/>
         <source>Play a sound effect (will be terminated if another effect is played on channel) [param1: panning, param2: effect ID, param3: ?, param4: ?]</source>
         <translation>Jouer un effet sonore (sera arrêté si un autre effet est joué sur le canal) [param1 : panoramique, param2 : effet id, param3 : ?, param4 : ?]</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4995"/>
         <source>Play a sound effect (will be terminated if another effect is played on channel) [param1: panning, param2: effect ID, param3: ?, param4: ?, param5: ?]</source>
         <translation>Jouer un effet sonore (sera arrêté si un autre effet est joué sur le canal) [param1 : panoramique, param2 : effet id, param3 : ?, param4 : ?, param5 : ?]</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4999"/>
         <source>Play a sound effect on channel #1 [param1: panning, param2: effect ID]</source>
         <translation>Jouer un effet sonore sur le canal n°1 [param1 : panoramique, param2 : effet id]</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5001"/>
         <source>Play a sound effect on channel #2 [param1: panning, param2: effect ID]</source>
         <translation>Jouer un effet sonore sur le canal n°2 [param1 : panoramique, param2 : effet id]</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5003"/>
         <source>Play a sound effect on channel #3 [param1: panning, param2: effect ID]</source>
         <translation>Jouer un effet sonore sur le canal n°3 [param1 : panoramique, param2 : effet id]</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5005"/>
         <source>Play a sound effect on channel #4 [param1: panning, param2: effect ID]</source>
         <translation>Jouer un effet sonore sur le canal n°4 [param1 : panoramique, param2 : effet id]</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5007"/>
         <source>Play a sound effect (cannot be stopped) [param1: effect ID]</source>
         <translation>Jouer un effet sonore (ne peut pas être arrêté) [param2 : effet id]</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5021"/>
         <source>Volume control (channel #1) [param1: volume]</source>
         <translation>Contrôle de volume (canal #1) [param1 : volume]</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5023"/>
         <source>Volume control (channel #2) [param1: volume]</source>
         <translation>Contrôle de volume (canal #2) [param1 : volume]</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5025"/>
         <source>Volume control (channel #3) [param1: volume]</source>
         <translation>Contrôle de volume (canal #3) [param1 : volume]</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5027"/>
         <source>Volume control (channel #4) [param1: volume]</source>
         <translation>Contrôle de volume (canal #4) [param1 : volume]</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5029"/>
         <source>Volume transitions (channel #1) [param1: transition time, param2: target volume]</source>
         <translation>Transitions de volume (canal n°1) [param1 : durée, param2 : volume cible]</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5031"/>
         <source>Volume transitions (channel #2) [param1: transition time, param2: target volume]</source>
         <translation>Transitions de volume (canal n°2) [param1 : durée, param2 : volume cible]</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5033"/>
         <source>Volume transitions (channel #3) [param1: transition time, param2: target volume]</source>
         <translation>Transitions de volume (canal n°3) [param1 : durée, param2 : volume cible]</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5035"/>
         <source>Volume transitions (channel #4) [param1: transition time, param2: target volume]</source>
         <translation>Transitions de volume (canal n°4) [param1 : durée, param2 : volume cible]</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5069"/>
         <source>Volume control for all channels [param1: volume]</source>
         <translation>Contrôle de volume sur tous les canaux [param1 : volume]</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5071"/>
         <source>Volume transitions for all channels [param1: transition time, param2: target volume]</source>
         <translation>Transition de volume sur tous les canaux [param1 : durée, param2 : volume cible]</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5081"/>
         <source>Set music volume [param1: volume]</source>
         <translation>Définir le volume de la musique [param1 : volume]</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5083"/>
         <source>Music volume transition [param1: transition time, param2: target volume]</source>
         <translation>Volume transition de la musique [param1 : durée, param2 : volume cible]</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5087"/>
         <source>Set music pan (noop in PC version)</source>
         <translation>Définir panorama de la musique (ne fait rien sur la version PC)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5089"/>
         <source>Music pan transition (noop in PC version)</source>
         <translation>Transition de panorama de la musique (ne fait rien sur la version PC)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5091"/>
         <source>Music pan fade (noop in PC version)</source>
         <translation>Panorama du fondu musical (ne fait rien sur la version PC)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5093"/>
         <source>Set music tempo [param1: tempo, 0x20 is normal]</source>
         <translation>Définir le tempo de la musique [param1 : tempo, la valeur normale est 0x20]</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5099"/>
         <source>Stop music-like (noop in PC version)</source>
         <translation>Arrêter la musique ou approchant (ne fait rien dans la version PC)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5160"/>
         <source>%1 and %2 and %3 and %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5205"/>
         <source>normal</source>
         <translation>normal</translation>
     </message>
@@ -2953,43 +2426,36 @@ Certains scripts peuvent y faire référence !</translation>
         <translation type="vanished">? (id=%1)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2041"/>
         <source>Return</source>
         <oldsource>Retourner</oldsource>
         <translation>Retourner</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2046"/>
         <source>Execute script #%3 in extern group %1 (priority %2/6) - Only if the script is not already running</source>
         <oldsource>Exécuter le script n°%3 du groupe externe %1 (priorité %2/6) - Seulement si le script n&apos;est pas déjà en cours d&apos;exécution</oldsource>
         <translation>Exécuter le script n°%3 du groupe externe %1 (priorité %2/6) - Seulement si le script n&apos;est pas déjà en cours d&apos;exécution</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2054"/>
         <source>Execute script #%3 in extern group %1 (priority %2/6)</source>
         <oldsource>Exécuter le script n°%3 du groupe externe %1 (priorité %2/6)</oldsource>
         <translation>Exécuter le script n°%3 du groupe externe %1 (priorité %2/6)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2062"/>
         <source>Execute script #%3 in group %1 (priority %2/6) - Waiting for end of execution to continue</source>
         <oldsource>Exécuter le script n°%3 du groupe %1 (priorité %2/6) - Attend la fin de l&apos;exécution pour continuer</oldsource>
         <translation>Exécuter le script n°%3 du groupe %1 (priorité %2/6) - Attend la fin de l&apos;exécution pour continuer</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2071"/>
         <source>Execute script #%3 in extern group associated with the character #%1 in the current party (priority %2/6) - Only if the script is not already running</source>
         <oldsource>Exécuter le script n°%3 du groupe externe lié au personnage No%1 de l&apos;équipe (priorité %2/6) - Seulement si le script n&apos;est pas déjà en cours d&apos;exécution</oldsource>
         <translation>Exécuter le script n°%3 du groupe externe lié au personnage n°%1 de l&apos;équipe (priorité %2/6) - Seulement si le script n&apos;est pas déjà en cours d&apos;exécution</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2080"/>
         <source>Execute script #%3 in extern group associated with the character #%1 in the current party (priority %2/6)</source>
         <oldsource>Exécuter le script n°%3 du groupe externe lié au personnage No%1 de l&apos;équipe (priorité %2/6)</oldsource>
         <translation>Exécuter le script n°%3 du groupe externe lié au personnage n°%1 de l&apos;équipe (priorité %2/6)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2089"/>
         <source>Execute script #%3 in group associated with the character #%1 in the current party (priority %2/6) - Waiting for end of execution to continue</source>
         <oldsource>Exécuter le script n°%3 du groupe lié au personnage No%1 de l&apos;équipe (priorité %2/6) - Attend la fin de l&apos;exécution pour continuer</oldsource>
         <translation>Exécuter le script n°%3 du groupe lié au personnage n°%1 de l&apos;équipe (priorité %2/6) - Attend la fin de l&apos;exécution pour continuer</translation>
@@ -3000,7 +2466,6 @@ Certains scripts peuvent y faire référence !</translation>
         <translation type="vanished">Retourner et exécuter le script n°%2 du groupe appelant (priorité %1/6)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2113"/>
         <source>Split party field (member 1: X=%1, Y=%2, dir=%3 ; member 2 : X=%4, Y=%5, dir=%6) (speed %7)</source>
         <oldsource>Faire sortir les membres de l&apos;équipe à partir du personnage jouable (perso 1 : X=%1, Y=%2, dir=%3 ; perso 2 : X=%4, Y=%5, dir=%6) (vitesse %7)</oldsource>
         <translation>Faire sortir les membres de l&apos;équipe à partir du personnage jouable (perso 1 : X=%1, Y=%2, dir=%3 ; perso 2 : X=%4, Y=%5, dir=%6) (vitesse %7)</translation>
@@ -3016,58 +2481,35 @@ Certains scripts peuvent y faire référence !</translation>
         <translation type="vanished">Modifier la vitesse des messages (%2) | %1 |</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2201"/>
         <source>Fill materia menu with all materias in full quantity</source>
         <oldsource>Remplir le menu matéria de toutes les matérias en quantité maximum</oldsource>
         <translation>Remplir le menu matéria de toutes les matérias en quantité maximum</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2208"/>
         <source>Fills all available item entries in full quantity</source>
         <oldsource>Remplir l&apos;inventaire par tous les objets en quantité maximum</oldsource>
         <translation>Remplir l&apos;inventaire par tous les objets en quantité maximum</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2215"/>
         <source>%1 battles</source>
         <oldsource>%1 les combats</oldsource>
         <translation>%1 les combats</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2216"/>
-        <location filename="../src/core/field/Opcode.cpp" line="2223"/>
-        <location filename="../src/core/field/Opcode.cpp" line="2618"/>
-        <location filename="../src/core/field/Opcode.cpp" line="2827"/>
-        <location filename="../src/core/field/Opcode.cpp" line="3486"/>
-        <location filename="../src/core/field/Opcode.cpp" line="3516"/>
-        <location filename="../src/core/field/Opcode.cpp" line="3659"/>
-        <location filename="../src/core/field/Opcode.cpp" line="4334"/>
-        <location filename="../src/core/field/Opcode.cpp" line="4520"/>
         <source>Activate</source>
         <oldsource>Activer</oldsource>
         <translation>Activer</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2216"/>
-        <location filename="../src/core/field/Opcode.cpp" line="2223"/>
-        <location filename="../src/core/field/Opcode.cpp" line="2618"/>
-        <location filename="../src/core/field/Opcode.cpp" line="2827"/>
-        <location filename="../src/core/field/Opcode.cpp" line="3486"/>
-        <location filename="../src/core/field/Opcode.cpp" line="3516"/>
-        <location filename="../src/core/field/Opcode.cpp" line="3659"/>
-        <location filename="../src/core/field/Opcode.cpp" line="4334"/>
-        <location filename="../src/core/field/Opcode.cpp" line="4520"/>
         <source>Deactivate</source>
         <translation>Désactiver</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2228"/>
         <source>Change name of %1 by text %2</source>
         <oldsource>Changer le nom de %1 par le texte %2</oldsource>
         <translation>Changer le nom de %1 par le texte %2</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2239"/>
         <source>Set game time to 0, unlock &quot;PHS&quot; and Save menu. New party: Cloud | (empty) | (empty)</source>
         <oldsource>Set game time to 0, unlock &quot;PHS&quot; and Save menu. New party: Cloud | (empty) | (empty);</oldsource>
         <translation>Met le temps à 0, débloque le menu &quot;PHS&quot; et &quot;Sauvegarder&quot;. Nouvelle équipe : Clad | (Vide) | (Vide)</translation>
@@ -3077,192 +2519,135 @@ Certains scripts peuvent y faire référence !</translation>
         <translation type="vanished">SPECIAL - </translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2272"/>
         <source>Label %1</source>
         <translation>Label %1</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2280"/>
-        <location filename="../src/core/field/Opcode.cpp" line="2288"/>
-        <location filename="../src/core/field/Opcode.cpp" line="2296"/>
-        <location filename="../src/core/field/Opcode.cpp" line="2304"/>
         <source>Goto label %1</source>
         <oldsource>Aller au label %1</oldsource>
         <translation>Aller au label %1</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2311"/>
-        <location filename="../src/core/field/Opcode.cpp" line="2325"/>
-        <location filename="../src/core/field/Opcode.cpp" line="2339"/>
-        <location filename="../src/core/field/Opcode.cpp" line="2353"/>
-        <location filename="../src/core/field/Opcode.cpp" line="2367"/>
-        <location filename="../src/core/field/Opcode.cpp" line="2381"/>
         <source>If %1 %3 %2 (%4)</source>
         <oldsource>Si %1 %3 %2 (%4)</oldsource>
         <translation>Si %1 %3 %2 (%4)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2318"/>
-        <location filename="../src/core/field/Opcode.cpp" line="2332"/>
-        <location filename="../src/core/field/Opcode.cpp" line="2346"/>
-        <location filename="../src/core/field/Opcode.cpp" line="2360"/>
-        <location filename="../src/core/field/Opcode.cpp" line="2374"/>
-        <location filename="../src/core/field/Opcode.cpp" line="2388"/>
-        <location filename="../src/core/field/Opcode.cpp" line="2435"/>
-        <location filename="../src/core/field/Opcode.cpp" line="2793"/>
-        <location filename="../src/core/field/Opcode.cpp" line="2806"/>
-        <location filename="../src/core/field/Opcode.cpp" line="2819"/>
-        <location filename="../src/core/field/Opcode.cpp" line="4370"/>
-        <location filename="../src/core/field/Opcode.cpp" line="4382"/>
         <source>else goto label %1</source>
         <oldsource>aller au label %1 sinon</oldsource>
         <translation>aller au label %1 sinon</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2399"/>
         <source>8 bit</source>
         <translation>8 bits</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2402"/>
         <source>16 bit</source>
         <translation>16 bits</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2405"/>
         <source>24 bit</source>
         <translation>24 bits</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2408"/>
         <source>32 bit</source>
         <translation>32 bits</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2415"/>
         <source>From is a pointer</source>
         <translation>&apos;De&apos; est un pointeur</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2419"/>
         <source>To is a pointer</source>
         <translation>&apos;Vers&apos; est un pointeur</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2422"/>
         <source>Write/Read entire savemap (from=%1, to=%2, absValue=%3, flags={%4})</source>
         <translation>Écrire/Lire toute la savemap (de=%1, vers=%2, valeurAbsolue=%3, flags={%4})</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2432"/>
         <source>If Red XIII is named Nanaki (%2)</source>
         <translation>Si Rouge XIII se nomme Nanaki (%2)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2471"/>
-        <location filename="../src/core/field/Opcode.cpp" line="3052"/>
         <source>Bike (parameter %1)</source>
         <oldsource>Course de moto (paramètre %1)</oldsource>
         <translation>Course de moto (paramètre %1)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2475"/>
         <source>Chocobo Races (parameter %1)</source>
         <oldsource>Course de chocobo (paramètre %1)</oldsource>
         <translation>Course de chocobo (paramètre %1)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2479"/>
         <source>Snowboard -normal mode- (parameter %1)</source>
         <oldsource>Descente en snowboard -mode normal- (paramètre %1)</oldsource>
         <translation>Descente en snowboard -mode normal- (paramètre %1)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2483"/>
         <source>Fort Condor (parameter %1)</source>
         <oldsource>Fort Condor (paramètre %1)</oldsource>
         <translation>Fort Condor (paramètre %1)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2487"/>
         <source>Submarine (parameter %1)</source>
         <oldsource>Sous-marin (paramètre %1)</oldsource>
         <translation>Sous-marin (paramètre %1)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2491"/>
         <source>Speed Square (parameter %1)</source>
         <oldsource>Speed Square (paramètre %1)</oldsource>
         <translation>Speed Square (paramètre %1)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2495"/>
         <source>Snowboard -Gold Saucer mode- (parameter %1)</source>
         <oldsource>Descente en snowboard -mode Gold Saucer- (paramètre %1)</oldsource>
         <translation>Descente en snowboard -mode Gold Saucer- (paramètre %1)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2499"/>
-        <location filename="../src/core/field/Opcode.cpp" line="3140"/>
         <source>%1? (parameter %2)</source>
         <oldsource>%1? (paramètre %2)</oldsource>
         <translation>%1? (paramètre %2)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2505"/>
         <source>Mini-game: %5 (After the game goto field %1 (X=%2, Y=%3, triangle ID=%4))</source>
         <oldsource>Lancer un mini-jeu : %5 (Après le jeu aller à l&apos;écran %1 (X=%2, Y=%3, triangle id=%4))</oldsource>
         <translation>Lancer un mini-jeu : %5 (Après le jeu aller à l&apos;écran %1 (X=%2, Y=%3, triangle id=%4))</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2532"/>
-        <location filename="../src/core/field/Opcode.cpp" line="3530"/>
         <source>Pre-emptive attack</source>
         <oldsource>Attaque préventive</oldsource>
         <translation>Attaque préventive</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2550"/>
-        <location filename="../src/core/field/Opcode.cpp" line="3545"/>
         <source>Disable game over</source>
         <oldsource>Désactiver Game Over</oldsource>
         <translation>Désactiver Game Over</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2559"/>
-        <location filename="../src/core/field/Opcode.cpp" line="3554"/>
         <source>Battle mode: %1</source>
         <oldsource>Mode de combat : %1</oldsource>
         <translation>Mode de combat : %1</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2566"/>
         <source>Stores the result of the last battle in %1</source>
         <oldsource>Stocker le résultat du dernier combat dans %1</oldsource>
         <translation>Stocker le résultat du dernier combat dans %1</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2580"/>
         <source>Fades the screen to the colour RGB(%2, %3, %4) (speed=%5, type=%1)</source>
         <oldsource>Voiler l&apos;écran avec la couleur RVB(%2, %3, %4) (vitesse=%5, type=%1)</oldsource>
         <translation>Voiler l&apos;écran avec la couleur RVB(%2, %3, %4) (vitesse=%5, type=%1)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2601"/>
-        <location filename="../src/core/field/Opcode.cpp" line="2745"/>
-        <location filename="../src/core/field/Opcode.cpp" line="4433"/>
         <source>ON</source>
         <translation>Autoriser</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2601"/>
-        <location filename="../src/core/field/Opcode.cpp" line="2745"/>
-        <location filename="../src/core/field/Opcode.cpp" line="4433"/>
         <source>OFF</source>
         <translation>Empêcher</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2600"/>
         <source>BGMOVIE : %1</source>
         <translation>BGMOVIE : %1</translation>
     </message>
@@ -3286,35 +2671,29 @@ Certains scripts peuvent y faire référence !</translation>
         <translation type="vanished">Filtre graphique sur l&apos;objet 3D - %1</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2744"/>
         <source>SLIP : %1</source>
         <translation>SLIP : %1</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2751"/>
         <source>Set Z-deph for the background layer #%1 (Z=%2)</source>
         <oldsource>Déplacer la couche %1 du décor (Z=%2)</oldsource>
         <translation>Déplacer la couche %1 du décor (Z=%2)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2759"/>
         <source>Animate the background layer #%1 (Horizontally=%2, Vertically=%3)</source>
         <oldsource>Animer la couche %1 du décor (horizontalement=%2, verticalement=%3)</oldsource>
         <translation>Animer la couche %1 du décor (horizontalement=%2, verticalement=%3)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2777"/>
         <source>Resizes/Repositions the window #%1 (X=%2, Y=%3, width=%4, height=%5)</source>
         <oldsource>Redimensionner fenêtre No%1 (X=%2, Y=%3, largeur=%4, hauteur=%5)</oldsource>
         <translation>Redimensionner fenêtre n°%1 (X=%2, Y=%3, largeur=%4, hauteur=%5)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5013"/>
         <source>Resumes only the music</source>
         <translation>Reprendre uniquement la musique</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5015"/>
         <source>Pauses only the music</source>
         <translation>Mettre en pause uniquement la musique</translation>
     </message>
@@ -3323,7 +2702,6 @@ Certains scripts peuvent y faire référence !</translation>
         <translation type="vanished">Modifier le volume de la musique</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5085"/>
         <source>Fade music volume</source>
         <translation>Attenuation du volume de la musique</translation>
     </message>
@@ -3340,52 +2718,42 @@ Certains scripts peuvent y faire référence !</translation>
         <translation type="vanished">Modifier le tempo de la musique</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5097"/>
         <source>Music tempo fade</source>
         <translation>Attenuation du tempo de la musique</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5101"/>
         <source>Stop music</source>
         <translation>Arrêter la musique</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5103"/>
         <source>Stop sound effects</source>
         <translation>Arrêter les effets sonores</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5177"/>
         <source>(Empty)</source>
         <translation>(Vide)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5192"/>
         <source>Top Left</source>
         <translation>haut gauche</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5193"/>
         <source>Bottom Left</source>
         <translation>bas gauche</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5194"/>
         <source>Top Right</source>
         <translation>haut droit</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5195"/>
         <source>Bottom Right</source>
         <translation>bas droit</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2106"/>
         <source>Join party field (speed=%1)</source>
         <translation>Rassembler les membres de l&apos;équipe dans le personnage jouable (vitesse=%1)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2128"/>
         <source>Set party from memory: %1 | %2 | %3</source>
         <translation>Affecter les membres de l&apos;équipe : %1 | %2 | %3</translation>
     </message>
@@ -3395,24 +2763,18 @@ Certains scripts peuvent y faire référence !</translation>
         <translation type="vanished">Récupérer les membres de l&apos;équipe : %1 | %2 | %3</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2163"/>
         <source>Ask for disc %1</source>
         <translation>Demander le CD %1</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2170"/>
         <source>%1 arrow</source>
         <translation>%1 le curseur main</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2171"/>
-        <location filename="../src/core/field/Opcode.cpp" line="4015"/>
         <source>Display</source>
         <translation>Afficher</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2171"/>
-        <location filename="../src/core/field/Opcode.cpp" line="4015"/>
         <source>Hide</source>
         <translation>Cacher</translation>
     </message>
@@ -3421,18 +2783,14 @@ Certains scripts peuvent y faire référence !</translation>
         <translation type="vanished">Modifier la vitesse de jeu (%1)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2222"/>
         <source>%1 movies</source>
         <translation>%1 les cinématiques</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2246"/>
         <source>Remove all items</source>
         <translation>Supprimer tous les objets de l&apos;inventaire</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/core/field/Opcode.cpp" line="2279"/>
-        <location filename="../src/core/field/Opcode.cpp" line="2287"/>
         <source>Forward %n byte(s)</source>
         <comment>With plural</comment>
         <translation>
@@ -3441,8 +2799,6 @@ Certains scripts peuvent y faire référence !</translation>
         </translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/core/field/Opcode.cpp" line="2295"/>
-        <location filename="../src/core/field/Opcode.cpp" line="2303"/>
         <source>Back %n byte(s)</source>
         <comment>With plural</comment>
         <translation>
@@ -3451,18 +2807,6 @@ Certains scripts peuvent y faire référence !</translation>
         </translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/core/field/Opcode.cpp" line="2317"/>
-        <location filename="../src/core/field/Opcode.cpp" line="2331"/>
-        <location filename="../src/core/field/Opcode.cpp" line="2345"/>
-        <location filename="../src/core/field/Opcode.cpp" line="2359"/>
-        <location filename="../src/core/field/Opcode.cpp" line="2373"/>
-        <location filename="../src/core/field/Opcode.cpp" line="2387"/>
-        <location filename="../src/core/field/Opcode.cpp" line="2434"/>
-        <location filename="../src/core/field/Opcode.cpp" line="2792"/>
-        <location filename="../src/core/field/Opcode.cpp" line="2805"/>
-        <location filename="../src/core/field/Opcode.cpp" line="2818"/>
-        <location filename="../src/core/field/Opcode.cpp" line="4369"/>
-        <location filename="../src/core/field/Opcode.cpp" line="4381"/>
         <source>else forward %n byte(s)</source>
         <comment>With plural</comment>
         <translation>
@@ -3471,41 +2815,30 @@ Certains scripts peuvent y faire référence !</translation>
         </translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2516"/>
         <source>Tutorial #%1</source>
         <translation>Lancer le tutoriel n°%1</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2529"/>
-        <location filename="../src/core/field/Opcode.cpp" line="3527"/>
         <source>Countdown</source>
         <translation>Compte à rebours</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2538"/>
-        <location filename="../src/core/field/Opcode.cpp" line="3536"/>
         <source>Do not play the battle victory music</source>
         <translation>Ne pas jouer Fanfare</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2541"/>
-        <location filename="../src/core/field/Opcode.cpp" line="3539"/>
         <source>Activates the battle arena</source>
         <translation>Active l&apos;arène de combat du Gold Saucer</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2547"/>
         <source>The party members do not perform their victory celebrations at the end of battle</source>
         <translation>Les personnages ne font pas leur animation de victoire</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2560"/>
-        <location filename="../src/core/field/Opcode.cpp" line="3555"/>
         <source>None</source>
         <translation>Aucun</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2573"/>
         <source>Wait %1 frame</source>
         <translation>Attendre %1 img</translation>
     </message>
@@ -3522,294 +2855,237 @@ Certains scripts peuvent y faire référence !</translation>
         <translation type="vanished">Attendre la fin de l&apos;exécution du filtre graphique</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2737"/>
         <source>Move Field Model to Party Member #%1</source>
         <translation>Déplacer l&apos;objet 3D vers le membre n°%1 de l&apos;équipe</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2770"/>
         <source>Close the window #%1</source>
         <translation>Fermer la fenêtre n°%1</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5218"/>
         <source>(no key)</source>
         <oldsource>(no key</oldsource>
         <translation>(aucune touche)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5220"/>
         <source> or </source>
         <oldsource> ou </oldsource>
         <translation> ou </translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2826"/>
         <source>%1 the movability of the playable character</source>
         <oldsource>%1 les déplacements du personnage jouable</oldsource>
         <translation>%1 les déplacements du personnage jouable</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2833"/>
         <source>Instantly turns the field model to face the party member #%1</source>
         <oldsource>Tourner instantanément l&apos;objet 3D vers le membre de l&apos;équipe No%1</oldsource>
         <translation>Tourner instantanément l&apos;objet 3D vers le membre de l&apos;équipe n°%1</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2840"/>
         <source>Turns the field model to face the party member #%1 (Speed=%2, Rotation=%3)</source>
         <oldsource>Tourner l&apos;objet 3D vers le membre de l&apos;équipe No%1 (vitesse=%2, sens de rotation=%3)</oldsource>
         <translation>Tourner l&apos;objet 3D vers le membre de l&apos;équipe n°%1 (vitesse=%2, sens de rotation=%3)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2852"/>
         <source>(none)</source>
         <oldsource>(vide)</oldsource>
         <translation>(vide)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2858"/>
         <source>Numeric (000000)</source>
         <oldsource>Affichage numérique</oldsource>
         <translation>Affichage numérique</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2866"/>
         <source>%2 in the window #%1 (left=%3, top=%4)</source>
         <oldsource>%2 dans fenêtre No%1 (gauche=%3, haut=%4)</oldsource>
         <translation>%2 dans fenêtre n°%1 (gauche=%3, haut=%4)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2903"/>
         <source>Remove %1 gils from the party</source>
         <oldsource>Retirer %1 gils à l&apos;équipe</oldsource>
         <translation>Retirer %1 gils à l&apos;équipe</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2910"/>
         <source>Copies the amount of gil in %1 and %2</source>
         <oldsource>Copier le nombre de Gils dans %1 et %2</oldsource>
         <translation>Copier le nombre de Gils dans %1 et %2</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2921"/>
-        <location filename="../src/core/field/Opcode.cpp" line="2928"/>
-        <location filename="../src/core/field/Opcode.cpp" line="2942"/>
         <source>Restores full HP and MP of every party member</source>
         <oldsource>Redonne les HP/MP aux membres de l&apos;équipe</oldsource>
         <translation>Redonne les HP/MP aux membres de l&apos;équipe</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2972"/>
         <source>Display %1 in the main menu</source>
         <oldsource>Afficher %1 dans le menu</oldsource>
         <translation>Afficher %1 dans le menu</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3006"/>
         <source>Ask Question %2 in the window #%1 (and put selected answer in %5) first line=%3, last line=%4</source>
         <oldsource>Poser question %2 dans la fenêtre No%1 (et mettre la réponse sélectionnée dans %5) première ligne=%3, dernière ligne=%4</oldsource>
         <translation>Poser question %2 dans la fenêtre n°%1 (et mettre la réponse sélectionnée dans %5) première ligne=%3, dernière ligne=%4</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3092"/>
         <source>all magic materias are present and mastered</source>
         <translation>toutes les matérias magiques sont présentes et au niveau maître</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3095"/>
         <source>all summon materias are present and mastered</source>
         <translation>toutes les matérias d&apos;invocation sont présentes et au niveau maître</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3098"/>
         <source>necessary command materias are present and mastered</source>
         <translation>les matérias de commande nécessaires sont présentes et au niveau maître</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3101"/>
         <source>Bahamut and Neo Bahamut materias are present</source>
         <translation>Les matérias Bahamut et Néo Bahamut sont présentes</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3104"/>
         <source>22? (parameter %1)</source>
         <translation>22? (paramètre %1)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3114"/>
         <source>Remove mastered magic materias and add Master Magic</source>
         <translation>Supprimer les matérias magiques au niveau maître et ajouter magie maîtresse</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3117"/>
         <source>Remove mastered summon materias and add Master Summon</source>
         <translation>Supprimer les matérias d&apos;invocation au niveau maître et ajouter invocation maître</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3120"/>
         <source>Remove mastered meaning command materias and add Master Command</source>
         <translation>Supprimer les matérias de commande niveau maître nécessaires à la fusion et ajouter commande maître</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3123"/>
         <source>Add Bahamut Zero to the inventory</source>
         <translation>Ajouter Bahamut ZÉRO à l&apos;inventaire</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3126"/>
         <source>23? (parameter %1)</source>
         <translation>23? (paramètre %1)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3022"/>
         <source>Exit program (parameter %1)</source>
         <oldsource>Fermer le programme (paramètre %1)</oldsource>
         <translation>Fermer le programme (paramètre %1)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3026"/>
         <source>Encount Error (parameter %1)</source>
         <oldsource>Encount Error (paramètre %1)</oldsource>
         <translation>Encount Error (paramètre %1)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3030"/>
         <source>ff7 credits (parameter %1)</source>
         <oldsource>Crédits de ff7 (paramètre %1)</oldsource>
         <translation>Crédits de ff7 (paramètre %1)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3034"/>
         <source>Change name of %1</source>
         <oldsource>Changer nom de %1</oldsource>
         <translation>Changer nom de %1</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3040"/>
         <source>Change party (parameter %1)</source>
         <oldsource>Changer l&apos;équipe (paramètre %1)</oldsource>
         <translation>Changer l&apos;équipe (paramètre %1)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3044"/>
         <source>Shop No%1</source>
         <oldsource>magasin No%1</oldsource>
         <translation>magasin n°%1</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3048"/>
         <source>main (parameter %1)</source>
         <oldsource>principal (paramètre %1)</oldsource>
         <translation>principal (paramètre %1)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2788"/>
         <source>If key %1 pressed (%2)</source>
         <translation>Si appuie sur la touche %1 (%2)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2801"/>
         <source>If key %1 pressed once (%2)</source>
         <translation>Si appuie sur la touche %1 une fois (%2)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2814"/>
         <source>If key %1 released once (%2)</source>
         <translation>Si relache la touche %1 pour la première fois (%2)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2855"/>
         <source>Clock (00:00)</source>
         <translation>Horloge</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2876"/>
         <source>Sets %2 in window #%1 (show %3 digits)</source>
         <translation>Affecter %2 dans la fenêtre n°%1 et afficher %3 chiffres</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2885"/>
         <source>Set Timer (H=%1, M=%2, S=%3)</source>
         <translation>Affecter une valeur au compte à rebours (H=%1, M=%2, S=%3)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2896"/>
         <source>Add %1 gil to the party </source>
         <translation>Ajouter %1 gils à l&apos;équipe</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2935"/>
         <source>Restores full HP and MP of every available character and removing status effects</source>
         <translation>Redonne les HP/MP à tous et soigne les troubles de statut</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2947"/>
         <source>Displays the dialog %2 in the window #%1</source>
         <translation>Afficher message %2 dans la fenêtre n°%1</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2955"/>
-        <location filename="../src/core/field/Opcode.cpp" line="2964"/>
         <source>Set %3 to the variable #%2 in the window #%1</source>
         <translation>Affecter %3 à la variable n°%2 dans la fenêtre n°%1</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2985"/>
         <source>Add %2 MP to party member #%1</source>
         <translation>Augmenter de %2 MPs le membre n°%1 de l&apos;équipe</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2999"/>
         <source>Remove %2 MP to party member #%1</source>
         <translation>Diminuer de %2 MPs le membre n°%1 de l&apos;équipe</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3056"/>
         <source>Save (parameter %1)</source>
         <oldsource>Sauvegarde (paramètre %1)</oldsource>
         <translation>Sauvegarde (paramètre %1)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3060"/>
         <source>Remove all materias (parameter %1)</source>
         <oldsource>Effacer toutes les matérias (paramètre %1)</oldsource>
         <translation>Effacer toutes les matérias (paramètre %1)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3064"/>
         <source>Restore all materias (parameter %1)</source>
         <oldsource>Rétablir toutes les matérias (paramètre %1)</oldsource>
         <translation>Rétablir toutes les matérias (paramètre %1)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3068"/>
         <source>Remove %1&apos;s Materia</source>
         <oldsource>Effacer la matéria de %1</oldsource>
         <translation>Effacer la matéria de %1</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3074"/>
         <source>Clear Cloud&apos;s materias (parameter %1)</source>
         <oldsource>Effacer les matérias de Clad (paramètre %1)</oldsource>
         <translation>Effacer les matérias de Clad (paramètre %1)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3078"/>
         <source>Restore Cloud&apos;s materias (parameter %1)</source>
         <oldsource>Rétablir les matérias de Clad (paramètre %1)</oldsource>
         <translation>Rétablir les matérias de Clad (paramètre %1)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3082"/>
-        <location filename="../src/core/field/Opcode.cpp" line="3132"/>
-        <location filename="../src/core/field/Opcode.cpp" line="3136"/>
         <source>? (parameter %1)</source>
         <oldsource>? (paramètre %1)</oldsource>
         <translation>? (paramètre %1)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3086"/>
         <source>HP to 1 (parameter %1)</source>
         <oldsource>HPs à 1 (paramètre %1)</oldsource>
         <translation>HPs à 1 (paramètre %1)</translation>
@@ -3820,79 +3096,66 @@ Certains scripts peuvent y faire référence !</translation>
         <translation type="vanished">maitre ? (paramètre %1)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3146"/>
         <source>Show menu %1</source>
         <oldsource>Afficher menu %1</oldsource>
         <translation>Afficher menu %1</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3153"/>
         <source>%1 access to the main menu</source>
         <oldsource>%1 l&apos;accès aux menus</oldsource>
         <translation>%1 l&apos;accès aux menus</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3160"/>
         <source>Set battle table: %1</source>
         <oldsource>Choisir la battle table : %1</oldsource>
         <translation>Choisir la battle table : %1</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3195"/>
         <source>Create window #%1 (X=%2, Y=%3, Width=%4, Height=%5)</source>
         <oldsource>Créer la fenêtre No%1 (X=%2, Y=%3, largeur=%4, hauteur=%5)</oldsource>
         <translation>Créer la fenêtre n°%1 (X=%2, Y=%3, largeur=%4, hauteur=%5)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3206"/>
         <source>Move the window #%1 (Move : X=%2, Y=%3)</source>
         <oldsource>Déplacer la fenêtre No%1 (déplacement : X=%2, Y=%3)</oldsource>
         <translation>Déplacer la fenêtre n°%1 (déplacement : X=%2, Y=%3)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3219"/>
         <source>Normal</source>
         <oldsource>Normale</oldsource>
         <translation>Normale</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3225"/>
         <source>Transparent Background</source>
         <oldsource>Fond semi-transparent</oldsource>
         <translation>Fond semi-transparent</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3237"/>
         <source>Authorize</source>
         <oldsource>autoriser</oldsource>
         <translation>autoriser</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3290"/>
         <source>Add %2 item(s) %1 to the inventory</source>
         <oldsource>Ajouter %2 objet(s) %1 dans l&apos;inventaire</oldsource>
         <translation>Ajouter %2 objet(s) %1 dans l&apos;inventaire</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3299"/>
         <source>Remove %2 item(s) %1 from the inventory</source>
         <oldsource>Supprimer %2 objet(s) %1 dans l&apos;inventaire</oldsource>
         <translation>Supprimer %2 objet(s) %1 dans l&apos;inventaire</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3308"/>
         <source>%2 = amount of item %1 in the inventory</source>
         <oldsource>%2 = quantité d&apos;objets %1 dans l&apos;inventaire</oldsource>
         <translation>%2 = quantité d&apos;objets %1 dans l&apos;inventaire</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3317"/>
         <source>Add %1 materia to the inventory (AP=%2)</source>
         <oldsource>Ajouter la matéria %1 dans l&apos;inventaire (AP=%2)</oldsource>
         <translation>Ajouter la matéria %1 dans l&apos;inventaire (AP=%2)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3326"/>
         <source>Remove %3 materia(s) %1 from the inventory (AP=%2)</source>
         <oldsource>Supprimer %3 matéria(s) %1 dans l&apos;inventaire (AP=%2)</oldsource>
         <translation>Supprimer %3 matéria(s) %1 dans l&apos;inventaire (AP=%2)</translation>
@@ -3908,42 +3171,34 @@ Certains scripts peuvent y faire référence !</translation>
         <translation type="vanished">Secouer l&apos;écran (nbOscillations=%1, Amplitude=%2, vitesse=%3)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3364"/>
         <source>Jump to map %1 (X=%2, Y=%3, triangle ID=%4, direction=%5)</source>
         <oldsource>Aller à l&apos;écran %1 (X=%2, Y=%3, triangle id=%4, direction=%5)</oldsource>
         <translation>Aller à l&apos;écran %1 (X=%2, Y=%3, triangle id=%4, direction=%5)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3375"/>
         <source>SCRLO (?=%1)</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3382"/>
         <source>SCRLC (?=%1)</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3388"/>
         <source>Scroll to group %2 (speed=%1, type=%3)</source>
         <oldsource>Centrer sur le groupe %2 (vitesse=%1, type=%3)</oldsource>
         <translation>Centrer sur le groupe %2 (vitesse=%1, type=%3)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3399"/>
         <source>Scroll to location (X=%1, Y=%2)</source>
         <oldsource>Centrer sur zone (X=%1, Y=%2)</oldsource>
         <translation>Centrer sur zone (X=%1, Y=%2)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3416"/>
-        <location filename="../src/core/field/Opcode.cpp" line="3434"/>
         <source>Scroll to location (X=%1, Y=%2, speed=%3)</source>
         <oldsource>Centrer sur zone (X=%1, Y=%2, vitesse=%3)</oldsource>
         <translation>Centrer sur zone (X=%1, Y=%2, vitesse=%3)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3445"/>
         <source>MPDSP : %1</source>
         <translation></translation>
     </message>
@@ -3953,397 +3208,319 @@ Certains scripts peuvent y faire référence !</translation>
         <translation type="vanished">Centrer sur Zone (?=%1, ?=%2, ?=%3)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3463"/>
         <source>Fades the screen to the colour RGB(%1, %2, %3) (speed=%4, type=%5, adjust=%6)</source>
         <oldsource>Voiler l&apos;écran avec la couleur RVB(%1, %2, %3) (vitesse=%4, type=%5, adjust=%6)</oldsource>
         <translation>Voiler l&apos;écran avec la couleur RVB(%1, %2, %3) (vitesse=%4, type=%5, adjust=%6)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3484"/>
         <source>%2 the triangle #%1</source>
         <oldsource>%2 le triangle No%1</oldsource>
         <translation>%2 le triangle n°%1</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3577"/>
         <source>Get coordinates of the party member #%1 (store : X in %2, Y in %3, Z in %4 and triangle ID in %5)</source>
         <oldsource>Obtenir les coordonnées du personnage No%1 de l&apos;équipe actuelle (stocker : X dans %2, Y dans %3, Z dans %4 et l&apos;id dans %5)</oldsource>
         <translation>Obtenir les coordonnées du personnage n°%1 de l&apos;équipe actuelle (stocker : X dans %2, Y dans %3, Z dans %4 et l&apos;id dans %5)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3590"/>
-        <location filename="../src/core/field/Opcode.cpp" line="3722"/>
         <source>%1 = %1 + %2 (8 bit)</source>
         <oldsource>%1 = %1 + %2 (8 bits)</oldsource>
         <translation>%1 = %1 + %2 (8 bits)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3600"/>
-        <location filename="../src/core/field/Opcode.cpp" line="3732"/>
         <source>%1 = %1 + %2 (16 bit)</source>
         <oldsource>%1 = %1 + %2 (16 bits)</oldsource>
         <translation>%1 = %1 + %2 (16 bits)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3610"/>
-        <location filename="../src/core/field/Opcode.cpp" line="3742"/>
         <source>%1 = %1 - %2 (8 bit)</source>
         <oldsource>%1 = %1 - %2 (8 bits)</oldsource>
         <translation>%1 = %1 - %2 (8 bits)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3620"/>
-        <location filename="../src/core/field/Opcode.cpp" line="3752"/>
         <source>%1 = %1 - %2 (16 bit)</source>
         <oldsource>%1 = %1 - %2 (16 bits)</oldsource>
         <translation>%1 = %1 - %2 (16 bits)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3630"/>
-        <location filename="../src/core/field/Opcode.cpp" line="3882"/>
         <source>%1 = %1 + 1 (8 bit)</source>
         <oldsource>%1 = %1 + 1 (8 bits)</oldsource>
         <translation>%1 = %1 + 1 (8 bits)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3637"/>
-        <location filename="../src/core/field/Opcode.cpp" line="3889"/>
         <source>%1 = %1 + 1 (16 bit)</source>
         <oldsource>%1 = %1 + 1 (16 bits)</oldsource>
         <translation>%1 = %1 + 1 (16 bits)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3644"/>
-        <location filename="../src/core/field/Opcode.cpp" line="3896"/>
         <source>%1 = %1 - 1 (8 bit)</source>
         <oldsource>%1 = %1 - 1 (8 bits)</oldsource>
         <translation>%1 = %1 - 1 (8 bits)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3651"/>
-        <location filename="../src/core/field/Opcode.cpp" line="3903"/>
         <source>%1 = %1 - 1 (16 bit)</source>
         <oldsource>%1 = %1 - 1 (16 bits)</oldsource>
         <translation>%1 = %1 - 1 (16 bits)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3665"/>
         <source>Seed Random Generator : %1</source>
         <translation>Seed Random Generator : %1</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3672"/>
         <source>%1 = %2 (8 bit)</source>
         <oldsource>%1 = %2 (8 bits)</oldsource>
         <translation>%1 = %2 (8 bits)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3682"/>
         <source>%1 = %2 (16 bit)</source>
         <oldsource>%1 = %2 (16 bits)</oldsource>
         <translation>%1 = %2 (16 bits)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3762"/>
         <source>%1 = %1 * %2 (8 bit)</source>
         <oldsource>%1 = %1 * %2 (8 bits)</oldsource>
         <translation>%1 = %1 * %2 (8 bits)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3772"/>
         <source>%1 = %1 * %2 (16 bit)</source>
         <oldsource>%1 = %1 * %2 (16 bits)</oldsource>
         <translation>%1 = %1 * %2 (16 bits)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3782"/>
         <source>%1 = %1 / %2 (8 bit)</source>
         <oldsource>%1 = %1 / %2 (8 bits)</oldsource>
         <translation>%1 = %1 / %2 (8 bits)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3792"/>
         <source>%1 = %1 / %2 (16 bit)</source>
         <oldsource>%1 = %1 / %2 (16 bits)</oldsource>
         <translation>%1 = %1 / %2 (16 bits)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3802"/>
         <source>%1 = %1 mod %2 (8 bit)</source>
         <oldsource>%1 = %1 mod %2 (8 bits)</oldsource>
         <translation>%1 = %1 mod %2 (8 bits)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3812"/>
         <source>%1 = %1 mod %2 (16 bit)</source>
         <oldsource>%1 = %1 mod %2 (16 bits)</oldsource>
         <translation>%1 = %1 mod %2 (16 bits)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3822"/>
         <source>%1 = %1 &amp; %2 (8 bit)</source>
         <oldsource>%1 = %1 &amp; %2 (8 bits)</oldsource>
         <translation>%1 = %1 &amp; %2 (8 bits)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3832"/>
         <source>%1 = %1 &amp; %2 (16 bit)</source>
         <oldsource>%1 = %1 &amp; %2 (16 bits)</oldsource>
         <translation>%1 = %1 &amp; %2 (16 bits)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3842"/>
         <source>%1 = %1 | %2 (8 bit)</source>
         <oldsource>%1 = %1 | %2 (8 bits)</oldsource>
         <translation>%1 = %1 | %2 (8 bits)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3852"/>
         <source>%1 = %1 | %2 (16 bit)</source>
         <oldsource>%1 = %1 | %2 (16 bits)</oldsource>
         <translation>%1 = %1 | %2 (16 bits)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3862"/>
         <source>%1 = %1 ^ %2 (8 bit)</source>
         <oldsource>%1 = %1 ^ %2 (8 bits)</oldsource>
         <translation>%1 = %1 ^ %2 (8 bits)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3872"/>
         <source>%1 = %1 ^ %2 (16 bit)</source>
         <oldsource>%1 = %1 ^ %2 (16 bits)</oldsource>
         <translation>%1 = %1 ^ %2 (16 bits)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3917"/>
         <source>%1 = %2 &amp; 0xFF (low byte)</source>
         <translation>%1 = %2 &amp; 0xFF (low byte)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3927"/>
         <source>%1 = (%2 &gt;&gt; 8) &amp; 0xFF (high byte)</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3937"/>
         <source>%1 = (%2 &amp; 0xFF) | ((%3 &amp; 0xFF) &lt;&lt; 8)</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3970"/>
         <source>Search the value %5 in the memory (bank=%1, start=%2+%3, end=%2+%4) and put the position in %6</source>
         <oldsource>Rechercher la valeur %5 dans la mémoire (bank=%1, début=%2+%3, fin=%2+%4) et mettre la position dans %6</oldsource>
         <translation>Rechercher la valeur %5 dans la mémoire (bank=%1, début=%2+%3, fin=%2+%4) et mettre la position dans %6</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3984"/>
         <source>Field model is playable and it is %1</source>
         <oldsource>L&apos;objet 3D est jouable et c&apos;est %1</oldsource>
         <translation>L&apos;objet 3D est jouable et c&apos;est %1</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3991"/>
         <source>This group is a field model (ID=%1)</source>
         <oldsource>Ce groupe est un objet 3D (id=%1)</oldsource>
         <translation>Ce groupe est un objet 3D (id=%1)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3998"/>
         <source>Play loop animation #%1 of the field model (speed=%2)</source>
         <oldsource>Play animation #%1 of the field model (speed=%2)</oldsource>
         <translation>Joue l&apos;animation %1 de l&apos;objet 3D en boucle (vitesse=%2)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4006"/>
-        <location filename="../src/core/field/Opcode.cpp" line="4108"/>
         <source>Play animation #%1 of the field model and reset to previous state (speed=%2)</source>
         <oldsource>Joue l&apos;animation %1 de l&apos;objet 3D et retourne à l&apos;état précédent (vitesse=%2)</oldsource>
         <translation>Joue l&apos;animation %1 de l&apos;objet 3D et retourne à l&apos;état précédent (vitesse=%2)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4021"/>
         <source>Place field Model (X=%1, Y=%2, Z=%3, triangle ID=%4)</source>
         <oldsource>Place l&apos;objet 3D (X=%1, Y=%2, Z=%3, triangle id=%4)</oldsource>
         <translation>Place l&apos;objet 3D (X=%1, Y=%2, Z=%3, triangle id=%4)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4033"/>
         <source>Place field Model (X=%1, Y=%2, triangle ID=%4)</source>
         <oldsource>Place l&apos;objet 3D (X=%1, Y=%2, triangle id=%4)</oldsource>
         <translation>Place l&apos;objet 3D (X=%1, Y=%2, triangle id=%4)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4044"/>
         <source>Place field Model (X=%1, Y=%2, Z=%3)</source>
         <oldsource>Place l&apos;objet 3D (X=%1, Y=%2, Z=%3)</oldsource>
         <translation>Place l&apos;objet 3D (X=%1, Y=%2, Z=%3)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4055"/>
         <source>Move field Model (X=%1, Y=%2)</source>
         <oldsource>Déplace l&apos;objet 3D (X=%1, Y=%2)</oldsource>
         <translation>Déplace l&apos;objet 3D (X=%1, Y=%2)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4065"/>
-        <location filename="../src/core/field/Opcode.cpp" line="4098"/>
         <source>Place field Model without animation (X=%1, Y=%2)</source>
         <oldsource>Déplace l&apos;objet 3D sans animation (X=%1, Y=%2)</oldsource>
         <translation>Déplace l&apos;objet 3D sans animation (X=%1, Y=%2)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4074"/>
         <source>Move field Model to the group %1</source>
         <oldsource>Déplace l&apos;objet 3D vers le groupe %1</oldsource>
         <translation>Déplace l&apos;objet 3D vers le groupe %1</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4080"/>
         <source>Rotation of the field model to group %1 (Speed=%3, Rotation=%2)</source>
         <oldsource>Rotation de l&apos;objet 3D vers le groupe %1 (vitesse=%3, sens de rotation=%2)</oldsource>
         <translation>Rotation de l&apos;objet 3D vers le groupe %1 (vitesse=%3, sens de rotation=%2)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4116"/>
         <source>Play animation #%1 of the field model (speed=%2, type=1)</source>
         <translation>Joue l&apos;animation %1 de l&apos;objet 3D (vitesse=%2, type=1)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4124"/>
-        <location filename="../src/core/field/Opcode.cpp" line="4220"/>
         <source>Play partially the animation #%1 of the field model and reset to initial state (first frame=%2, last frame=%3, speed=%4)</source>
         <oldsource>Joue partiellement l&apos;animation %1 de l&apos;objet 3D et retourne à l&apos;état précédent (première img=%2, dernière img=%3, vitesse=%4)</oldsource>
         <translation>Joue partiellement l&apos;animation %1 de l&apos;objet 3D et retourne à l&apos;état précédent (première img=%2, dernière img=%3, vitesse=%4)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4134"/>
-        <location filename="../src/core/field/Opcode.cpp" line="4230"/>
         <source>Play partially the animation #%1 of the field model (first frame=%2, last frame=%3, speed=%4)</source>
         <oldsource>Joue partiellement l&apos;animation %1 de l&apos;objet 3D (première img=%2, dernière img=%3, vitesse=%4)</oldsource>
         <translation>Joue partiellement l&apos;animation %1 de l&apos;objet 3D (première img=%2, dernière img=%3, vitesse=%4)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4151"/>
         <source>Set field model direction: %1</source>
         <oldsource>Mettre l&apos;objet 3D dans la direction : %1</oldsource>
         <translation>Mettre l&apos;objet 3D dans la direction : %1</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4158"/>
         <source>Rotation (direction=%1, nbRevolution=%2, speed=%3, ?=%4)</source>
         <oldsource>Rotation (direction=%1, nbTours=%2, vitesse=%3, ?=%4)</oldsource>
         <translation>Rotation (direction=%1, nbTours=%2, vitesse=%3, ?=%4)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4168"/>
         <source>Inversed rotation (direction=%1, nbRevolution=%2, speed=%3, ?=%4)</source>
         <oldsource>Rotation inversée (direction=%1, nbTours=%2, vitesse=%3, ?=%4)</oldsource>
         <translation>Rotation inversée (direction=%1, nbTours=%2, vitesse=%3, ?=%4)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4177"/>
         <source>Direct the field model towards the group %1</source>
         <oldsource>Mettre l&apos;objet 3D en direction du groupe %1</oldsource>
         <translation>Mettre l&apos;objet 3D en direction du groupe %1</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4183"/>
         <source>Store direction of the group %1 in %2</source>
         <oldsource>Stocker dans %2 la direction du groupe %1</oldsource>
         <translation>Stocker dans %2 la direction du groupe %1</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4192"/>
         <source>Store position of the group %1 in %2 (X) and %3 (Y)</source>
         <oldsource>Stocker dans %2 et %3 la position X et Y du groupe %1</oldsource>
         <translation>Stocker dans %2 et %3 la position X et Y du groupe %1</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4202"/>
         <source>Store triangle ID of the group %1 in %2</source>
         <oldsource>Stocker dans %2 le triangle id du groupe %1</oldsource>
         <translation>Stocker dans %2 le triangle id du groupe %1</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4212"/>
         <source>Play animation #%1 of the field model (speed=%2, type=2)</source>
         <translation>Joue l&apos;animation %1 de l&apos;objet 3D (vitesse=%2, type=2)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4240"/>
         <source>Set the field model animations speed: %1</source>
         <oldsource>Configurer la vitesse des animations de l&apos;objet 3D : %1</oldsource>
         <translation>Configurer la vitesse des animations de l&apos;objet 3D : %1</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4252"/>
         <source>Control the group %1</source>
         <oldsource>Prendre le contrôle du groupe %1</oldsource>
         <translation>Prendre le contrôle du groupe %1</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4259"/>
         <source>Field model jump (X=%1, Y=%2, triangle ID=%3, Steps=%4)</source>
         <oldsource>Faire sauter un personnage (X=%1, Y=%2, triangle id=%3, hauteur=%4)</oldsource>
         <translation>Faire sauter un personnage (X=%1, Y=%2, triangle id=%3, hauteur=%4)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4270"/>
         <source>Store position of the group %1 in %2 (X), %3 (Y), %4 (Z) and %5 (triangle ID)</source>
         <oldsource>Stocker la position du groupe %1 dans des variables (%2=X, %3=Y, %4=Z, %5=triangle id)</oldsource>
         <translation>Stocker la position du groupe %1 dans des variables (%2=X, %3=Y, %4=Z, %5=triangle id)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4283"/>
         <source>Climb a ladder with the animation #%6 (X=%1, Y=%2, Z=%3, triangle ID=%4, direction1=%5, direction2=%7, speed=%8)</source>
         <oldsource>Monter une échelle avec l&apos;animation %6 (X=%1, Y=%2, Z=%3, triangle id=%4, sens=%5, direction=%7, vitesse=%8)</oldsource>
         <translation>Monter une échelle avec l&apos;animation %6 (X=%1, Y=%2, Z=%3, triangle id=%4, sens=%5, direction=%7, vitesse=%8)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4299"/>
         <source>Offset Object (movement=%1, X=%2, Y=%3, Z=%4, speed=%5)</source>
         <oldsource>Offset Object (mouvement=%1, X=%2, Y=%3, Z=%4, vitesse=%5)</oldsource>
         <translation>Offset Object (mouvement=%1, X=%2, Y=%3, Z=%4, vitesse=%5)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4326"/>
-        <location filename="../src/core/field/Opcode.cpp" line="4484"/>
         <source>Set range of the contact circle for the field model: %1</source>
         <oldsource>Modifier la distance nécessaire pour toucher l&apos;objet 3D : %1</oldsource>
         <translation>Modifier la distance nécessaire pour toucher l&apos;objet 3D : %1</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4354"/>
         <source>New party: %1 | %2 | %3</source>
         <oldsource>Nouvelle équipe : %1 | %2 | %3</oldsource>
         <translation>Nouvelle équipe : %1 | %2 | %3</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4377"/>
         <source>If %1 exists (%2)</source>
         <oldsource>Si %1 existe (%2)</oldsource>
         <translation>Si %1 existe (%2)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4389"/>
         <source>%2 %1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4399"/>
         <source>Locks %1 in PHS menu</source>
         <oldsource>Bloque %1 dans le menu PHS</oldsource>
         <translation>Bloque %1 dans le menu PHS</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4406"/>
         <source>Unlock %1 in PHS menu</source>
         <oldsource>Débloque %1 dans le menu PHS</oldsource>
         <translation>Débloque %1 dans le menu PHS</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4413"/>
         <source>Create line (X1=%1, Y1=%2, Z1=%3, X2=%4, Y2=%5, Z2=%6)</source>
         <translation>Créer ligne (X1=%1, Y1=%2, Z1=%3, X2=%4, Y2=%5, Z2=%6)</translation>
     </message>
@@ -4353,19 +3530,14 @@ Certains scripts peuvent y faire référence !</translation>
         <translation type="vanished">Définit la zone (X1=%1, Y1=%2, Z1=%3, X2=%4, Y2=%5, Z2=%6)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4425"/>
         <source>%1 line</source>
         <translation>%1 la ligne</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2594"/>
-        <location filename="../src/core/field/Opcode.cpp" line="4426"/>
         <source>Enable</source>
         <translation>Activer</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2594"/>
-        <location filename="../src/core/field/Opcode.cpp" line="4426"/>
         <source>Disable</source>
         <translation>Désactiver</translation>
     </message>
@@ -4384,99 +3556,82 @@ Certains scripts peuvent y faire référence !</translation>
         <translation type="vanished">Redimensionner la zone (X1=%1, Y1=%2, Z1=%3, X2=%4, Y2=%5, Z2=%6)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4453"/>
         <source>%4 = ((Sinus(%1) * %2) + %3) &gt;&gt; 12</source>
         <translation>%4 = ((Sinus(%1) * %2) + %3) &gt;&gt; 12</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4465"/>
         <source>%4 = ((Cosinus(%1) * %2) + %3) &gt;&gt; 12</source>
         <translation>%4 = ((Cosinus(%1) * %2) + %3) &gt;&gt; 12</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4499"/>
         <source>PMJMP2</source>
         <translation>PMJMP2</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4519"/>
         <source>%1 rotation</source>
         <translation>%1 rotation</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4526"/>
         <source>Play animation #%1 for &apos;%3&apos; (speed=%2)</source>
         <oldsource>Jouer animation No%1 pour &apos;%3&apos; (vitesse=%2)</oldsource>
         <translation>Jouer animation n°%1 pour &apos;%3&apos; (vitesse=%2)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4553"/>
         <source>Multiply RGB(%6, %5, %4) on the colors in a palette (sourcePal=%1, targetPal=%2, first color=%3, color count=%7+1)</source>
         <oldsource>Multiplier RVB(%6, %5, %4) sur les couleurs d&apos;une palette (sourcePal=%1, ciblePal=%2, première couleur=%3, nombre de couleurs=%7+1)</oldsource>
         <translation>Multiplier RVB(%6, %5, %4) sur les couleurs d&apos;une palette (sourcePal=%1, ciblePal=%2, première couleur=%3, nombre de couleurs=%7+1)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4578"/>
         <source>Hide the state #%2 of the background parameter #%1</source>
         <oldsource>Cacher l&apos;état n°%2 du paramètre No%1</oldsource>
         <translation>Cacher l&apos;état n°%2 du paramètre n°%1</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4588"/>
         <source>Show next state of the background parameter #%1</source>
         <oldsource>Afficher l&apos;état suivant du paramètre No%1</oldsource>
         <translation>Afficher l&apos;état suivant du paramètre n°%1</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4602"/>
         <source>Hide background parameter #%1</source>
         <oldsource>Cacher paramètre No%1</oldsource>
         <translation>Cacher paramètre n°%1</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4609"/>
         <source>Load the palette #%1 in the position %2 (color count=%3)</source>
         <oldsource>Charger la palette No%1 à la position %2 (nombre de couleurs=%3)</oldsource>
         <translation>Charger la palette n°%1 à la position %2 (nombre de couleurs=%3)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4620"/>
         <source>Load the position %1 in the palette #%2 (color count=%3)</source>
         <oldsource>Charger la position %1 dans la palette n°%2 (nombre de couleurs=%3)</oldsource>
         <translation>Charger la position %1 dans la palette n°%2 (nombre de couleurs=%3)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4631"/>
         <source>Copy palette (sourcePal=%1, targetPal=%2, color count=%3)</source>
         <oldsource>Copier palette (sourcePal=%1, ciblePal=%2, nombre de couleurs=%3)</oldsource>
         <translation>Copier palette (sourcePal=%1, ciblePal=%2, nombre de couleurs=%3)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4642"/>
         <source>Copy partially palette (sourcePal=%1, targetPal=%2, first color=%3, color count=%4)</source>
         <oldsource>Copier un morceau de palette (sourcePal=%1, ciblePal=%2, première couleur=%3, nombre de couleurs=%4)</oldsource>
         <translation>Copier un morceau de palette (sourcePal=%1, ciblePal=%2, première couleur=%3, nombre de couleurs=%4)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4654"/>
         <source>Add RGB(%5, %4, %3) on the colors in a palette (sourcePal=%1, targetPal=%2, color count=%6)</source>
         <oldsource>Additionner RVB(%5, %4, %3) sur les couleurs d&apos;une palette (sourcePal=%1, ciblePal=%2, nombre de couleurs=%6)</oldsource>
         <translation>Additionner RVB(%5, %4, %3) sur les couleurs d&apos;une palette (sourcePal=%1, ciblePal=%2, nombre de couleurs=%6)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4668"/>
         <source>Multiply RGB(%5, %4, %3) on the colors in a palette (sourcePal=%1, targetPal=%2, color count=%6)</source>
         <oldsource>Multiplier RVB(%5, %4, %3) sur les couleurs d&apos;une palette (sourcePal=%1, ciblePal=%2, nombre de couleurs=%6)</oldsource>
         <translation>Multiplier RVB(%5, %4, %3) sur les couleurs d&apos;une palette (sourcePal=%1, ciblePal=%2, nombre de couleurs=%6)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4682"/>
         <source>Load the palette #%1 in the position %2 (first color=%3, color count=%4)</source>
         <oldsource>Charger la palette No%1 à la position %2 (première couleur=%3, nombre de couleurs=%4)</oldsource>
         <translation>Charger la palette n°%1 à la position %2 (première couleur=%3, nombre de couleurs=%4)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4692"/>
         <source>Load the position %1 in the palette #%2 (first color=%3, color count=%4)</source>
         <oldsource>Charger la position %1 dans la palette n°%2 (première couleur=%3, nombre de couleurs=%4)</oldsource>
         <translation>Charger la position %1 dans la palette n°%2 (première couleur=%3, nombre de couleurs=%4)</translation>
@@ -4490,7 +3645,6 @@ Certains scripts peuvent y faire référence !</translation>
         <translation type="vanished">ADPAL2 %1</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4757"/>
         <source>Play sound #%1 (position=%2/127)</source>
         <oldsource>Jouer son No%1 (position=%2/127)</oldsource>
         <translation>Jouer son n°%1 (position=%2/127)</translation>
@@ -4501,31 +3655,26 @@ Certains scripts peuvent y faire référence !</translation>
         <translation type="vanished">MUSVT (musique n°%1)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4788"/>
         <source>MUSVM (music #%1)</source>
         <oldsource>MUSVM (musique No%1)</oldsource>
         <translation>MUSVM (musique n°%1)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4795"/>
         <source>%1 music</source>
         <oldsource>%1 musique</oldsource>
         <translation>%1 musique</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4809"/>
         <source>CHMPH: Save (unknown) in %1 and (unknown) in %2</source>
         <oldsource>CHMPH : Sauvegarder (inconnu) dans %1 et (inconnu) dans %2</oldsource>
         <translation>CHMPH : Sauvegarder (inconnu) dans %1 et (inconnu) dans %2</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4833"/>
         <source>Save Movie frame in %1</source>
         <oldsource>Stocker Movie frame dans %1</oldsource>
         <translation>Stocker Movie frame dans %1</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4840"/>
         <source>Camera Movie: %1</source>
         <oldsource>Camera Movie : %1</oldsource>
         <translation>Camera Movie : %1</translation>
@@ -4540,13 +3689,11 @@ Certains scripts peuvent y faire référence !</translation>
         <translation type="vanished">CMUSC (musique n°%1, inconnu1=%2, inconnu2=%3, inconnu2=%4, inconnu4=%5, inconnu5=%6, inconnu6=%7)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4866"/>
         <source>If music is currently playing set %1 to 1</source>
         <oldsource>Si la musique est jouée mettre %1 à 1</oldsource>
         <translation>Si la musique est jouée mettre %1 à 1</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4874"/>
         <source>Game Over</source>
         <translation>Fin de partie</translation>
     </message>
@@ -4554,163 +3701,131 @@ Certains scripts peuvent y faire référence !</translation>
 <context>
     <name>OpcodeList</name>
     <message>
-        <location filename="../src/widgets/OpcodeList.cpp" line="35"/>
         <source>Action</source>
         <translation>Action</translation>
     </message>
     <message>
-        <location filename="../src/widgets/OpcodeList.cpp" line="59"/>
         <source>Copy</source>
         <oldsource>Copier</oldsource>
         <translation>Copier</translation>
     </message>
     <message>
-        <location filename="../src/widgets/OpcodeList.cpp" line="79"/>
         <source>Expand the tree</source>
         <oldsource>Étendre l&apos;arbre</oldsource>
         <translation>Étendre l&apos;arbre</translation>
     </message>
     <message>
-        <location filename="../src/widgets/OpcodeList.cpp" line="44"/>
         <source>Edit</source>
         <translation>Modifier</translation>
     </message>
     <message>
-        <location filename="../src/widgets/OpcodeList.cpp" line="48"/>
         <source>Add</source>
         <translation>Ajouter</translation>
     </message>
     <message>
-        <location filename="../src/widgets/OpcodeList.cpp" line="55"/>
         <source>Cut</source>
         <translation>Couper</translation>
     </message>
     <message>
-        <location filename="../src/widgets/OpcodeList.cpp" line="63"/>
         <source>Copy text</source>
         <translation>Copier texte</translation>
     </message>
     <message>
-        <location filename="../src/widgets/OpcodeList.cpp" line="67"/>
         <source>Paste</source>
         <translation>Coller</translation>
     </message>
     <message>
-        <location filename="../src/widgets/OpcodeList.cpp" line="71"/>
         <source>Up</source>
         <translation>Déplacer vers le haut</translation>
     </message>
     <message>
-        <location filename="../src/widgets/OpcodeList.cpp" line="75"/>
         <source>Down</source>
         <translation>Déplacer vers le bas</translation>
     </message>
     <message>
-        <location filename="../src/widgets/OpcodeList.cpp" line="80"/>
         <source>Undo</source>
         <translation>Annuler</translation>
     </message>
     <message>
-        <location filename="../src/widgets/OpcodeList.cpp" line="84"/>
         <source>Redo</source>
         <oldsource>Refaire</oldsource>
         <translation>Refaire</translation>
     </message>
     <message>
-        <location filename="../src/widgets/OpcodeList.cpp" line="88"/>
         <source>Edit text</source>
         <oldsource>Modifier texte</oldsource>
         <translation>Modifier texte</translation>
     </message>
     <message>
-        <location filename="../src/widgets/OpcodeList.cpp" line="92"/>
-        <location filename="../src/widgets/OpcodeList.cpp" line="248"/>
         <source>Disable tree</source>
         <translation>Désactiver arbre</translation>
     </message>
     <message>
-        <location filename="../src/widgets/OpcodeList.cpp" line="93"/>
         <source>Search opcode...</source>
         <translation>Chercher l&apos;opcode...</translation>
     </message>
     <message>
-        <location filename="../src/widgets/OpcodeList.cpp" line="250"/>
         <source>Enable tree</source>
         <translation>Activer abre</translation>
     </message>
     <message>
-        <location filename="../src/widgets/OpcodeList.cpp" line="282"/>
         <source>Goto label</source>
         <oldsource>Aller au label</oldsource>
         <translation>Aller au label</translation>
     </message>
     <message>
-        <location filename="../src/widgets/OpcodeList.cpp" line="283"/>
         <source>Alt + Click to go to the label</source>
         <oldsource>Alt + clic pour aller au label</oldsource>
         <translation>Alt + clic pour aller au label</translation>
     </message>
     <message>
-        <location filename="../src/widgets/OpcodeList.cpp" line="145"/>
         <source>&amp;Script editor</source>
         <oldsource>Édition du &amp;script</oldsource>
         <translation>Édition du &amp;script</translation>
     </message>
     <message>
-        <location filename="../src/widgets/OpcodeList.cpp" line="151"/>
         <source>Add line</source>
         <translation>Ajouter a line</translation>
     </message>
     <message>
-        <location filename="../src/widgets/OpcodeList.cpp" line="153"/>
         <source>Remove line</source>
         <translation>Supprimer a line</translation>
     </message>
     <message>
-        <location filename="../src/widgets/OpcodeList.cpp" line="156"/>
         <source>Move up</source>
         <translation>Monter une commande</translation>
     </message>
     <message>
-        <location filename="../src/widgets/OpcodeList.cpp" line="158"/>
         <source>Move down</source>
         <translation>Descendre une commande</translation>
     </message>
     <message>
-        <location filename="../src/widgets/OpcodeList.cpp" line="285"/>
         <source>Goto script</source>
         <translation>Aller au script</translation>
     </message>
     <message>
-        <location filename="../src/widgets/OpcodeList.cpp" line="286"/>
         <source>Alt + Click to go to the script</source>
         <translation>Alt + clic pour aller au script</translation>
     </message>
     <message>
-        <location filename="../src/widgets/OpcodeList.cpp" line="491"/>
         <source>If this script is run,
  assume that the last non-empty script that runs</source>
         <translation>Si ce script est exécuté,
  considérez que c&apos;est le dernier script non vide qui est exécuté</translation>
     </message>
     <message>
-        <location filename="../src/widgets/OpcodeList.cpp" line="51"/>
-        <location filename="../src/widgets/OpcodeList.cpp" line="796"/>
         <source>Delete</source>
         <translation>Supprimer</translation>
     </message>
     <message>
-        <location filename="../src/widgets/OpcodeList.cpp" line="797"/>
         <source>Are you sure you want to delete %1?</source>
         <translation>Voulez-vous vraiment supprimer %1 ?</translation>
     </message>
     <message>
-        <location filename="../src/widgets/OpcodeList.cpp" line="799"/>
         <source>the selected command</source>
         <translation>the selected command</translation>
     </message>
     <message>
-        <location filename="../src/widgets/OpcodeList.cpp" line="800"/>
         <source>the selected commands</source>
         <translation>les commandes sélectionnées</translation>
     </message>
@@ -4723,27 +3838,22 @@ Certains scripts peuvent y faire référence !</translation>
         <translation type="vanished">Opérations diverses</translation>
     </message>
     <message>
-        <location filename="../src/widgets/OperationsManager.cpp" line="23"/>
         <source>Batch processing</source>
         <translation>Traitement par lot</translation>
     </message>
     <message>
-        <location filename="../src/widgets/OperationsManager.cpp" line="25"/>
         <source>Clean all unused texts</source>
         <translation>Effacer tous les textes inutilisés</translation>
     </message>
     <message>
-        <location filename="../src/widgets/OperationsManager.cpp" line="26"/>
         <source>Autosize all text windows in the game</source>
         <translation>Redimensionner toutes les fenêtres du jeu</translation>
     </message>
     <message>
-        <location filename="../src/widgets/OperationsManager.cpp" line="27"/>
         <source>Disable all texts in the game</source>
         <translation>Désactiver tous les textes du jeu</translation>
     </message>
     <message>
-        <location filename="../src/widgets/OperationsManager.cpp" line="28"/>
         <source>Disable all battles in the game</source>
         <translation>Désactiver tous combats du jeu</translation>
     </message>
@@ -4752,23 +3862,19 @@ Certains scripts peuvent y faire référence !</translation>
         <translation type="vanished">Supprimer les données inutiles des listes des modèles 3D</translation>
     </message>
     <message>
-        <location filename="../src/widgets/OperationsManager.cpp" line="30"/>
         <source>Clean unused data in field model loaders</source>
         <oldsource>Remove all unused data for field backgrounds</oldsource>
         <translation>Supprimer les données inutilisées pour les listes de modèles 3D</translation>
     </message>
     <message>
-        <location filename="../src/widgets/OperationsManager.cpp" line="31"/>
         <source>Clean unused data for field backgrounds</source>
         <translation>Supprimer les données inutilisées pour les décors</translation>
     </message>
     <message>
-        <location filename="../src/widgets/OperationsManager.cpp" line="32"/>
         <source>Repair broken backgrounds (lastmap, fr_e)</source>
         <translation>Réparer les décors cassés ((lastmap, fr_e)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/OperationsManager.cpp" line="36"/>
         <source>Apply</source>
         <oldsource>Appliquer</oldsource>
         <translation>Appliquer</translation>
@@ -4777,8 +3883,6 @@ Certains scripts peuvent y faire référence !</translation>
 <context>
     <name>OrientationWidget</name>
     <message>
-        <location filename="../src/widgets/OrientationWidget.cpp" line="95"/>
-        <location filename="../src/widgets/OrientationWidget.cpp" line="97"/>
         <source>Right</source>
         <translation>Droite</translation>
     </message>
@@ -4786,52 +3890,42 @@ Certains scripts peuvent y faire référence !</translation>
 <context>
     <name>PsfDialog</name>
     <message>
-        <location filename="../src/widgets/PsfDialog.cpp" line="37"/>
         <source>psflib</source>
         <translation>psflib</translation>
     </message>
     <message>
-        <location filename="../src/widgets/PsfDialog.cpp" line="39"/>
         <source>Title</source>
         <translation>Titre</translation>
     </message>
     <message>
-        <location filename="../src/widgets/PsfDialog.cpp" line="41"/>
         <source>Artist</source>
         <translation>Artiste</translation>
     </message>
     <message>
-        <location filename="../src/widgets/PsfDialog.cpp" line="43"/>
         <source>Game</source>
         <translation>Jeu</translation>
     </message>
     <message>
-        <location filename="../src/widgets/PsfDialog.cpp" line="45"/>
         <source>Year</source>
         <translation>Année</translation>
     </message>
     <message>
-        <location filename="../src/widgets/PsfDialog.cpp" line="47"/>
         <source>Genre</source>
         <translation>Genre</translation>
     </message>
     <message>
-        <location filename="../src/widgets/PsfDialog.cpp" line="49"/>
         <source>Comment</source>
         <translation>Commentaire</translation>
     </message>
     <message>
-        <location filename="../src/widgets/PsfDialog.cpp" line="51"/>
         <source>Copyright</source>
         <translation>Copyright</translation>
     </message>
     <message>
-        <location filename="../src/widgets/PsfDialog.cpp" line="53"/>
         <source>Author</source>
         <translation>Auteur</translation>
     </message>
     <message>
-        <location filename="../src/widgets/PsfDialog.cpp" line="78"/>
         <source>(auto)</source>
         <translation>(auto)</translation>
     </message>
@@ -4839,18 +3933,15 @@ Certains scripts peuvent y faire référence !</translation>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/Data.cpp" line="506"/>
         <source>Cloud</source>
         <oldsource>Clad</oldsource>
         <translation>Clad</translation>
     </message>
     <message>
-        <location filename="../src/Data.cpp" line="506"/>
         <source>Barret</source>
         <translation>Barret</translation>
     </message>
     <message>
-        <location filename="../src/Data.cpp" line="506"/>
         <source>Tifa</source>
         <translation>Tifa</translation>
     </message>
@@ -4859,129 +3950,104 @@ Certains scripts peuvent y faire référence !</translation>
         <translation type="vanished">Aeris</translation>
     </message>
     <message>
-        <location filename="../src/Data.cpp" line="507"/>
         <source>Red XIII</source>
         <translation>Red XIII</translation>
     </message>
     <message>
-        <location filename="../src/Data.cpp" line="507"/>
         <source>Yuffie</source>
         <translation>Youfie</translation>
     </message>
     <message>
-        <location filename="../src/Data.cpp" line="507"/>
         <source>Aerith</source>
         <translation>Aerith</translation>
     </message>
     <message>
-        <location filename="../src/Data.cpp" line="508"/>
         <source>Cait Sith</source>
         <translation>Cait Sith</translation>
     </message>
     <message>
-        <location filename="../src/Data.cpp" line="508"/>
         <source>Vincent</source>
         <translation>Vincent</translation>
     </message>
     <message>
-        <location filename="../src/Data.cpp" line="508"/>
         <source>Cid</source>
         <translation>Cid</translation>
     </message>
     <message>
-        <location filename="../src/Data.cpp" line="509"/>
         <source>Yound Cloud</source>
         <oldsource>Jeune Clad</oldsource>
         <translation>Jeune Clad</translation>
     </message>
     <message>
-        <location filename="../src/Data.cpp" line="509"/>
         <source>Sephiroth</source>
         <translation>Sephiroth</translation>
     </message>
     <message>
-        <location filename="../src/Data.cpp" line="509"/>
         <source>Chocobo</source>
         <translation>Chocobo</translation>
     </message>
     <message>
-        <location filename="../src/Data.cpp" line="514"/>
         <source>[CAMERA|L2]</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/Data.cpp" line="514"/>
         <source>[TARGET|R2]</source>
         <translation>[CIBLE|R2]</translation>
     </message>
     <message>
-        <location filename="../src/Data.cpp" line="515"/>
         <source>[PAGE UP|L1]</source>
         <oldsource>[PAGE HAUT|L1]</oldsource>
         <translation>[PAGE HAUT|L1]</translation>
     </message>
     <message>
-        <location filename="../src/Data.cpp" line="515"/>
         <source>[PAGE DOWN|R1]</source>
         <translation>[PAGE BAS|R1]</translation>
     </message>
     <message>
-        <location filename="../src/Data.cpp" line="516"/>
         <source>[MENU|TRIANGLE]</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/Data.cpp" line="516"/>
         <source>[OK|CIRCLE]</source>
         <translation>[OK|ROND]</translation>
     </message>
     <message>
-        <location filename="../src/Data.cpp" line="517"/>
         <source>[CANCEL|CROSS]</source>
         <translation>[ANNULER|CROIX]</translation>
     </message>
     <message>
-        <location filename="../src/Data.cpp" line="517"/>
         <source>[SWITCH|SQUARE]</source>
         <translation>[CHANGER|CARRE]</translation>
     </message>
     <message>
-        <location filename="../src/Data.cpp" line="518"/>
         <source>[ASSIST|SELECT]</source>
         <translation>[ASSISTER|SELECT]</translation>
     </message>
     <message>
-        <location filename="../src/Data.cpp" line="519"/>
         <source>[START]</source>
         <translation>[DEMARRER|START]</translation>
     </message>
     <message>
-        <location filename="../src/Data.cpp" line="520"/>
         <source>[UP]</source>
         <translation>[HAUT]</translation>
     </message>
     <message>
-        <location filename="../src/Data.cpp" line="520"/>
         <source>[RIGHT]</source>
         <translation>[DROITE]</translation>
     </message>
     <message>
-        <location filename="../src/Data.cpp" line="521"/>
         <source>[DOWN]</source>
         <translation>[BAS]</translation>
     </message>
     <message>
-        <location filename="../src/Data.cpp" line="521"/>
         <source>[LEFT]</source>
         <translation>[GAUCHE]</translation>
     </message>
     <message>
-        <location filename="../src/core/field/GrpScript.cpp" line="117"/>
         <source>Untitled</source>
         <translation>Sans nom</translation>
     </message>
     <message>
-        <location filename="../src/core/field/GrpScript.cpp" line="151"/>
         <source>Field model</source>
         <translation>Objet 3D</translation>
     </message>
@@ -4990,96 +4056,79 @@ Certains scripts peuvent y faire référence !</translation>
         <translation type="vanished">Zone</translation>
     </message>
     <message>
-        <location filename="../src/core/field/GrpScript.cpp" line="155"/>
         <source>Line</source>
         <translation>Ligne</translation>
     </message>
     <message>
-        <location filename="../src/core/field/GrpScript.cpp" line="157"/>
         <source>Animation</source>
         <translation>Animation</translation>
     </message>
     <message>
-        <location filename="../src/core/field/GrpScript.cpp" line="159"/>
         <source>Main</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/core/field/GrpScript.cpp" line="187"/>
         <source>S0 - Init</source>
         <translatorcomment>S0 - Init</translatorcomment>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/core/field/GrpScript.cpp" line="189"/>
         <source>S0 - Main</source>
         <translation>S0 - Main</translation>
     </message>
     <message>
-        <location filename="../src/core/field/GrpScript.cpp" line="192"/>
         <source>S1 - Talk</source>
         <oldsource>S1 - Parler</oldsource>
         <translation>S1 - Parler</translation>
     </message>
     <message>
-        <location filename="../src/core/field/GrpScript.cpp" line="195"/>
         <source>S1 - [OK]</source>
         <translation>S1 - [OK]</translation>
     </message>
     <message>
-        <location filename="../src/core/field/GrpScript.cpp" line="200"/>
         <source>S2 - Contact</source>
         <oldsource>S2 - Toucher</oldsource>
         <translation>S2 - Toucher</translation>
     </message>
     <message>
-        <location filename="../src/core/field/GrpScript.cpp" line="203"/>
         <source>S2 - Move</source>
         <oldsource>S2 - Bouger</oldsource>
         <translation>S2 - Bouger</translation>
     </message>
     <message>
-        <location filename="../src/core/field/GrpScript.cpp" line="208"/>
         <source>S3 - Move</source>
         <oldsource>S3 - Bouger</oldsource>
         <translation>S3 - Bouger</translation>
     </message>
     <message>
-        <location filename="../src/core/field/GrpScript.cpp" line="213"/>
         <source>S4 - Go</source>
         <oldsource>S4 - Aller</oldsource>
         <translation>S4 - Aller</translation>
     </message>
     <message>
-        <location filename="../src/core/field/GrpScript.cpp" line="218"/>
         <source>S5 - Go 1x</source>
         <oldsource>S5 - Aller 1x</oldsource>
         <translation>S5 - Aller 1x</translation>
     </message>
     <message>
-        <location filename="../src/core/field/GrpScript.cpp" line="223"/>
         <source>S6 - Go away</source>
         <oldsource>S6 - Partir</oldsource>
         <translation>S6 - Partir</translation>
     </message>
     <message>
-        <location filename="../src/core/field/GrpScript.cpp" line="228"/>
         <source>Script %1</source>
         <translation>Script %1</translation>
     </message>
     <message>
-        <location filename="../src/core/field/GrpScript.cpp" line="492"/>
         <source>Group &apos;%1&apos;:</source>
         <oldsource>Groupe &apos;%1&apos; :</oldsource>
         <translation>Groupe &apos;%1&apos; :</translation>
     </message>
     <message>
-        <location filename="../src/core/field/GrpScript.cpp" line="500"/>
         <source>Script &apos;%1&apos; :</source>
         <translation>Script &apos;%1&apos; :</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Script.cpp" line="167"/>
         <source>Label %1 is declared several times.</source>
         <oldsource>Le label %1 est déclaré plusieurs fois.</oldsource>
         <translation>Le label %1 est déclaré plusieurs fois.</translation>
@@ -5090,7 +4139,6 @@ Certains scripts peuvent y faire référence !</translation>
         <translation type="vanished">Le label %1 est inaccessible, veuillez utiliser un saut long.</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Script.cpp" line="222"/>
         <source>Label %1 is unreachable, please bring this instruction closer.</source>
         <translation>Le label %1 est inaccessible, rapprochez cette instruction du label.</translation>
     </message>
@@ -5100,39 +4148,32 @@ Certains scripts peuvent y faire référence !</translation>
         <translation type="vanished">Le label %1 est inaccessible car votre script dépasse 65535 octets, veuillez réduire la taille du script.</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Script.cpp" line="198"/>
         <source>Label %1 not found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Script.cpp" line="216"/>
         <source>Invalid jump, you must point to a valid label.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Script.cpp" line="219"/>
         <source>The label %1 is unreachable because it is located before the opcode.</source>
         <oldsource>Le label %1 est inaccessible car il se trouve avant la commande.</oldsource>
         <translation>Le label %1 est inaccessible car il se trouve avant la commande.</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Script.cpp" line="225"/>
         <source>Invalid jump to the label %1 which is after the maximum possible size of the script.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Script.cpp" line="228"/>
         <source>Invalid jump to before the script.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Script.cpp" line="237"/>
         <source>Script too big, it should not exceed 65535 bytes. Actual size: %1.</source>
         <oldsource>Script trop grand, il ne doit pas dépasser les 65535 octets. Taille actuelle : %1.</oldsource>
         <translation>Script too big, it should not exceed 65535 bytes. Actual size: %1.</translation>
     </message>
     <message>
-        <location filename="../src/core/field/TutFileStandard.cpp" line="163"/>
         <source>Error</source>
         <oldsource>Erreur</oldsource>
         <translation>Erreur</translation>
@@ -5144,112 +4185,84 @@ Make sure it is valid or delete it.</source>
 Vérifiez que ce fichier est valide ou supprimez-le.</translation>
     </message>
     <message>
-        <location filename="../src/core/field/TutFileStandard.cpp" line="167"/>
         <source>totalLength=%1
 id=%2
 </source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/core/field/TutFileStandard.cpp" line="174"/>
         <source>length=%1
 </source>
         <translation>length=%1
 </translation>
     </message>
     <message>
-        <location filename="../src/core/field/TutFileStandard.cpp" line="181"/>
         <source>ChannelCount=%1
 </source>
         <translation>nbCanaux=%1
 </translation>
     </message>
     <message>
-        <location filename="../src/core/IsoArchiveFF7.cpp" line="531"/>
         <source>Cannot update game binaries.</source>
         <translation>Impossible de mettre à jour les binaires du jeu.</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Section1File.cpp" line="45"/>
         <source>Map name</source>
         <translation>Nom de l&apos;écran</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Section1File.cpp" line="46"/>
         <source>Hello world!</source>
         <translation>Salut tout le monde !</translation>
     </message>
     <message>
-        <location filename="../src/core/field/FieldArchiveIOPS.cpp" line="418"/>
         <source>Cannot remove destination archive</source>
         <translation>Impossible de supprimer l&apos;archive de destination</translation>
     </message>
     <message>
-        <location filename="../src/core/field/FieldArchiveIOPS.cpp" line="434"/>
         <source>Cannot rename temporary file to destination path</source>
         <translation>Impossible de renommer les fichiers temporaires vers le chemin de destination</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Field.cpp" line="411"/>
         <source>File size greater than 10000000</source>
         <translation>Taille du fichier supérieure à 10000000</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Field.cpp" line="424"/>
         <source>Malformed LZS header</source>
         <translation>En-tête LZS mal formée</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Field.cpp" line="452"/>
-        <location filename="../src/core/field/Field.cpp" line="556"/>
         <source>Incorrect field file size</source>
         <translation>Taille du fichier d&apos;écran incorrecte</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Field.cpp" line="465"/>
-        <location filename="../src/core/field/Field.cpp" line="564"/>
         <source>Cannot open section 1 (texts, scripts and musics)</source>
         <translation>Impossible d&apos;ouvrir la section 1 (textes, scripts et musiques)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Field.cpp" line="473"/>
-        <location filename="../src/core/field/Field.cpp" line="572"/>
         <source>Cannot open tutos section</source>
         <translation>Impossible d&apos;ouvrir la partie tutoriels</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Field.cpp" line="481"/>
-        <location filename="../src/core/field/Field.cpp" line="587"/>
         <source>Cannot open encounters section</source>
         <translation>Impossible d&apos;ouvrir la partie rencontres aléatoires</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Field.cpp" line="489"/>
-        <location filename="../src/core/field/Field.cpp" line="595"/>
         <source>Cannot open walkmesh section</source>
         <translation>Impossible d&apos;ouvrir la partie walkmesh</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Field.cpp" line="497"/>
-        <location filename="../src/core/field/Field.cpp" line="603"/>
         <source>Cannot open camera section</source>
         <translation>Impossible d&apos;ouvrir la partie caméra</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Field.cpp" line="505"/>
-        <location filename="../src/core/field/Field.cpp" line="611"/>
         <source>Cannot open info section</source>
         <translation>Impossible d&apos;ouvrir la partie infos</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Field.cpp" line="513"/>
-        <location filename="../src/core/field/Field.cpp" line="580"/>
         <source>Cannot open model loader section</source>
         <translation>Impossible d&apos;ouvrir la partie qui liste les modèles 3D</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Field.cpp" line="542"/>
-        <location filename="../src/core/field/Field.cpp" line="633"/>
         <source>Cannot open background section</source>
         <translation>Impossible d&apos;ouvrir la partie décors</translation>
     </message>
@@ -5257,92 +4270,76 @@ id=%2
 <context>
     <name>ScriptEditor</name>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="48"/>
         <source>Script Editor%1</source>
         <oldsource>Éditeur de script%1</oldsource>
         <translation>Éditeur de script%1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="48"/>
         <source> (init mode)</source>
         <translation> (init mode)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="52"/>
         <source>Control Structures</source>
         <oldsource>Structures de contrôle</oldsource>
         <translation>Structures de contrôle</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="54"/>
         <source>Windowing and messages</source>
         <oldsource>Fenêtres et messages</oldsource>
         <translation>Fenêtres et messages</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="55"/>
         <source>Party and inventory</source>
         <oldsource>Équipe et inventaire</oldsource>
         <translation>Équipe et inventaire</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="56"/>
         <source>Field Models and animations</source>
         <oldsource>Objets 3D et animations</oldsource>
         <translation>Objets 3D et animations</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="58"/>
         <source>Background</source>
         <translation>Décor</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="60"/>
         <source>Audio and video</source>
         <oldsource>Audio et vidéo</oldsource>
         <translation>Audio et vidéo</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="61"/>
         <source>Modules</source>
         <translation>Modules</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="78"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="490"/>
         <source>Return</source>
         <oldsource>Retourner</oldsource>
         <translation>Retourner</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="491"/>
         <source>Return to</source>
         <oldsource>Retourner à</oldsource>
         <translation>Retourner à</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="493"/>
         <source>Execute a script</source>
         <oldsource>Exécuter un script</oldsource>
         <translation>Exécuter un script</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="495"/>
         <source>Execute a script from a party member</source>
         <oldsource>Exécuter un script d&apos;un équipier</oldsource>
         <translation>Exécuter un script d&apos;un équipier</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="498"/>
         <source>Label</source>
         <translation>Label</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="499"/>
         <source>Goto label</source>
         <oldsource>Aller au label</oldsource>
         <translation>Aller au label</translation>
@@ -5353,25 +4350,21 @@ id=%2
         <translation type="vanished">Si personnage existe</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="512"/>
         <source>Binary operation</source>
         <oldsource>Opération binaire</oldsource>
         <translation>Opération binaire</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="517"/>
         <source>Unary operation</source>
         <oldsource>Opération unaire</oldsource>
         <translation>Opération unaire</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="520"/>
         <source>Bitwise operation</source>
         <oldsource>Opération bit à bit</oldsource>
         <translation>Opération bit à bit</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="523"/>
         <source>Seed Random Generator</source>
         <translation>Seed Random Generator</translation>
     </message>
@@ -5384,339 +4377,279 @@ id=%2
         <translation type="vanished">Cosinus</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="543"/>
         <source>Ask Question</source>
         <oldsource>Poser une question</oldsource>
         <translation>Poser une question</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="546"/>
         <source>Enable/Disable menu</source>
         <oldsource>Activer/Désactiver menu</oldsource>
         <translation>Activer/Désactiver menu</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="551"/>
         <source>HP/MP Maximum (1)</source>
         <oldsource>HP/MP restaurés (1)</oldsource>
         <translation>HP/MP restaurés (1)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="552"/>
         <source>HP/MP Maximum (2)</source>
         <oldsource>HP/MP restaurés (2)</oldsource>
         <translation>HP/MP restaurés (2)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="553"/>
         <source>HP/MP Maximum with Status Clear</source>
         <oldsource>HP/MP/statut restaurés</oldsource>
         <translation>HP/MP/statut restaurés</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="554"/>
         <source>HP/MP Maximum (3)</source>
         <oldsource>HP/MP restaurés (3)</oldsource>
         <translation>HP/MP restaurés (3)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="566"/>
         <source>Add Materia</source>
         <oldsource>Ajouter Matéria</oldsource>
         <translation>Ajouter Matéria</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="567"/>
         <source>Remove Materia</source>
         <oldsource>Retirer Matéria</oldsource>
         <translation>Retirer Matéria</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="568"/>
         <source>Amount of Materia</source>
         <oldsource>Quantité de Matérias</oldsource>
         <translation>Quantité de Matérias</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="584"/>
         <source>Get Group Direction (Dir)</source>
         <oldsource>Obtenir la direction d&apos;un groupe (Dir)</oldsource>
         <translation>Obtenir la direction d&apos;un groupe (Dir)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="585"/>
         <source>Get Party Member Direction (Dir)</source>
         <oldsource>Obtenir la direction d&apos;un équipier (Dir)</oldsource>
         <translation>Obtenir la direction d&apos;un équipier (Dir)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="586"/>
         <source>Get Group Triangle ID (I)</source>
         <oldsource>Obtenir le triangle id d&apos;un groupe (I)</oldsource>
         <translation>Obtenir le triangle id d&apos;un groupe (I)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="587"/>
         <source>Get Party Member Triangle ID (I)</source>
         <oldsource>Obtenir le triangle id d&apos;un équipier (I)</oldsource>
         <translation>Obtenir le triangle id d&apos;un équipier (I)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="588"/>
         <source>Get Group coordinates (X,Y)</source>
         <oldsource>Obtenir les coordonnées d&apos;un groupe (X,Y)</oldsource>
         <translation>Obtenir les coordonnées d&apos;un groupe (X,Y)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="589"/>
         <source>Get Group coordinates (X,Y,Z,I)</source>
         <oldsource>Obtenir les coordonnées d&apos;un groupe (X,Y,Z,I)</oldsource>
         <translation>Obtenir les coordonnées d&apos;un groupe (X,Y,Z,I)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="590"/>
         <source>Get Party coordinates (X,Y,Z,I)</source>
         <oldsource>Obtenir les coordonnées d&apos;un équipier (X,Y,Z,I)</oldsource>
         <translation>Obtenir les coordonnées d&apos;un équipier (X,Y,Z,I)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="592"/>
         <source>Place (X,Y,Z)</source>
         <oldsource>Placer (X,Y,Z)</oldsource>
         <translation>Placer (X,Y,Z)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="593"/>
         <source>Place (X,Y,I)</source>
         <oldsource>Placer (X,Y,I)</oldsource>
         <translation>Placer (X,Y,I)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="594"/>
         <source>Place (X,Y,Z,I)</source>
         <oldsource>Placer (X,Y,Z,I)</oldsource>
         <translation>Placer (X,Y,Z,I)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="595"/>
         <source>Place (Dir)</source>
         <oldsource>Placer (Dir)</oldsource>
         <translation>Placer (Dir)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="598"/>
         <source>Move without animation</source>
         <oldsource>Déplacer sans animation</oldsource>
         <translation>Déplacer sans animation</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="599"/>
         <source>Move without animation or rotation</source>
         <oldsource>Déplacer sans animation ni rotation</oldsource>
         <translation>Déplacer sans animation ni rotation</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="604"/>
         <source>Direction to Group</source>
         <oldsource>Rotation vers un groupe</oldsource>
         <translation>Rotation vers un groupe</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="606"/>
         <source>Inversed Turn</source>
         <oldsource>Rotation inversée</oldsource>
         <translation>Rotation inversée</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="607"/>
         <source>Direction (inversed) to Group</source>
         <oldsource>Rotation inversée vers un groupe</oldsource>
         <translation>Rotation inversée vers un groupe</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="608"/>
         <source>Direction (inversed) to Party Member</source>
         <oldsource>Rotation inversée vers un équipier</oldsource>
         <translation>Rotation inversée vers un équipier</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="611"/>
         <source>Play animation (loop)</source>
         <oldsource>Jouer animation en boucle</oldsource>
         <translation>Jouer animation en boucle</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="612"/>
         <source>Play animation (1)</source>
         <oldsource>Jouer animation (1)</oldsource>
         <translation>Jouer animation (1)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="613"/>
         <source>Play animation (2)</source>
         <oldsource>Jouer animation (2)</oldsource>
         <translation>Jouer animation (2)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="614"/>
         <source>Play animation and return (1)</source>
         <oldsource>Jouer animation et revenir (1)</oldsource>
         <translation>Jouer animation et revenir (1)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="615"/>
         <source>Play animation and return (2)</source>
         <oldsource>Jouer animation et revenir (2)</oldsource>
         <translation>Jouer animation et revenir (2)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="616"/>
         <source>Play partial animation (1)</source>
         <oldsource>Jouer partiellement animation (1)</oldsource>
         <translation>Jouer partiellement animation (1)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="617"/>
         <source>Play partial animation (2)</source>
         <oldsource>Jouer partiellement animation (2)</oldsource>
         <translation>Jouer partiellement animation (2)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="618"/>
         <source>Play partial animation and return (1)</source>
         <oldsource>Jouer partiellement animation et revenir (1)</oldsource>
         <translation>Jouer partiellement animation et revenir (1)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="619"/>
         <source>Play partial animation and return (2)</source>
         <oldsource>Jouer partiellement animation et revenir (2)</oldsource>
         <translation>Jouer partiellement animation et revenir (2)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="620"/>
         <source>Play Stand/Walk/Run animation</source>
         <oldsource>Jouer animation Stand/Walk/Run</oldsource>
         <translation>Jouer animation Stand/Walk/Run</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="621"/>
         <source>Play jump animation</source>
         <oldsource>Jouer animation du saut</oldsource>
         <translation>Jouer animation du saut</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="53"/>
         <source>Mathematics</source>
         <translation>Opérations mathématiques</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="57"/>
         <source>Walkmesh and locations</source>
         <translation>Zones</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="59"/>
         <source>Fade and camera</source>
         <translation>Transitions et caméra</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="62"/>
         <source>Unknown</source>
         <translation>Inconnu</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="80"/>
         <source>Cancel</source>
         <translation>Annuler</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="501"/>
         <source>If...then</source>
         <translation>Si...alors</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="503"/>
         <source>If key pressed</source>
         <translation>Si touche pressée</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="504"/>
         <source>If Party Member</source>
         <translation>Si personnage membre de l&apos;équipe</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="505"/>
         <source>If character exists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="506"/>
         <source>[DLPB&apos;s custom opcode] If Red XIII is named Nanaki</source>
         <translation>[DLPB&apos;s custom opcode] Si Rouge XIII est nommé Nanaki</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="508"/>
         <source>Wait</source>
         <translation>Attendre</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="509"/>
         <source>No Operation</source>
         <translation>Ne rien faire</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="524"/>
         <source>Two Byte from two one-byte</source>
         <translation>Créer un mot de deux octets</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="525"/>
         <source>Sinus / Cosinus</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="528"/>
         <source>Window creation</source>
         <translation>Créer une fenêtre</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="529"/>
         <source>Resizes/Repositions a window</source>
         <translation>Redimensionner une fenêtre</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="530"/>
         <source>Set line count in window</source>
         <translation>Modifier le nombre de lignes dans fenêtre</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="531"/>
         <source>Move a window</source>
         <translation>Déplacer une fenêtre</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="532"/>
         <source>Set window type</source>
         <translation>Modifier type de fenêtre</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="533"/>
         <source>Reset a window</source>
         <translation>Remettre une fenêtre à zéro</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="534"/>
         <source>Close a window (1)</source>
         <translation>Fermer une fenêtre (1)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="535"/>
         <source>Close a window (2)</source>
         <translation>Fermer une fenêtre (2)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="537"/>
         <source>Numerical Display</source>
         <translation>Mettre un compteur dans fenêtre</translation>
     </message>
@@ -5725,12 +4658,10 @@ id=%2
         <translation type="vanished">Modifier variable dans fenêtre (16 bits)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="539"/>
         <source>Countdown</source>
         <translation>Compte à rebours</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="538"/>
         <source>Set numerical display value</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5739,654 +4670,530 @@ id=%2
         <translation type="vanished">Modifier variable dans fenêtre (8 bits)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="542"/>
         <source>Set window Text</source>
         <translation>Afficher texte</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="545"/>
         <source>Set map name</source>
         <translation>Modifier le nom du lieu</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="547"/>
         <source>Get window color</source>
         <translation>Obtenir la couleur d&apos;une fenêtre</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="548"/>
         <source>Set window color</source>
         <translation>Changer la couleur d&apos;une fenêtre</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="556"/>
         <source>Increase MP</source>
         <translation>Augmenter les MPs</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="557"/>
         <source>Decrease MP</source>
         <translation>Diminuer les MPs</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="558"/>
         <source>Increase HP</source>
         <translation>Augmenter les HPs</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="559"/>
         <source>Decrease HP</source>
         <translation>Diminuer les HPs</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="560"/>
         <source>Add gil</source>
         <translation>Ajouter des gils</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="561"/>
         <source>Remove gil</source>
         <translation>Retirer des gils</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="562"/>
         <source>Amount of gil</source>
         <translation>Quantité d&apos;argent</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="563"/>
         <source>Add Item</source>
         <translation>Ajouter objet</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="564"/>
         <source>Remove item</source>
         <translation>Retirer objet</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="565"/>
         <source>Amount of item</source>
         <translation>Quantité d&apos;objets</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="570"/>
         <source>Party Change</source>
         <translation>Nouvelle équipe</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="571"/>
         <source>Add Character to the party</source>
         <translation>Ajouter un personnage</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="572"/>
         <source>Remove Character from the party</source>
         <translation>Retirer un personnage</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="573"/>
         <source>Save party</source>
         <translation>Sauvegarder l&apos;équipe</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="574"/>
         <source>Load party</source>
         <translation>Restaurer l&apos;équipe</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="575"/>
         <source>Create/Delete character</source>
         <translation>Créer/effacer personnage</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="576"/>
         <source>Lock character</source>
         <translation>Bloquer personnage</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="577"/>
         <source>Unlock character</source>
         <translation>Débloquer personnage</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="580"/>
         <source>Set Field Model</source>
         <translation>Définir objet 3D</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="581"/>
         <source>Set character to Field Model</source>
         <translation>Affecter personnage à objet 3D</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="582"/>
         <source>Group control</source>
         <translation>Prendre le contrôle d&apos;un groupe</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="597"/>
         <source>Move</source>
         <translation>Déplacer</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="600"/>
         <source>Move to Group</source>
         <translation>Déplacer vers un groupe</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="601"/>
         <source>Move to Party Member</source>
         <translation>Déplacer vers un équipier</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="603"/>
         <source>Turn</source>
         <translation>Rotation</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="605"/>
         <source>Direction to Party Member</source>
         <translation>Rotation vers un équipier</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="609"/>
         <source>Wait for Turn</source>
         <translation>Attendre fin rotation</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="622"/>
         <source>Play climb animation</source>
         <translation>Jouer animation de l&apos;échelle</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="623"/>
         <source>Party field join</source>
         <translation>Rejoindre le leader</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="624"/>
         <source>Party field split</source>
         <translation>Séparer les membres de l&apos;équipe</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="625"/>
         <source>Stop animation</source>
         <oldsource>Arrêter animation</oldsource>
         <translation>Arrêter animation</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="626"/>
         <source>Wait for animation</source>
         <oldsource>Attendre fin animation</oldsource>
         <translation>Attendre fin animation</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="628"/>
         <source>Character Graphics - Eye open/close</source>
         <oldsource>Filtre graphique - OEil ouvert/fermé</oldsource>
         <translation>Filtre graphique - OEil ouvert/fermé</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="629"/>
         <source>Character Graphics - Activate/Deactivate blending</source>
         <oldsource>Filtre graphique - Activer/Désactiver transparence</oldsource>
         <translation>Filtre graphique - Activer/Désactiver transparence</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="630"/>
         <source>Character Graphics - ??? - AMBNT</source>
         <oldsource>Filtre graphique - AMBNT</oldsource>
         <translation>Filtre graphique - ??? - AMBNT</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="631"/>
         <source>Character Graphics - ??? (1)</source>
         <oldsource>Filtre graphique - ??? (1)</oldsource>
         <translation>Filtre graphique - ??? (1)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="632"/>
         <source>Character Graphics - ??? (2)</source>
         <oldsource>Filtre graphique - ??? (2)</oldsource>
         <translation>Filtre graphique - ??? (2)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="633"/>
         <source>Character Graphics - ??? (3)</source>
         <oldsource>Filtre graphique - ??? (3)</oldsource>
         <translation>Filtre graphique - ??? (3)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="634"/>
         <source>Character Graphics - LIGHT</source>
         <oldsource>Filtre graphique - LIGHT</oldsource>
         <translation>Filtre graphique - LIGHT</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="635"/>
         <source>Character Graphics - ??? (4)</source>
         <oldsource>Filtre graphique - ??? (4)</oldsource>
         <translation>Filtre graphique - ??? (4)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="636"/>
         <source>Character Graphics - ??? (5)</source>
         <oldsource>Filtre graphique - ??? (5)</oldsource>
         <translation>Filtre graphique - ??? (5)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="637"/>
         <source>Character Graphics - ??? (6)</source>
         <oldsource>Filtre graphique - ??? (6)</oldsource>
         <translation>Filtre graphique - ??? (6)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="638"/>
         <source>Character Graphics - SBOBJ</source>
         <oldsource>Filtre graphique - SBOBJ</oldsource>
         <translation>Filtre graphique - SBOBJ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="639"/>
         <source>Character Graphics - ??? (7)</source>
         <oldsource>Filtre graphique - ??? (7)</oldsource>
         <translation>Filtre graphique - ??? (7)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="640"/>
         <source>Character Graphics - ??? (8)</source>
         <oldsource>Filtre graphique - ??? (8)</oldsource>
         <translation>Filtre graphique - ??? (8)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="641"/>
         <source>Character Graphics - SHINE</source>
         <oldsource>Filtre graphique - SHINE</oldsource>
         <translation>Filtre graphique - SHINE</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="642"/>
         <source>Character Graphics - RESET</source>
         <oldsource>Filtre graphique - RESET</oldsource>
         <translation>Filtre graphique - RESET</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="643"/>
         <source>Wait For Character Graphics</source>
         <oldsource>Attendre fin filtre graphique</oldsource>
         <translation>Attendre fin filtre graphique</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="645"/>
         <source>OFST</source>
         <translation>OFST</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="646"/>
         <source>OFSTW</source>
         <translation>OFSTW</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="648"/>
         <source>Movement Speed</source>
         <translation>Vitesse déplacements</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="650"/>
         <source>Hide/Display Field Model</source>
         <translation>Cacher/Afficher objet 3D</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="652"/>
         <source>Character Blink</source>
         <translation>Cligner des yeux</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="653"/>
         <source>Talk On/Off</source>
         <translation>Activer/désactiver parler</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="654"/>
         <source>Contact On/Off</source>
         <translatorcomment>\</translatorcomment>
         <translation>Activer/désactiver toucher</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="655"/>
         <source>Talk Range (8-bit)</source>
         <translation>Distance pour parler (8 bits)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="656"/>
         <source>Contact range (8-bit)</source>
         <translation>Distance pour toucher (8 bits)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="657"/>
         <source>Talk Range (16-bit)</source>
         <translation>Distance pour parler (16 bits)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="658"/>
         <source>Contact range (16-bit)</source>
         <translation>Distance pour toucher (16 bits)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="661"/>
         <source>Create line</source>
         <oldsource>Create location</oldsource>
         <translation>Créer ligne</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="662"/>
         <source>Set line</source>
         <oldsource>Set location</oldsource>
         <translation>Modifier ligne</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="663"/>
         <source>Line On/Off</source>
         <oldsource>Location On/Off</oldsource>
         <translation>Activer/Désactiver ligne</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="664"/>
         <source>Triangle On/Off</source>
         <translation>Activer/Désactiver triangle</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="669"/>
         <source>Move background Z layer</source>
         <translation>Déplacer une couche du décor (Z)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="671"/>
         <source>Show a background state</source>
         <translation>Afficher un état d&apos;un paramètre</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="672"/>
         <source>Hide background state</source>
         <translation>Cacher un état d&apos;un paramètre</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="673"/>
         <source>Show next background state</source>
         <translation>Afficher l&apos;état suivant d&apos;un paramètre</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="674"/>
         <source>Show previous background state</source>
         <translation>Afficher l&apos;état précédent d&apos;un paramètre</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="675"/>
         <source>Hide background parameters</source>
         <translation>Cacher un paramètre</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="691"/>
         <source>Scroll to playable character</source>
         <translation>Centrer sur le personnage jouable</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="692"/>
         <source>Scroll to party member</source>
         <translation>Centrer sur personnage</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="696"/>
         <source>Scroll (X,Y,Smooth)</source>
         <translation>Centrer (X,Y,Vitesse amortie)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="697"/>
         <source>Scroll (X,Y,Linear)</source>
         <translation>Centrer (X,Y,Vitesse linéaire)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="701"/>
         <source>Shake</source>
         <translation>Secouer l&apos;écran</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="702"/>
         <source>Wait for scroll</source>
         <translation>Attendre fin centrage</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="711"/>
         <source>Alter sound (8-bit)</source>
         <translation>Modifier son (8 bits)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="712"/>
         <source>Alter sound (16-bit)</source>
         <translation>Modifier son (16 bits)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="715"/>
         <source>Play temporary music</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="716"/>
         <source>MUSVM (unused)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="717"/>
         <source>Music Unlock/Lock</source>
         <oldsource>Music On/Off</oldsource>
         <translation>Déverrouiller/Verrouiller musique</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="719"/>
         <source>CHMPH (unused)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="720"/>
         <source>Get music status</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="721"/>
         <source>Field music</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="722"/>
         <source>Play basic akao operation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="724"/>
         <source>Set next movie</source>
         <translation>Prochaine cinématique</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="725"/>
         <source>Play movie</source>
         <translation>Jouer la cinématique choisie</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="735"/>
         <source>Battle result load</source>
         <translation>Résultat du dernier combat</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="737"/>
         <source>Change Map</source>
         <translation>Changer d&apos;écran</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="738"/>
         <source>Last Map ID</source>
         <translation>ID de l&apos;écran précédent</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="739"/>
         <source>Start Battle</source>
         <translation>Combattre</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="740"/>
         <source>Battle On/Off</source>
         <translation>Activer/désactiver les combats</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="743"/>
         <source>Map Jump On/Off</source>
         <translation>Activer/désactiver les changements d&apos;écran</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="744"/>
         <source>Character movability On/Off</source>
         <translation>Activer/Désactiver déplacements</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="745"/>
         <source>Preload field Map</source>
         <translation>Précharger un écran</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="649"/>
         <source>Animation Speed</source>
         <oldsource>Vitesse animations</oldsource>
         <translation>Vitesse animations</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="540"/>
         <source>Set window variable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="651"/>
         <source>Enable/Disable rotation</source>
         <oldsource>Activer/Désactiver rotation</oldsource>
         <translation>Activer/Désactiver rotation</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="666"/>
         <source>SLIP</source>
         <translation>SLIP</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="670"/>
         <source>Animate background layer</source>
         <oldsource>Animer une couche du décor</oldsource>
         <translation>Animer une couche du décor</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="677"/>
         <source>Store Palette</source>
         <translation>Enregistrer palette</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="678"/>
         <source>Store Palette (S)</source>
         <translation>Enregistrer palette (S)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="679"/>
         <source>Load Palette</source>
         <translation>Charger palette</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="680"/>
         <source>Load Palette (S)</source>
         <translation>Charger palette (S)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="681"/>
         <source>Copy Palette</source>
         <translation>Copier palette</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="682"/>
         <source>Copy Palette (2)</source>
         <translation>Copier palette (2)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="683"/>
         <source>Partial Copy Palette</source>
         <translation>Copier partiellement palette</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="684"/>
         <source>Partial Copy Palette (2)</source>
         <translation>Copier partiellement palette (2)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="685"/>
         <source>Multiply Palette</source>
         <oldsource>Multiplier Palette</oldsource>
         <translation>Multiplier Palette</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="686"/>
         <source>Multiply Palette (2)</source>
         <oldsource>Multiplier Palette (2)</oldsource>
         <translation>Multiplier Palette (2)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="687"/>
         <source>Add Palette</source>
         <oldsource>Additionner Palette</oldsource>
         <translation>Additionner Palette</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="688"/>
         <source>Add Palette (2)</source>
         <oldsource>Additionner Palette (2)</oldsource>
         <translation>Additionner Palette (2)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="693"/>
         <source>Scroll to group</source>
         <oldsource>Centrer sur groupe</oldsource>
         <translation>Centrer sur groupe</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="695"/>
         <source>Scroll (X,Y)</source>
         <oldsource>Centrer (X,Y)</oldsource>
         <translation>Centrer (X,Y)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="698"/>
         <source>SCRLO</source>
         <translation>SCRLO</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="699"/>
         <source>SCRLC</source>
         <translation>SCRLC</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="704"/>
         <source>VWOFT</source>
         <translation>VWOFT</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="705"/>
         <source>FADE</source>
         <translation>FADE</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="706"/>
         <source>FADEW</source>
         <translation>FADEW</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="707"/>
         <source>NFADE</source>
         <translation>NFADE</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="710"/>
         <source>Play sound</source>
         <oldsource>Jouer son</oldsource>
         <translation>Jouer son</translation>
@@ -6400,7 +5207,6 @@ id=%2
         <translation type="vanished">AKAO2</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="714"/>
         <source>Play music</source>
         <oldsource>Jouer musique</oldsource>
         <translation>Jouer musique</translation>
@@ -6414,7 +5220,6 @@ id=%2
         <translation type="vanished">MUSVM</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="718"/>
         <source>Battle music</source>
         <oldsource>Musique de combat</oldsource>
         <translation>Musique de combat</translation>
@@ -6436,46 +5241,38 @@ id=%2
         <translation type="vanished">CMUSC</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="726"/>
         <source>MVIEF</source>
         <translation>MVIEF</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="727"/>
         <source>MVCAM</source>
         <translation>MVCAM</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="728"/>
         <source>BGMOVIE</source>
         <translation>BGMOVIE</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="731"/>
         <source>Play tutorial</source>
         <oldsource>Lancer un tutoriel</oldsource>
         <translation>Lancer un tutoriel</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="732"/>
         <source>Display a menu</source>
         <oldsource>Afficher menu</oldsource>
         <translation>Afficher menu</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="733"/>
         <source>Disc change screen</source>
         <oldsource>Changer de disque</oldsource>
         <translation>Changer de disque</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="734"/>
         <source>Minigame</source>
         <oldsource>Mini-jeu</oldsource>
         <translation>Mini-jeu</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="736"/>
         <source>Battle Table</source>
         <oldsource>Table de combat</oldsource>
         <translation>Table de combat</translation>
@@ -6486,115 +5283,94 @@ id=%2
         <translation type="vanished">Changer d&apos;écran</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="741"/>
         <source>Battle mode</source>
         <oldsource>Mode de combat</oldsource>
         <translation>Mode de combat</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="742"/>
         <source>Battle mode (2)</source>
         <oldsource>Mode de combat (2)</oldsource>
         <translation>Mode de combat (2)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="746"/>
         <source>PMJMP2</source>
         <translation>PMJMP2</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="747"/>
         <source>Game Over</source>
         <translation>Fin de partie</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="748"/>
         <source>[DLPB&apos;s custom opcode] Write/Read to entire Savemap</source>
         <translation>[DLPB&apos;s custom opcode] Écrire/Lire vers la savemap</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="749"/>
         <source>[DLPB&apos;s custom opcode] Write to any memory address via array</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="750"/>
         <source>SPECIAL - Cursor On/Off</source>
         <oldsource>SPECIAL - Activer/Désactiver curseur</oldsource>
         <translation>SPECIAL - Curseur Affiché/Caché</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="751"/>
         <source>SPECIAL - PNAME</source>
         <translation>SPECIAL - PNAME</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="752"/>
         <source>SPECIAL - Game Speed</source>
         <oldsource>SPECIAL - Vitesse du jeu</oldsource>
         <translation>SPECIAL - Vitesse du jeu</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="753"/>
         <source>SPECIAL - Messages Speed</source>
         <oldsource>SPECIAL - Vitesse des message</oldsource>
         <translation>SPECIAL - Vitesse des message</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="754"/>
         <source>SPECIAL - Full Materia</source>
         <translation>SPECIAL - Toutes les matérias</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="755"/>
         <source>SPECIAL - Full Item</source>
         <translation>SPECIAL - Tous les objets</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="756"/>
         <source>SPECIAL - Battle On/Off</source>
         <oldsource>SPECIAL - Activer/Désactiver combats</oldsource>
         <translation>SPECIAL - Activer/Désactiver combats</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="757"/>
         <source>SPECIAL - Character movability On/Off</source>
         <oldsource>SPECIAL - Activer/Désactiver mouvements</oldsource>
         <translation>SPECIAL - Activer/Désactiver mouvements</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="758"/>
         <source>SPECIAL - Rename character</source>
         <oldsource>SPECIAL - Renommer personnage</oldsource>
         <translation>SPECIAL - Renommer personnage</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="759"/>
         <source>SPECIAL - Clear Game</source>
         <translation>SPECIAL - Remettre à zéro le jeu</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="760"/>
         <source>SPECIAL - Clear Items</source>
         <translation>SPECIAL - Supprimertous  les objets</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="763"/>
         <source>MPDSP</source>
         <translation>MPDSP</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="764"/>
         <source>SETX</source>
         <translation>SETX</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="765"/>
         <source>GETX</source>
         <translation>GETX</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="766"/>
         <source>SEARCHX</source>
         <translation>SEARCHX</translation>
     </message>
@@ -6602,65 +5378,53 @@ id=%2
 <context>
     <name>ScriptEditorBinaryOpPage</name>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorMathPage.cpp" line="31"/>
         <source>Assignment</source>
         <translation>Affectation</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorMathPage.cpp" line="32"/>
         <source>Addition (wrapped)</source>
         <oldsource>Addition (cyclique)</oldsource>
         <translation>Addition (cyclique)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorMathPage.cpp" line="33"/>
         <source>Addition (capped)</source>
         <oldsource>Addition (plafonnée)</oldsource>
         <translation>Addition (plafonnée)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorMathPage.cpp" line="34"/>
         <source>Subtraction (wrapped)</source>
         <oldsource>Soustraction (cyclique)</oldsource>
         <translation>Soustraction (cyclique)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorMathPage.cpp" line="35"/>
         <source>Subtraction (capped)</source>
         <translation>Soustraction (avec plancher à 0)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorMathPage.cpp" line="38"/>
         <source>Modulo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorMathPage.cpp" line="39"/>
         <source>And</source>
         <translation>Et</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorMathPage.cpp" line="42"/>
         <source>Low-byte</source>
         <translation>Octet de poids faible</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorMathPage.cpp" line="43"/>
         <source>High-byte</source>
         <translation>Octet de poids fort</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorMathPage.cpp" line="58"/>
         <source>It is not possible to divide per 0 or use mod 0, or the game will crash.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorMathPage.cpp" line="36"/>
         <source>Multiplication</source>
         <translation>Multiplication</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorMathPage.cpp" line="37"/>
         <source>Division</source>
         <translation>Division</translation>
     </message>
@@ -6670,25 +5434,21 @@ id=%2
         <translation type="vanished">Modulo</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorMathPage.cpp" line="40"/>
         <source>Or</source>
         <oldsource>Ou</oldsource>
         <translation>Ou</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorMathPage.cpp" line="41"/>
         <source>Exclusive or</source>
         <oldsource>Ou exclusif</oldsource>
         <translation>Ou exclusif</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorMathPage.cpp" line="46"/>
         <source>8-bit</source>
         <oldsource>8 bits</oldsource>
         <translation>8 bits</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorMathPage.cpp" line="47"/>
         <source>16-bit</source>
         <oldsource>16 bits</oldsource>
         <translation>16 bits</translation>
@@ -6697,34 +5457,28 @@ id=%2
 <context>
     <name>ScriptEditorBitOpPage</name>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorMathPage.cpp" line="605"/>
         <source>Set a bit to 1</source>
         <oldsource>Mettre un bit à 1</oldsource>
         <translation>Mettre un bit à 1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorMathPage.cpp" line="606"/>
         <source>Set a bit to 0</source>
         <oldsource>Mettre un bit à 0</oldsource>
         <translation>Mettre un bit à 0</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorMathPage.cpp" line="607"/>
         <source>Toggles a bit</source>
         <translation>Inverser la valeur d&apos;un bit</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorMathPage.cpp" line="610"/>
         <source>Variable</source>
         <translation>Variable</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorMathPage.cpp" line="612"/>
         <source>Position</source>
         <translation>Position</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorMathPage.cpp" line="614"/>
         <source>Operation</source>
         <oldsource>Opération</oldsource>
         <translation>Opération</translation>
@@ -6733,68 +5487,38 @@ id=%2
 <context>
     <name>ScriptEditorBooleanPage</name>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="775"/>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="779"/>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="787"/>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="791"/>
         <source>Enable</source>
         <translation type="unfinished">Activer</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="775"/>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="779"/>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="787"/>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="791"/>
         <source>Disable</source>
         <translation type="unfinished">Désactiver</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="783"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="783"/>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="825"/>
         <source>Hide</source>
         <translation type="unfinished">Cacher</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="795"/>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="799"/>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="811"/>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="815"/>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="819"/>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="829"/>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="833"/>
         <source>Activate</source>
         <translation type="unfinished">Activer</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="795"/>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="799"/>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="811"/>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="815"/>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="819"/>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="829"/>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="833"/>
         <source>Deactivate</source>
         <translation type="unfinished">Désactiver</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="803"/>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="807"/>
         <source>ON</source>
         <translation type="unfinished">Autoriser</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="803"/>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="807"/>
         <source>OFF</source>
         <translation type="unfinished">Empêcher</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="825"/>
         <source>Display</source>
         <translation type="unfinished">Afficher</translation>
     </message>
@@ -6802,52 +5526,42 @@ id=%2
 <context>
     <name>ScriptEditorDLPBSavemap</name>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorSpecialPage.cpp" line="38"/>
         <source>8 bit</source>
         <translation>8 bits</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorSpecialPage.cpp" line="39"/>
         <source>16 bit</source>
         <translation>16 bits</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorSpecialPage.cpp" line="40"/>
         <source>24 bit</source>
         <translation>24 bits</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorSpecialPage.cpp" line="41"/>
         <source>32 bit</source>
         <translation>32 bits</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorSpecialPage.cpp" line="43"/>
         <source>From is a pointer</source>
         <translation>&quot;De&quot; est un pointeur</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorSpecialPage.cpp" line="44"/>
         <source>To is a pointer</source>
         <translation>&quot;Vers&quot; est un pointeur</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorSpecialPage.cpp" line="47"/>
         <source>From</source>
         <translation>De</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorSpecialPage.cpp" line="49"/>
         <source>To</source>
         <translation>Vers</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorSpecialPage.cpp" line="51"/>
         <source>Abs Value</source>
         <translation>Valeur absolue</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorSpecialPage.cpp" line="53"/>
         <source>Size</source>
         <translation>Taille</translation>
     </message>
@@ -6855,12 +5569,10 @@ id=%2
 <context>
     <name>ScriptEditorDLPBWriteToMemory</name>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorSpecialPage.cpp" line="111"/>
         <source>Address</source>
         <translation type="unfinished">Adresse</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorSpecialPage.cpp" line="113"/>
         <source>Bytes</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6868,46 +5580,38 @@ id=%2
 <context>
     <name>ScriptEditorExecCharPage</name>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorStructPage.cpp" line="237"/>
         <source>Script %1</source>
         <translation>Script %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorStructPage.cpp" line="241"/>
         <source>Asynchronous, no wait</source>
         <oldsource>Asynchrone, n&apos;attend pas</oldsource>
         <translation>Asynchrone, n&apos;attend pas</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorStructPage.cpp" line="242"/>
         <source>Asynchronous, wait</source>
         <oldsource>Asynchrone, attend</oldsource>
         <translation>Asynchrone, attend</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorStructPage.cpp" line="243"/>
         <source>Synchronous, wait</source>
         <oldsource>Synchrone, attend</oldsource>
         <translation>Synchrone, attend</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorStructPage.cpp" line="246"/>
         <source>Team member</source>
         <translation>Équipier</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorStructPage.cpp" line="248"/>
         <source>Script</source>
         <translation>Script</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorStructPage.cpp" line="250"/>
         <source>Priority</source>
         <oldsource>Priorité</oldsource>
         <translation>Priorité</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorStructPage.cpp" line="252"/>
         <source>Type</source>
         <translation>Type</translation>
     </message>
@@ -6915,42 +5619,35 @@ id=%2
 <context>
     <name>ScriptEditorExecPage</name>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorStructPage.cpp" line="107"/>
         <source>Asynchronous, no wait</source>
         <oldsource>Asynchrone, n&apos;attend pas</oldsource>
         <translation>Asynchrone, n&apos;attend pas</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorStructPage.cpp" line="108"/>
         <source>Asynchronous, wait</source>
         <oldsource>Asynchrone, attend</oldsource>
         <translation>Asynchrone, attend</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorStructPage.cpp" line="109"/>
         <source>Synchronous, wait</source>
         <oldsource>Synchrone, attend</oldsource>
         <translation>Synchrone, attend</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorStructPage.cpp" line="112"/>
         <source>Group</source>
         <oldsource>Groupe</oldsource>
         <translation>Groupe</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorStructPage.cpp" line="114"/>
         <source>Script</source>
         <translation>Script</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorStructPage.cpp" line="116"/>
         <source>Priority</source>
         <oldsource>Priorité</oldsource>
         <translation>Priorité</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorStructPage.cpp" line="118"/>
         <source>Type</source>
         <translation>Type</translation>
     </message>
@@ -6958,323 +5655,264 @@ id=%2
 <context>
     <name>ScriptEditorGenericList</name>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="615"/>
         <source>Long</source>
         <oldsource>Entier long</oldsource>
         <translation>Entier long</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="616"/>
         <source>Signed long</source>
         <oldsource>Entier long signé</oldsource>
         <translation>Entier long signé</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="617"/>
         <source>X coordinate</source>
         <oldsource>Coordonnée X</oldsource>
         <translation>Coordonnée X</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="618"/>
         <source>Y coordinate</source>
         <oldsource>Coordonnée Y</oldsource>
         <translation>Coordonnée Y</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="619"/>
         <source>Z coordinate</source>
         <oldsource>Coordonnée Z</oldsource>
         <translation>Coordonnée Z</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="621"/>
         <source>Tutorial</source>
         <oldsource>Tutoriel</oldsource>
         <translation>Tutoriel</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="623"/>
         <source>Disc</source>
         <oldsource>Disque</oldsource>
         <translation>Disque</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="624"/>
         <source>Minigame</source>
         <oldsource>Mini-jeu</oldsource>
         <translation>Mini-jeu</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="627"/>
         <source>Speed (16-bit)</source>
         <oldsource>Vitesse (16 bits)</oldsource>
         <translation>Vitesse (16 bits)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="628"/>
         <source>Direction</source>
         <translation>Direction</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="629"/>
         <source>Triangle</source>
         <translation>Triangle</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="630"/>
         <source>Group</source>
         <oldsource>Groupe</oldsource>
         <translation>Groupe</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="631"/>
         <source>Script</source>
         <translation>Script</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="633"/>
         <source>Bank</source>
         <translation>Bank</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="634"/>
         <source>Address</source>
         <oldsource>Adresse</oldsource>
         <translation>Adresse</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="635"/>
         <source>Priority</source>
         <oldsource>Priorité</oldsource>
         <translation>Priorité</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="636"/>
         <source>Flag</source>
         <translation>Flag</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="639"/>
         <source>Operator</source>
         <oldsource>Opérateur</oldsource>
         <translation>Opérateur</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="640"/>
         <source>Boolean</source>
         <oldsource>Booléen</oldsource>
         <translation>Booléen</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="642"/>
         <source>Parameter</source>
         <oldsource>Paramètre</oldsource>
         <translation>Paramètre</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="643"/>
         <source>State</source>
         <oldsource>État</oldsource>
         <translation>État</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="647"/>
         <source>Variable</source>
         <translation>Variable</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="649"/>
         <source>Rotation</source>
         <oldsource>Sens de rotation</oldsource>
         <translation>Sens de rotation</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="650"/>
         <source>Display Type</source>
         <oldsource>Type d&apos;affichage</oldsource>
         <translation>Type d&apos;affichage</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="651"/>
         <source>Text</source>
         <oldsource>Texte</oldsource>
         <translation>Texte</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="652"/>
         <source>Menu</source>
         <translation>Menu</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="43"/>
         <source>Add a line</source>
         <translation>Ajouter une ligne</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="45"/>
         <source>Delete a line</source>
         <translation>Effacer une ligne</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="55"/>
         <source>Arguments:</source>
         <translation>Paramètres :</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="614"/>
         <source>Double long</source>
         <translation>Entier double long</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="620"/>
         <source>Map</source>
         <translation>Écran</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="622"/>
         <source>Character</source>
         <translation>Personnage</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="625"/>
         <source>Short</source>
         <translation>Entier court</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="626"/>
         <source>Speed (8-bit)</source>
         <translation>Vitesse (8 bits)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="632"/>
         <source>Team member</source>
         <translation>Équipier</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="637"/>
         <source>Jump (short)</source>
         <translation>Saut court</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="638"/>
         <source>Jump (long)</source>
         <oldsource>Jumb (long)</oldsource>
         <translation>Saut long</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="641"/>
         <source>Layer</source>
         <translation>Couche</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="644"/>
         <source>Window</source>
         <translation>Fenêtre</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="645"/>
         <source>Width</source>
         <translation>Largeur</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="646"/>
         <source>Height</source>
         <translation>Hauteur</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="648"/>
         <source>Key(s)</source>
         <translation>Touche(s)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="653"/>
         <source>Window Type</source>
         <translation>Type de fenêtre</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="654"/>
         <source>Item</source>
         <translation>Objet</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="655"/>
         <source>Materia</source>
         <oldsource>Matéria</oldsource>
         <translation>Matéria</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="656"/>
         <source>Quantity</source>
         <oldsource>Quantité</oldsource>
         <translation>Quantité</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="657"/>
         <source>Color</source>
         <oldsource>Couleur</oldsource>
         <translation>Couleur</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="658"/>
         <source>Animation</source>
         <translation>Animation</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="659"/>
         <source>Music</source>
         <oldsource>Musique</oldsource>
         <translation>Musique</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="660"/>
         <source>Sound</source>
         <oldsource>Son</oldsource>
         <translation>Son</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="661"/>
         <source>Video</source>
         <oldsource>Vidéo</oldsource>
         <translation>Vidéo</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="662"/>
         <source>Label</source>
         <translation>Label</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="663"/>
         <source>Sound operation</source>
         <translation>Opération sur le son</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="664"/>
         <source>Shake type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="665"/>
         <source>X Amplitude</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="666"/>
         <source>X Frames</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="667"/>
         <source>Y Amplitude</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="668"/>
         <source>Y Frames</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="670"/>
         <source>???</source>
         <translation>???</translation>
     </message>
@@ -7282,33 +5920,27 @@ id=%2
 <context>
     <name>ScriptEditorIfKeyPage</name>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorStructPage.cpp" line="690"/>
         <source>Key pressed</source>
         <oldsource>Touche pressée</oldsource>
         <translation>Touche pressée</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorStructPage.cpp" line="665"/>
         <source>Keys</source>
         <translation>Touches</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorStructPage.cpp" line="691"/>
         <source>Key pressed once</source>
         <translation>Touche pressée une fois</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorStructPage.cpp" line="692"/>
         <source>Key released once</source>
         <translation>Touche lâchée une fois</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorStructPage.cpp" line="694"/>
         <source>Type</source>
         <translation>Type</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorStructPage.cpp" line="696"/>
         <source>Label</source>
         <translation>Label</translation>
     </message>
@@ -7316,7 +5948,6 @@ id=%2
 <context>
     <name>ScriptEditorIfPage</name>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorStructPage.cpp" line="530"/>
         <source>16-bit signed</source>
         <oldsource>Sur 16 bits signés</oldsource>
         <translation>Sur 16 bits signés</translation>
@@ -7332,17 +5963,14 @@ id=%2
         <translation type="vanished">Long (16 bits)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorStructPage.cpp" line="529"/>
         <source>8-bit unsigned</source>
         <translation>Sur 8 bits non signés</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorStructPage.cpp" line="531"/>
         <source>16-bit unsigned</source>
         <translation>Sur 16 bits non signés</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorStructPage.cpp" line="536"/>
         <source>Test</source>
         <translation type="unfinished">Test</translation>
     </message>
@@ -7351,13 +5979,11 @@ id=%2
         <translation type="vanished">Test à effectuer</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorStructPage.cpp" line="540"/>
         <source>Compare type</source>
         <oldsource>Type de comparaison</oldsource>
         <translation>Type de comparaison</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorStructPage.cpp" line="542"/>
         <source>Label</source>
         <translation>Label</translation>
     </message>
@@ -7370,18 +5996,14 @@ id=%2
 <context>
     <name>ScriptEditorIfQPage</name>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorStructPage.cpp" line="783"/>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorStructPage.cpp" line="784"/>
         <source>(Empty)</source>
         <translation>(Vide)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorStructPage.cpp" line="789"/>
         <source>Character</source>
         <translation>Personnage</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorStructPage.cpp" line="791"/>
         <source>Label</source>
         <translation>Label</translation>
     </message>
@@ -7389,7 +6011,6 @@ id=%2
 <context>
     <name>ScriptEditorJumpNanakiPage</name>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorStructPage.cpp" line="478"/>
         <source>Label</source>
         <translation>Label</translation>
     </message>
@@ -7407,7 +6028,6 @@ id=%2
         <translation type="vanished">Long (16 bits)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorStructPage.cpp" line="419"/>
         <source>Label</source>
         <translation>Label</translation>
     </message>
@@ -7423,12 +6043,10 @@ id=%2
 <context>
     <name>ScriptEditorJumpPageInterface</name>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorStructPage.cpp" line="388"/>
         <source>Label %1</source>
         <translation>Label %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorStructPage.cpp" line="398"/>
         <source>New label</source>
         <oldsource>Nouveau label</oldsource>
         <translation>Nouveau label</translation>
@@ -7437,7 +6055,6 @@ id=%2
 <context>
     <name>ScriptEditorLabelPage</name>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorStructPage.cpp" line="337"/>
         <source>Label</source>
         <translation>Label</translation>
     </message>
@@ -7445,19 +6062,16 @@ id=%2
 <context>
     <name>ScriptEditorMoviePage</name>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorMoviePage.cpp" line="35"/>
         <source>Disc</source>
         <oldsource>Disque</oldsource>
         <translation>Disque</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorMoviePage.cpp" line="37"/>
         <source>Video</source>
         <oldsource>Vidéo</oldsource>
         <translation>Vidéo</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorMoviePage.cpp" line="49"/>
         <source>Disc %1</source>
         <oldsource>Disque %1</oldsource>
         <translation>Disque %1</translation>
@@ -7466,17 +6080,14 @@ id=%2
 <context>
     <name>ScriptEditorReturnToPage</name>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorStructPage.cpp" line="47"/>
         <source>Script %1</source>
         <translation>Script %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorStructPage.cpp" line="51"/>
         <source>Script</source>
         <translation>Script</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorStructPage.cpp" line="53"/>
         <source>Priority</source>
         <oldsource>Priorité</oldsource>
         <translation>Priorité</translation>
@@ -7485,12 +6096,10 @@ id=%2
 <context>
     <name>ScriptEditorSinCosPage</name>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorMathPage.cpp" line="853"/>
         <source>Sinus</source>
         <translation type="unfinished">Sinus</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorMathPage.cpp" line="854"/>
         <source>Cosinus</source>
         <translation type="unfinished">Cosinus</translation>
     </message>
@@ -7498,38 +6107,31 @@ id=%2
 <context>
     <name>ScriptEditorUnaryOpPage</name>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorMathPage.cpp" line="391"/>
         <source>Increment (wrapped)</source>
         <translation>Incrémentation (cyclique)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorMathPage.cpp" line="392"/>
         <source>Increment (capped)</source>
         <translation>Incrémentation (plafonnée)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorMathPage.cpp" line="393"/>
         <source>Decrement (wrapped)</source>
         <translation>Décrémentation (cyclique)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorMathPage.cpp" line="394"/>
         <source>Decrement (capped)</source>
         <translation>Décrémentation (avec plancher à 0)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorMathPage.cpp" line="395"/>
         <source>Random</source>
         <translation>Aléatoire</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorMathPage.cpp" line="398"/>
         <source>8-bit</source>
         <oldsource>8 bits</oldsource>
         <translation>8 bits</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorMathPage.cpp" line="399"/>
         <source>16-bit</source>
         <oldsource>16 bits</oldsource>
         <translation>16 bits</translation>
@@ -7538,7 +6140,6 @@ id=%2
 <context>
     <name>ScriptEditorWaitPage</name>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorStructPage.cpp" line="841"/>
         <source>Images</source>
         <translation>Images</translation>
     </message>
@@ -7546,43 +6147,35 @@ id=%2
 <context>
     <name>ScriptEditorWindowModePage</name>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorWindowPage.cpp" line="270"/>
         <source>Normal</source>
         <translation>Normale</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorWindowPage.cpp" line="271"/>
         <source>Without frame</source>
         <translation>Sans bords</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorWindowPage.cpp" line="275"/>
         <source>Allow</source>
         <translation>Autoriser</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorWindowPage.cpp" line="276"/>
         <source>Prevent</source>
         <translation>Empêcher</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorWindowPage.cpp" line="280"/>
         <source>Window ID</source>
         <translation>Fenêtre ID</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorWindowPage.cpp" line="284"/>
         <source>Closing</source>
         <translation>Fermeture</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorWindowPage.cpp" line="272"/>
         <source>Transparency</source>
         <oldsource>Transparent</oldsource>
         <translation>Transparent</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorWindowPage.cpp" line="282"/>
         <source>Type</source>
         <translation>Type</translation>
     </message>
@@ -7590,18 +6183,15 @@ id=%2
 <context>
     <name>ScriptEditorWindowMovePage</name>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorWindowPage.cpp" line="354"/>
         <source>Window ID</source>
         <translation>Fenêtre ID</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorWindowPage.cpp" line="356"/>
         <source>Relative X</source>
         <oldsource>X relatif</oldsource>
         <translation>X relatif</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorWindowPage.cpp" line="358"/>
         <source>Relative Y</source>
         <oldsource>Y relatif</oldsource>
         <translation>Y relatif</translation>
@@ -7610,62 +6200,51 @@ id=%2
 <context>
     <name>ScriptEditorWindowPage</name>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorWindowPage.cpp" line="50"/>
         <source>Align horizontally</source>
         <oldsource>Aligner horizontalement</oldsource>
         <translation>Aligner horizontalement</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorWindowPage.cpp" line="51"/>
         <source>Align vertically</source>
         <oldsource>Aligner verticalement</oldsource>
         <translation>Aligner verticalement</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorWindowPage.cpp" line="43"/>
         <source>[Keep empty window]</source>
         <translation>[Laisser la fenêtre vide]</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorWindowPage.cpp" line="52"/>
         <source>Autosize</source>
         <translation>Taille automatique</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorWindowPage.cpp" line="57"/>
         <source>Window ID</source>
         <translation>Fenêtre ID</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorWindowPage.cpp" line="133"/>
         <source>X</source>
         <translation>X</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorWindowPage.cpp" line="61"/>
         <source>Y</source>
         <translation>Y</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorWindowPage.cpp" line="63"/>
         <source>W</source>
         <oldsource>L</oldsource>
         <translation>L</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorWindowPage.cpp" line="67"/>
         <source>Text in preview:</source>
         <oldsource>Texte en aperçu :</oldsource>
         <translation>Texte en aperçu :</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorWindowPage.cpp" line="116"/>
         <source>Lines</source>
         <oldsource>Lignes</oldsource>
         <translation>Lignes</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorWindowPage.cpp" line="65"/>
         <source>H</source>
         <translation>H</translation>
     </message>
@@ -7681,17 +6260,14 @@ id=%2
         <translation type="obsolete">16 bits</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorWindowPage.cpp" line="414"/>
         <source>Window ID</source>
         <translation type="unfinished">Fenêtre ID</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorWindowPage.cpp" line="416"/>
         <source>Window Variable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorWindowPage.cpp" line="418"/>
         <source>Value</source>
         <translation type="unfinished">Valeur</translation>
     </message>
@@ -7699,7 +6275,6 @@ id=%2
 <context>
     <name>ScriptEditorWithPriorityPage</name>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorStructPage.cpp" line="31"/>
         <source>Lower priority number is higher priority in the game</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7707,7 +6282,6 @@ id=%2
 <context>
     <name>ScriptManager</name>
     <message>
-        <location filename="../src/widgets/ScriptManager.cpp" line="197"/>
         <source>Error on line %1 : %2</source>
         <oldsource>Erreur ligne %1 : %2</oldsource>
         <translation>Erreur ligne %1 : %2</translation>
@@ -7716,159 +6290,124 @@ id=%2
 <context>
     <name>Search</name>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="33"/>
         <source>Scripts</source>
         <translation>Scripts</translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="34"/>
         <source>Texts</source>
         <oldsource>Textes</oldsource>
         <translation>Textes</translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="106"/>
         <source>Text</source>
         <oldsource>Texte</oldsource>
         <translation>Texte</translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="107"/>
         <source>Variable</source>
         <translation>Variable</translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="108"/>
         <source>Opcode</source>
         <translation>Opcode</translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="122"/>
-        <location filename="../src/widgets/Search.cpp" line="306"/>
         <source>Regular expression</source>
         <oldsource>Utiliser les expressions régulières</oldsource>
         <translation>Utiliser les expressions régulières</translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="160"/>
         <source>Var</source>
         <translation>Var</translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="176"/>
-        <location filename="../src/widgets/Search.cpp" line="450"/>
         <source>Value</source>
         <oldsource>Valeur</oldsource>
         <translation>Valeur</translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="180"/>
         <source>Test</source>
         <translation>Test</translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="181"/>
         <source>Bit test</source>
         <oldsource>Test bit</oldsource>
         <translation>Test bit</translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="215"/>
         <source>Script</source>
         <translation>Script</translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="217"/>
         <source>Group</source>
         <oldsource>Groupe</oldsource>
         <translation>Groupe</translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="30"/>
-        <location filename="../src/widgets/Search.cpp" line="119"/>
-        <location filename="../src/widgets/Search.cpp" line="296"/>
         <source>Find</source>
         <translation>Rechercher</translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="38"/>
         <source>Find next</source>
         <translation>Chercher le suivant</translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="39"/>
         <source>Find previous</source>
         <translation>Chercher le précédent</translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="40"/>
         <source>Find all</source>
         <translation>Chercher tout</translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="109"/>
         <source>Run</source>
         <translation>Exec</translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="110"/>
         <source>Map jump</source>
         <translation>Saut d&apos;écran</translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="121"/>
-        <location filename="../src/widgets/Search.cpp" line="305"/>
         <source>Match case</source>
         <translation>Sensible à la casse</translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="177"/>
         <source>All</source>
         <translation>Tout</translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="178"/>
         <source>Assignment</source>
         <translation>Affectation</translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="179"/>
         <source>Bit Assignment</source>
         <translation>Affectation Bit</translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="182"/>
         <source>Assignment ≠</source>
         <translation>Affectation ≠</translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="183"/>
         <source>Assignment &lt;</source>
         <translation>Affectation &lt;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="184"/>
         <source>Assignment ≤</source>
         <translation>Affectation ≤</translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="185"/>
         <source>Assignment &gt;</source>
         <translation>Affectation &gt;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="186"/>
         <source>Assignment ≥</source>
         <translation>Affectation ≥</translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="240"/>
-        <location filename="../src/widgets/Search.cpp" line="309"/>
         <source>Scope</source>
         <translation>Contexte</translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="976"/>
         <source>%1 occurrences replaced.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7881,32 +6420,26 @@ id=%2
         <translation type="vanished">Uniquement l&apos;écran courant</translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="243"/>
         <source>Current group script</source>
         <oldsource>Uniquement le groupe courant</oldsource>
         <translation>Uniquement le groupe courant</translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="244"/>
         <source>Current script</source>
         <oldsource>Uniquement le script courant</oldsource>
         <translation>Uniquement le script courant</translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="301"/>
-        <location filename="../src/widgets/Search.cpp" line="302"/>
         <source>Replace</source>
         <oldsource>Remplacer</oldsource>
         <translation>Remplacer</translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="303"/>
         <source>Replace all</source>
         <oldsource>Remplacer tout</oldsource>
         <translation>Remplacer tout</translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="312"/>
         <source>Current text</source>
         <translation>Uniquement le texte courant</translation>
     </message>
@@ -7915,7 +6448,6 @@ id=%2
         <translation type="vanished">Dernier écran</translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="514"/>
         <source>Last opcode</source>
         <translation>Dernière instruction</translation>
     </message>
@@ -7924,83 +6456,67 @@ id=%2
         <translation type="vanished">Premier écran</translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="526"/>
         <source>First opcode</source>
         <translation>Première instruction</translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="597"/>
         <source>%1,
 continued from top.</source>
         <translation>%1,
 poursuite au début.</translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="717"/>
         <source>%1,
 chase at the end.</source>
         <translation>%1,
 poursuite à la fin.</translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="450"/>
         <source>Position</source>
         <translation>Position</translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="241"/>
-        <location filename="../src/widgets/Search.cpp" line="310"/>
         <source>All maps</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="242"/>
-        <location filename="../src/widgets/Search.cpp" line="311"/>
         <source>Current map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="511"/>
         <source>Last map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="512"/>
         <source>Last group</source>
         <oldsource>Dernier groupe</oldsource>
         <translation>Dernier groupe</translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="513"/>
         <source>Last script</source>
         <oldsource>Dernier script</oldsource>
         <translation>Dernier script</translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="515"/>
         <source>Last text</source>
         <oldsource>Dernier texte</oldsource>
         <translation>Dernier texte</translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="523"/>
         <source>First map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="524"/>
         <source>First group</source>
         <oldsource>Premier groupe</oldsource>
         <translation>Premier groupe</translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="525"/>
         <source>First script</source>
         <oldsource>Premier script</oldsource>
         <translation>Premier script</translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="527"/>
         <source>First text</source>
         <oldsource>Premier texte</oldsource>
         <translation>Premier texte</translation>
@@ -8009,45 +6525,37 @@ poursuite à la fin.</translation>
 <context>
     <name>SearchAll</name>
     <message>
-        <location filename="../src/widgets/SearchAll.cpp" line="26"/>
         <source>Find All</source>
         <translation>Rechercher tout</translation>
     </message>
     <message>
-        <location filename="../src/widgets/SearchAll.cpp" line="45"/>
         <source>Copy</source>
         <oldsource>Copier</oldsource>
         <translation>Copier</translation>
     </message>
     <message>
-        <location filename="../src/widgets/SearchAll.cpp" line="65"/>
         <source>Group</source>
         <oldsource>Groupe</oldsource>
         <translation>Groupe</translation>
     </message>
     <message>
-        <location filename="../src/widgets/SearchAll.cpp" line="65"/>
         <source>Script</source>
         <translation>Script</translation>
     </message>
     <message>
-        <location filename="../src/widgets/SearchAll.cpp" line="65"/>
         <source>Lines</source>
         <translation>Lignes</translation>
     </message>
     <message>
-        <location filename="../src/widgets/SearchAll.cpp" line="65"/>
         <source>Instruction</source>
         <translation>Commande</translation>
     </message>
     <message>
-        <location filename="../src/widgets/SearchAll.cpp" line="73"/>
         <source>Text #</source>
         <oldsource>Texte n°</oldsource>
         <translation>Texte n°</translation>
     </message>
     <message>
-        <location filename="../src/widgets/SearchAll.cpp" line="73"/>
         <source>Text</source>
         <translation>Texte</translation>
     </message>
@@ -8055,13 +6563,10 @@ poursuite à la fin.</translation>
 <context>
     <name>SpinBoxDelegate</name>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/Delegate.cpp" line="106"/>
-        <location filename="../src/widgets/ScriptEditorWidgets/Delegate.cpp" line="107"/>
         <source>(Empty)</source>
         <translation>(Vide)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/Delegate.cpp" line="222"/>
         <source>Choose a new color</source>
         <translation>Choisir une nouvelle couleur</translation>
     </message>
@@ -8069,214 +6574,174 @@ poursuite à la fin.</translation>
 <context>
     <name>TextManager</name>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="36"/>
         <source>Texts</source>
         <oldsource>Textes</oldsource>
         <translation>Textes</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="42"/>
         <source>Add text</source>
         <oldsource>Ajouter texte</oldsource>
         <translation>Ajouter texte</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="68"/>
         <source>Member 1</source>
         <oldsource>Membre 1</oldsource>
         <translation>Membre 1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="70"/>
         <source>Member 2</source>
         <oldsource>Membre 2</oldsource>
         <translation>Membre 2</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="72"/>
         <source>Member 3</source>
         <oldsource>Membre 3</oldsource>
         <translation>Membre 3</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="75"/>
         <source>New Page</source>
         <oldsource>Nouvelle page</oldsource>
         <translation>Nouvelle page</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="77"/>
         <source>Choice</source>
         <oldsource>Choix</oldsource>
         <translation>Choix</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="82"/>
         <source>Grey</source>
         <oldsource>Gris</oldsource>
         <translation>Gris</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="84"/>
         <source>Blue</source>
         <oldsource>Bleu</oldsource>
         <translation>Bleu</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="92"/>
         <source>Cyan</source>
         <translation>Cyan</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="38"/>
         <source>Show unused texts</source>
         <translation>Afficher les textes non utilisés</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="43"/>
         <source>Remove text</source>
         <translation>Supprimer texte</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="86"/>
         <source>Red</source>
         <translation>Rouge</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="88"/>
         <source>Purple</source>
         <translation>Violet</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="90"/>
         <source>Green</source>
         <translation>Vert</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="94"/>
         <source>Yellow</source>
         <translation>Jaune</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="96"/>
         <source>White</source>
         <translation>Blanc</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="98"/>
         <source>Blink</source>
         <translation>Clignotant</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="100"/>
         <source>Multicolor</source>
         <oldsource>Multicolore</oldsource>
         <translation>Multicolore</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="105"/>
         <source>Pause</source>
         <translation>Pause</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="107"/>
         <source>Pause 0</source>
         <translation>Pause 0</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="109"/>
         <source>Pause 5</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="111"/>
         <source>Pause 10</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="113"/>
         <source>Pause 15</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="115"/>
         <source>Pause 20</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="117"/>
         <source>Pause 30</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="119"/>
         <source>Pause 40</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="121"/>
         <source>Pause 50</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="123"/>
         <source>Pause 60</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="125"/>
         <source>Pauses</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="131"/>
         <source>Var10</source>
         <translation>Var10</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="133"/>
         <source>Var16</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="135"/>
         <source>Var10r</source>
         <oldsource>Var10d</oldsource>
         <translation>Var10d</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="137"/>
         <source>Vars</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="143"/>
         <source>Circle</source>
         <oldsource>Cercle</oldsource>
         <translation>Cercle</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="145"/>
         <source>Triangle</source>
         <translation>Triangle</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="147"/>
         <source>Square</source>
         <translation>Carré</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="151"/>
         <source>Keys</source>
         <translation>Touches</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="164"/>
         <source>Others</source>
         <translation>Autres</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="549"/>
         <source>Window %1/%2</source>
         <oldsource>Fenêtre %1/%2</oldsource>
         <translation>Fenêtre %1/%2</translation>
@@ -8290,83 +6755,68 @@ Le supprimer remplacera les appels à ce texte par des appels au texte qui suit.
 Êtes-vous sûr de vouloir continuer ?</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="149"/>
         <source>Cross</source>
         <oldsource>Croix</oldsource>
         <translation>Croix</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="156"/>
         <source>Scrolling</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="158"/>
         <source>Spaced characters</source>
         <oldsource>Caractères espacés</oldsource>
         <translation>Caractères espacés</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="160"/>
         <source>Memory access</source>
         <oldsource>Accès mémoire</oldsource>
         <translation>Accès mémoire</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="162"/>
         <source>New Page²</source>
         <oldsource>Nouvelle page²</oldsource>
         <translation>Nouvelle page²</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="209"/>
         <source>Align horizontally</source>
         <translation>Aligner horizontalement</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="210"/>
         <source>Align vertically</source>
         <translation>Aligner verticalement</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="211"/>
         <source>Autosize</source>
         <translation>Taille automatique</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="220"/>
         <source>X</source>
         <translation>X</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="221"/>
         <source>Y</source>
         <translation>Y</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="222"/>
         <source>W</source>
         <translation>L</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="223"/>
         <source>H</source>
         <translation>H</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="387"/>
         <source>Text %1</source>
         <oldsource>Texte %1</oldsource>
         <translation>Texte %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="496"/>
         <source>Text used in scripts</source>
         <oldsource>Texte utilisé dans les script</oldsource>
         <translation>Texte utilisé dans les script</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="496"/>
         <source>This text is used by one or more scripts on this field.
 Removing this text may break scripts that reference it.
 Are you sure you want to continue?</source>
@@ -8375,7 +6825,6 @@ Le supprimer remplacera les appels à ce texte par des appels au texte qui suit.
 Êtes-vous sûr de vouloir continuer ?</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="527"/>
         <source>Page %1/%2</source>
         <translation>Page %1/%2</translation>
     </message>
@@ -8383,19 +6832,16 @@ Le supprimer remplacera les appels à ce texte par des appels au texte qui suit.
 <context>
     <name>TextPreview</name>
     <message>
-        <location filename="../src/widgets/TextPreview.cpp" line="57"/>
         <source>Member 1</source>
         <oldsource>Membre 1</oldsource>
         <translation>Membre 1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextPreview.cpp" line="58"/>
         <source>Member 2</source>
         <oldsource>Membre 2</oldsource>
         <translation>Membre 2</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextPreview.cpp" line="59"/>
         <source>Member 3</source>
         <oldsource>Membre 3</oldsource>
         <translation>Membre 3</translation>
@@ -8404,131 +6850,104 @@ Le supprimer remplacera les appels à ce texte par des appels au texte qui suit.
 <context>
     <name>TutWidget</name>
     <message>
-        <location filename="../src/widgets/TutWidget.cpp" line="28"/>
         <source>Tutorials/Sounds</source>
         <oldsource>Tutoriels/Musiques</oldsource>
         <translation>Tutoriels/Musiques</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TutWidget.cpp" line="31"/>
         <source>Add</source>
         <translation>Ajouter</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TutWidget.cpp" line="32"/>
         <source>Remove</source>
         <translation>Supprimer</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TutWidget.cpp" line="46"/>
         <source>Export...</source>
         <oldsource>Exporter...</oldsource>
         <translation>Exporter...</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TutWidget.cpp" line="47"/>
         <source>Import...</source>
         <oldsource>Importer...</oldsource>
         <translation>Importer...</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TutWidget.cpp" line="54"/>
         <source>PlayStation</source>
         <translation>PlayStation</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TutWidget.cpp" line="55"/>
         <source>PC</source>
         <translation>PC</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TutWidget.cpp" line="132"/>
         <source>%1 - %2 : %3</source>
         <translation>%1 - %2 : %3</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TutWidget.cpp" line="145"/>
         <source>Music ID:</source>
         <oldsource>ID musique :</oldsource>
         <translation>ID musique :</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TutWidget.cpp" line="158"/>
         <source>Repair</source>
         <translation>Réparer</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TutWidget.cpp" line="159"/>
         <source>Replace by empty AKAO</source>
         <translation>Remplacer par un AKAO vide</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TutWidget.cpp" line="160"/>
         <source>Replace by empty tuto</source>
         <translation>Remplacer par un tuto vide</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TutWidget.cpp" line="163"/>
         <source>There is an error</source>
         <translation>Quelque chose ne tourne pas rond</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TutWidget.cpp" line="217"/>
         <source>Broken %1</source>
         <translation>Cassé %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TutWidget.cpp" line="219"/>
         <source>Tuto %1</source>
         <translation>Tuto %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TutWidget.cpp" line="221"/>
         <source>Music %1</source>
         <oldsource>Musique %1</oldsource>
         <translation>Musique %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TutWidget.cpp" line="333"/>
         <source>Tutorial</source>
         <oldsource>Tutoriel</oldsource>
         <translation>Tutoriel</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TutWidget.cpp" line="334"/>
         <source>Music</source>
         <oldsource>Musique</oldsource>
         <translation>Musique</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TutWidget.cpp" line="351"/>
-        <location filename="../src/widgets/TutWidget.cpp" line="547"/>
         <source>Import</source>
         <oldsource>Importer</oldsource>
         <translation>Importer</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TutWidget.cpp" line="351"/>
-        <location filename="../src/widgets/TutWidget.cpp" line="543"/>
         <source>sound_%1.akao</source>
         <translation>son_%1.akao</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TutWidget.cpp" line="351"/>
-        <location filename="../src/widgets/TutWidget.cpp" line="490"/>
-        <location filename="../src/widgets/TutWidget.cpp" line="544"/>
         <source>Final Fantasy Sound (*.akao)</source>
         <translation>Son Final Fantasy (*.akao)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TutWidget.cpp" line="358"/>
         <source>Insert a tutorial here will shift the IDs of the tutorials that follows, this may be a problem.
 Are you sure you want to continue?</source>
         <translation>Insérer un tutoriel ici va décaler les identifiants des tutoriels qui suit, cela risque de poser problème.
 Êtes-vous sûr de vouloir continuer ?</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TutWidget.cpp" line="385"/>
         <source>This tutorial may be used by one or more scripts on this field.
 Delete can cause errors.
 Are you sure you want to continue?</source>
@@ -8537,7 +6956,6 @@ Le supprimer peut provoquer des erreurs.
 Êtes-vous sûr de vouloir continuer ?</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TutWidget.cpp" line="385"/>
         <source>This tutorial is used by one or more scripts on this field.
 Remove will replace calls to this tutorial with calls to the tutorial that follows.
 Are you sure you want to continue?</source>
@@ -8546,59 +6964,44 @@ Le supprimer remplacera les appels à ce tutoriel par des appels au tutoriel qui
 Êtes-vous sûr de vouloir continuer ?</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TutWidget.cpp" line="491"/>
         <source>PSF MIDI file (*.minipsf)</source>
         <translation>PSF MIDI file (*.minipsf)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TutWidget.cpp" line="497"/>
         <source>%1.akao</source>
         <translation>%1.akao</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TutWidget.cpp" line="512"/>
-        <location filename="../src/widgets/TutWidget.cpp" line="557"/>
-        <location filename="../src/widgets/TutWidget.cpp" line="562"/>
         <source>Error</source>
         <oldsource>Opening error</oldsource>
         <translation>Erreur</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TutWidget.cpp" line="512"/>
         <source>Opening error file</source>
         <translation>Erreur d&apos;ouverture du fichier</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TutWidget.cpp" line="557"/>
         <source>Opening Error File</source>
         <translation>Erreur d&apos;ouverture du fichier</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TutWidget.cpp" line="562"/>
         <source>File too large</source>
         <translation>Fichier trop gros</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TutWidget.cpp" line="358"/>
-        <location filename="../src/widgets/TutWidget.cpp" line="385"/>
         <source>Tutorial used in scripts</source>
         <oldsource>Tutoriel utilisé dans les script</oldsource>
         <translation>Tutoriel utilisé dans les script</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TutWidget.cpp" line="494"/>
-        <location filename="../src/widgets/TutWidget.cpp" line="540"/>
         <source>tuto_%1.tutps</source>
         <translation>tuto_%1.tutps</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TutWidget.cpp" line="495"/>
-        <location filename="../src/widgets/TutWidget.cpp" line="541"/>
         <source>Tuto Final Fantasy VII PS (*.tutps)</source>
         <translation>Tuto Final Fantasy VII PS (*.tutps)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TutWidget.cpp" line="501"/>
         <source>Export</source>
         <oldsource>Exporter</oldsource>
         <translation>Exporter</translation>
@@ -8607,112 +7010,92 @@ Le supprimer remplacera les appels à ce tutoriel par des appels au tutoriel qui
 <context>
     <name>VarManager</name>
     <message>
-        <location filename="../src/widgets/VarManager.cpp" line="25"/>
         <source>Variable manager</source>
         <oldsource>Gestionnaire de variables</oldsource>
         <translation>Gestionnaire de variables</translation>
     </message>
     <message>
-        <location filename="../src/widgets/VarManager.cpp" line="35"/>
         <source>Rename</source>
         <oldsource>Renommer</oldsource>
         <translation>Renommer</translation>
     </message>
     <message>
-        <location filename="../src/widgets/VarManager.cpp" line="51"/>
         <source>Address</source>
         <oldsource>Adresse</oldsource>
         <translation>Adresse</translation>
     </message>
     <message>
-        <location filename="../src/widgets/VarManager.cpp" line="74"/>
         <source>Addresses Used</source>
         <oldsource>Adresses utilisées</oldsource>
         <translation>Adresses utilisées</translation>
     </message>
     <message>
-        <location filename="../src/widgets/VarManager.cpp" line="264"/>
         <source>Error</source>
         <oldsource>Erreur</oldsource>
         <translation>Erreur</translation>
     </message>
     <message>
-        <location filename="../src/widgets/VarManager.cpp" line="272"/>
         <source>Searching</source>
         <oldsource>Recherche</oldsource>
         <translation>Recherche</translation>
     </message>
     <message>
-        <location filename="../src/widgets/VarManager.cpp" line="51"/>
         <source>Nickname</source>
         <translation>Surnom</translation>
     </message>
     <message>
-        <location filename="../src/widgets/VarManager.cpp" line="51"/>
         <source>Operation</source>
         <translation>Opération</translation>
     </message>
     <message>
-        <location filename="../src/widgets/VarManager.cpp" line="51"/>
         <source>Size</source>
         <translation>Taille</translation>
     </message>
     <message>
-        <location filename="../src/widgets/VarManager.cpp" line="61"/>
         <source>Var banks 08, 09 and 10 are temporary and do not appear in the game save. &lt;br/&gt;Other banks are stored in pair: for example 01-02 is in the same memory location, but the first is used to store 8-bit values and the second is used to store 16-bit values.</source>
         <translation>Les banks de variable 08, 09 et 10 sont temporaires et n&apos;apparaissent pas dans les sauvegardes du jeu. &lt;br/&gt;Les autres banks sont stockés par paires : par exemple 01-02 représentent le même emplacement mémoire, mais le premier est utilisé pour stocker des valeurs sur 8 bits et le second est utilisé pour stocker des valeurs sur 16 bits.</translation>
     </message>
     <message>
-        <location filename="../src/widgets/VarManager.cpp" line="75"/>
         <source>Save</source>
         <translation>Enregistrer</translation>
     </message>
     <message>
-        <location filename="../src/widgets/VarManager.cpp" line="264"/>
         <source>Save Failed</source>
         <translation>Fichier vars.cfg inaccessible.
 Échec de l&apos;enregistrement.</translation>
     </message>
     <message>
-        <location filename="../src/widgets/VarManager.cpp" line="272"/>
         <source>Searching, it may take a minute...</source>
         <translation>Recherche des variables en cours, cela peut prendre une minute...</translation>
     </message>
     <message>
-        <location filename="../src/widgets/VarManager.cpp" line="333"/>
         <source>rw</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/widgets/VarManager.cpp" line="335"/>
         <source>r</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/widgets/VarManager.cpp" line="337"/>
         <source>w</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/widgets/VarManager.cpp" line="340"/>
         <source>bitfield</source>
         <oldsource>bits</oldsource>
         <translation>bits</translation>
     </message>
     <message>
-        <location filename="../src/widgets/VarManager.cpp" line="343"/>
         <source>1 Byte</source>
         <oldsource>1 octet</oldsource>
         <translation>1 octet</translation>
     </message>
     <message>
-        <location filename="../src/widgets/VarManager.cpp" line="346"/>
         <source>2 Bytes</source>
         <oldsource>2 octets</oldsource>
         <translation>2 octets</translation>
     </message>
     <message>
-        <location filename="../src/widgets/VarManager.cpp" line="349"/>
         <source>2 Signed Bytes</source>
         <oldsource>2 octets signés</oldsource>
         <translation>2 octets signés</translation>
@@ -8721,18 +7104,15 @@ Le supprimer remplacera les appels à ce tutoriel par des appels au tutoriel qui
 <context>
     <name>VarOrValueWidget</name>
     <message>
-        <location filename="../src/widgets/VarOrValueWidget.cpp" line="229"/>
         <source>Value</source>
         <oldsource>Valeur</oldsource>
         <translation>Valeur</translation>
     </message>
     <message>
-        <location filename="../src/widgets/VarOrValueWidget.cpp" line="233"/>
         <source>8-bit Var</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/VarOrValueWidget.cpp" line="237"/>
         <source>16-bit Var</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8744,17 +7124,14 @@ Le supprimer remplacera les appels à ce tutoriel par des appels au tutoriel qui
 <context>
     <name>VertexWidget</name>
     <message>
-        <location filename="../src/widgets/VertexWidget.cpp" line="43"/>
         <source>X</source>
         <translation>X</translation>
     </message>
     <message>
-        <location filename="../src/widgets/VertexWidget.cpp" line="45"/>
         <source>Y</source>
         <translation>Y</translation>
     </message>
     <message>
-        <location filename="../src/widgets/VertexWidget.cpp" line="47"/>
         <source>Z</source>
         <translation>Z</translation>
     </message>
@@ -8762,199 +7139,157 @@ Le supprimer remplacera les appels à ce tutoriel par des appels au tutoriel qui
 <context>
     <name>WalkmeshManager</name>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="56"/>
         <source>Camera</source>
         <oldsource>Caméra</oldsource>
         <translation>Caméra</translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="26"/>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="57"/>
         <source>Walkmesh</source>
         <translation>Walkmesh</translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="104"/>
         <source>Add camera</source>
         <oldsource>Ajouter caméra</oldsource>
         <translation>Ajouter caméra</translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="105"/>
         <source>Remove camera</source>
         <oldsource>Supprimer caméra</oldsource>
         <translation>Supprimer caméra</translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="43"/>
         <source>Use the arrow keys to move the camera.</source>
         <translation>Utilisez les touches directionnelles pour déplacer la caméra.</translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="47"/>
         <source>Reset Camera</source>
         <oldsource>Reset</oldsource>
         <translation>Remettre à 0</translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="49"/>
         <source>Show 3D models</source>
         <translation>Afficher modèles</translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="52"/>
         <source>Show Background</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="58"/>
         <source>Gateways</source>
         <translation>Sorties</translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="59"/>
         <source>Doors</source>
         <translation>Portes</translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="60"/>
         <source>Arrows</source>
         <translation>Flèches</translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="61"/>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="378"/>
         <source>Camera range</source>
         <translation>Limites caméra</translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="62"/>
         <source>Miscellaneous</source>
         <translation>Divers</translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="130"/>
         <source>Zoom:</source>
         <translation>Distance (zoom) :</translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="132"/>
         <source>Camera axis:</source>
         <oldsource>Axes de la caméra :</oldsource>
         <translation>Axes de la caméra :</translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="136"/>
         <source>Camera position:</source>
         <oldsource>Position de la caméra :</oldsource>
         <translation>Position de la caméra :</translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="137"/>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="348"/>
         <source>X</source>
         <translation>X</translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="139"/>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="350"/>
         <source>Y</source>
         <translation>Y</translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="141"/>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="352"/>
         <source>Z</source>
         <translation>Z</translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="168"/>
         <source>Add triangle</source>
         <oldsource>Ajouter triangle</oldsource>
         <translation>Ajouter triangle</translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="169"/>
         <source>Remove triangle</source>
         <oldsource>Supprimer triangle</oldsource>
         <translation>Supprimer triangle</translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="187"/>
         <source>Triangle accessible via the line 1-2 :</source>
         <oldsource>Triangle accessible via la ligne 1-2 :</oldsource>
         <translation>Triangle accessible via la ligne 1-2 :</translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="191"/>
         <source>Triangle accessible via the line 2-3 :</source>
         <oldsource>Triangle accessible via la ligne 2-3 :</oldsource>
         <translation>Triangle accessible via la ligne 2-3 :</translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="195"/>
         <source>Triangle accessible via the line 3-1 :</source>
         <oldsource>Triangle accessible via la ligne 3-1 :</oldsource>
         <translation>Triangle accessible via la ligne 3-1 :</translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="200"/>
         <source>Point 1 :</source>
         <translation>Point 1 :</translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="202"/>
         <source>Point 2 :</source>
         <translation>Point 2 :</translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="204"/>
         <source>Point 3 :</source>
         <translation>Point 3 :</translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="229"/>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="278"/>
         <source>Enable</source>
         <translation>Activer</translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="233"/>
         <source>T</source>
         <translation>T</translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="241"/>
         <source>Show an arrow</source>
         <translation>Afficher une flèche</translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="247"/>
         <source>Exit line:</source>
         <translation>Ligne de sortie :</translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="298"/>
         <source>Background state ID:</source>
         <translation>Id état décor :</translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="300"/>
         <source>Behavior:</source>
         <translation>Comportement :</translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="308"/>
         <source>Trigger Line Door:</source>
         <translation>Ligne déclench. porte :</translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="344"/>
         <source>Red</source>
         <translation>Rouge</translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="345"/>
         <source>Green</source>
         <translation>Vert</translation>
     </message>
@@ -8967,57 +7302,46 @@ Le supprimer remplacera les appels à ce tutoriel par des appels au tutoriel qui
         <translation type="vanished">Bas</translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="395"/>
         <source>Right</source>
         <translation>Droite</translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="397"/>
         <source>Left</source>
         <translation>Gauche</translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="407"/>
         <source>Background layer 3 height</source>
         <translation>Hauteur couche 3 décor</translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="409"/>
         <source>Background layer 4 width</source>
         <translation>Largeur couche 4 décor</translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="411"/>
         <source>Background layer 4 height</source>
         <translation>Hauteur couche 4 décor</translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="420"/>
         <source>Layer 1</source>
         <translation>Couche 1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="422"/>
         <source>Layer 2</source>
         <translation>Couche 2</translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="424"/>
         <source>Layer 3</source>
         <translation>Couche 3</translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="426"/>
         <source>Layer 4</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="468"/>
         <source>Unknown:</source>
         <translation>Inconnu :</translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="470"/>
         <source>Field map scale:</source>
         <oldsource>Field scale:</oldsource>
         <translation>Zoom écran :</translation>
@@ -9031,134 +7355,100 @@ Le supprimer remplacera les appels à ce tutoriel par des appels au tutoriel qui
         <translation type="vanished">Erreur d&apos;ouverture du walkmesh</translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="250"/>
         <source>Destination point:</source>
         <oldsource>Point de destination :</oldsource>
         <translation>Point de destination :</translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="252"/>
         <source>Character orientation:</source>
         <oldsource>Orientation du perso. :</oldsource>
         <translation>Orientation du perso. :</translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="254"/>
         <source>Field ID:</source>
         <oldsource>Id écran :</oldsource>
         <translation>Id écran :</translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="296"/>
         <source>Background parameter ID:</source>
         <oldsource>Id parametre décor :</oldsource>
         <translation>Id parametre décor :</translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="302"/>
         <source>Sound ID:</source>
         <oldsource>Id son :</oldsource>
         <translation>Id son :</translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="343"/>
         <source>Invisible</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="358"/>
         <source>Position:</source>
         <oldsource>Position :</oldsource>
         <translation>Position :</translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="359"/>
         <source>Type:</source>
         <oldsource>Type :</oldsource>
         <translation>Type :</translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="379"/>
         <source>Layer sizes (for layer animations)</source>
         <oldsource>Tailles des couches (pour les animations de couche)</oldsource>
         <translation>Tailles des couches (pour les animations de couche)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="380"/>
         <source>Layer flags</source>
         <oldsource>Flags couches</oldsource>
         <translation>Flags couches</translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="391"/>
         <source>Top</source>
         <translation>Haut</translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="393"/>
         <source>Bottom</source>
         <translation>Bas</translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="405"/>
         <source>Background layer 3 width</source>
         <oldsource>Largeur couche 3 décor</oldsource>
         <translation>Largeur couche 3 décor</translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="463"/>
         <source>Movements orientation:</source>
         <oldsource>Orientation des mouvements :</oldsource>
         <translation>Orientation des mouvements :</translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="466"/>
         <source>Camera Focus Height on the playable character:</source>
         <oldsource>Hauteur focus caméra sur le personnage :</oldsource>
         <translation>Hauteur focus caméra sur le personnage :</translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="513"/>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="715"/>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="717"/>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="737"/>
         <source>Camera %1</source>
         <oldsource>Caméra %1</oldsource>
         <translation>Caméra %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="529"/>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="862"/>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="864"/>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="884"/>
         <source>Triangle %1</source>
         <translation>Triangle %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="556"/>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="1244"/>
         <source>Door %1</source>
         <oldsource>Porte %1</oldsource>
         <translation>Porte %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="544"/>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="558"/>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="574"/>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="1188"/>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="1248"/>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="1372"/>
         <source>Unused</source>
         <translation>Inutilisé</translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="572"/>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="1368"/>
         <source>Arrow %1</source>
         <translation>Flèche %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="1049"/>
         <source>?</source>
         <translation>?</translation>
     </message>
@@ -9166,13 +7456,11 @@ Le supprimer remplacera les appels à ce tutoriel par des appels au tutoriel qui
 <context>
     <name>Window</name>
     <message>
-        <location filename="../src/Window.cpp" line="61"/>
         <source>&amp;File</source>
         <oldsource>&amp;Fichier</oldsource>
         <translation>&amp;Fichier</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="63"/>
         <source>&amp;Open...</source>
         <oldsource>&amp;Ouvrir...</oldsource>
         <translation>&amp;Ouvrir...</translation>
@@ -9183,7 +7471,6 @@ Le supprimer remplacera les appels à ce tutoriel par des appels au tutoriel qui
         <translation type="vanished">&amp;Exporter l&apos;écran courant...</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="72"/>
         <source>&amp;Mass Export...</source>
         <oldsource>Exporter en &amp;masse...</oldsource>
         <translation>Exporter en &amp;masse...</translation>
@@ -9194,27 +7481,21 @@ Le supprimer remplacera les appels à ce tutoriel par des appels au tutoriel qui
         <translation type="vanished">&amp;Importer dans l&apos;écran courant...</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="75"/>
-        <location filename="../src/Window.cpp" line="422"/>
-        <location filename="../src/Window.cpp" line="1624"/>
         <source>Archive Mana&amp;ger...</source>
         <oldsource>Ges&amp;tionnaire d&apos;archive...</oldsource>
         <translation>Ges&amp;tionnaire d&apos;archive...</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="77"/>
         <source>R&amp;un FF7</source>
         <oldsource>Run FF7</oldsource>
         <translation>&amp;Lancer FF7</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="86"/>
         <source>T&amp;ools</source>
         <oldsource>&amp;Outils</oldsource>
         <translation>&amp;Outils</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="87"/>
         <source>&amp;Texts...</source>
         <oldsource>&amp;Textes...</oldsource>
         <translation>&amp;Textes...</translation>
@@ -9225,18 +7506,15 @@ Le supprimer remplacera les appels à ce tutoriel par des appels au tutoriel qui
         <translation type="vanished">&amp;Modèles 3D...</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="90"/>
         <source>Tutorials/&amp;Sounds...</source>
         <oldsource>T&amp;utoriels/Musiques...</oldsource>
         <translation>T&amp;utoriels/Musiques...</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="92"/>
         <source>&amp;Background...</source>
         <translation>&amp;Background...</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="95"/>
         <source>Variable Mana&amp;ger...</source>
         <oldsource>&amp;Gestionnaire de variables...</oldsource>
         <translation>&amp;Gestionnaire de variables...</translation>
@@ -9247,169 +7525,134 @@ Le supprimer remplacera les appels à ce tutoriel par des appels au tutoriel qui
         <translation type="vanished">Opér&amp;ations diverses...</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="102"/>
         <source>&amp;Japanese Characters</source>
         <oldsource>Caractères &amp;japonais</oldsource>
         <translation>Caractères &amp;japonais</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="106"/>
         <source>&amp;Language</source>
         <oldsource>&amp;Langues</oldsource>
         <translation>&amp;Langues</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="109"/>
         <source>English (default)</source>
         <oldsource>Français (défaut)</oldsource>
         <translation>English (défaut)</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="131"/>
         <source>&amp;Configuration...</source>
         <translation>&amp;Configuration...</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="371"/>
         <source>Restart the program for the settings to take effect.</source>
         <oldsource>Relancez le programme pour que les paramètres prennent effet.</oldsource>
         <translation>Relancez le programme pour que les paramètres prennent effet.</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="64"/>
         <source>Open &amp;Directory...</source>
         <translation>Ouvrir un &amp;dossier...</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="65"/>
         <source>&amp;Recent files</source>
         <translation>Fichiers ré&amp;cents</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="69"/>
         <source>&amp;Save</source>
         <translation>Enregi&amp;strer</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="70"/>
         <source>Save &amp;As...</source>
         <translation>Enre&amp;gistrer Sous...</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="71"/>
         <source>&amp;Export the current map...</source>
         <translation>&amp;Exporter l&apos;écran courant...</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="73"/>
         <source>&amp;Import to current map...</source>
         <translation>&amp;Importer dans l&apos;écran courant...</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="82"/>
         <source>C&amp;lose</source>
         <translation>Fe&amp;rmer</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="83"/>
         <source>E&amp;xit</source>
         <translation>&amp;Quitter</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="88"/>
         <source>Map &amp;Models...</source>
         <translation>&amp;Modèles 3D...</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="89"/>
         <source>Encounte&amp;rs...</source>
         <translation>&amp;Rencontres aléatoires...</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="91"/>
         <source>&amp;Walkmesh...</source>
         <translation>&amp;Zones...</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="93"/>
         <source>M&amp;iscellaneous...</source>
         <translation>&amp;Divers...</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="96"/>
         <source>&amp;Find...</source>
         <translation>Rec&amp;hercher...</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="97"/>
         <source>B&amp;atch processing...</source>
         <translation>Tr&amp;aitement par lot...</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="100"/>
         <source>&amp;Settings</source>
         <translation>&amp;Paramètres</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="118"/>
         <source>English</source>
         <translation>Français</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="140"/>
         <source>Main &amp;toolbar</source>
         <translation>Barre d&apos;outils &amp;principale</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="145"/>
-        <location filename="../src/Window.cpp" line="496"/>
         <source>Open a file</source>
         <translation>Ouvrir un fichier</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="147"/>
-        <location filename="../src/Window.cpp" line="405"/>
         <source>Save</source>
         <translation>Sauvegarder</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="150"/>
         <source>Find</source>
         <translation>Rechercher</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="154"/>
         <source>Text editor</source>
         <translation>Editeur de texte</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="156"/>
         <source>Model loader editor</source>
         <translation>Liste des modèles 3D</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="160"/>
         <source>Walkmesh editor</source>
         <translation>Walkmesh</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="225"/>
-        <location filename="../src/Window.cpp" line="227"/>
         <source>&amp;?</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="298"/>
         <source>&amp;View</source>
         <translation>&amp;Affichage</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="1204"/>
         <source>Uncompressed PC Field Map (*.dec)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="1355"/>
         <source>PS Field Map (*.DAT)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9418,17 +7661,14 @@ Le supprimer remplacera les appels à ce tutoriel par des appels au tutoriel qui
         <translation type="vanished">Liste des écrans</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="304"/>
         <source>Background Preview</source>
         <translation>Aperçu décor</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="370"/>
         <source>Settings changed</source>
         <translation>Paramètres modifiés</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="403"/>
         <source>
 
 Edited files:</source>
@@ -9437,25 +7677,20 @@ Edited files:</source>
 Fichiers modifiés :</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="405"/>
         <source>Would you like to save changes of %1?%2</source>
         <translation>Voulez-vous enregistrer les changements de %1 ?%2</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="488"/>
         <source>Compatible Files (*.lgp *.DAT *.bin *.iso *.img)</source>
         <oldsource>Fichiers compatibles (*.lgp *.DAT *.bin *.iso *.img)</oldsource>
         <translation>Fichiers compatibles (*.lgp *.DAT *.bin *.iso *.img)</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="489"/>
         <source>Lgp Files (*.lgp)</source>
         <oldsource>Fichiers Lgp (*.lgp)</oldsource>
         <translation>Fichiers Lgp (*.lgp)</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="490"/>
-        <location filename="../src/Window.cpp" line="1063"/>
         <source>DAT File (*.DAT)</source>
         <oldsource>Fichier DAT (*.DAT)</oldsource>
         <translation>Fichier DAT (*.DAT)</translation>
@@ -9466,25 +7701,21 @@ Fichiers modifiés :</translation>
         <translation type="vanished">Fichier Field PC (*)</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="492"/>
         <source>Disc Image (*.bin *.iso *.img)</source>
         <oldsource>Image disque (*.bin *.iso *.img)</oldsource>
         <translation>Image disque (*.bin *.iso *.img)</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="546"/>
         <source>Select a folder containing the Final Fantasy VII field files</source>
         <oldsource>Sélectionnez un dossier contenant des fichiers field issus de Final Fantasy VII</oldsource>
         <translation>Sélectionnez un dossier contenant des fichiers field issus de Final Fantasy VII</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="554"/>
         <source>File Type</source>
         <oldsource>Type de fichiers</oldsource>
         <translation>Type de fichiers</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="555"/>
         <source>What type of file to look for?
  - Playstation field files (&quot;EXAMPLE.DAT&quot;)
  - PC Field File (&quot;example&quot;)
@@ -9498,37 +7729,30 @@ Fichiers modifiés :</translation>
  - Les fichiers field PC (&quot;exemple&quot;)</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="559"/>
         <source>PS</source>
         <translation>PS</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="560"/>
         <source>PC</source>
         <translation>PC</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="600"/>
         <source>Cancel</source>
         <translation>Annuler</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="600"/>
         <source>Stop</source>
         <translation>Arrêter</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="629"/>
         <source>Opening...</source>
         <translation>Ouverture...</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="648"/>
         <source>Nothing found!</source>
         <translation>Rien trouvé !</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="652"/>
         <source>The file already exists</source>
         <translation>Le fichier existe déjà</translation>
     </message>
@@ -9545,96 +7769,76 @@ Fichiers modifiés :</translation>
         <translation type="vanished">Impossible de copier le fichier</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="673"/>
         <source>This error should not appear, thank you for reporting it</source>
         <translation>Cette erreur ne devrais pas s&apos;afficher, merci de le signaler</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="1039"/>
         <source>Error Compiling Scripts:
 scene %1 (%2), group %3 (%4), script %5, line %6: %7</source>
         <translation>Erreur de compilation des scripts :
 écran %1 (%2), groupe %3 (%4), script %5, ligne %6 : %7</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="1039"/>
         <source>Compilation Error</source>
         <translation>Erreur de compilation</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="1054"/>
         <source>Save Directory As</source>
         <translation>Enregistrer dossier sous</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="1069"/>
         <source>Save As</source>
         <translation>Enregistrer sous</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="1076"/>
         <source>Saving...</source>
         <translation>Sauvegarde...</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="661"/>
-        <location filename="../src/Window.cpp" line="1102"/>
         <source>Unable to remove the file, check write permissions.</source>
         <translation>Impossible de supprimer le fichier, vérifiez les droits d&apos;écriture.</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="301"/>
         <source>Map List</source>
         <translation>Liste des écrans</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="491"/>
         <source>PC field File (*)</source>
         <translation>Fichier Field PC (*)</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="664"/>
         <source>Failed to rename the file, check write permissions.</source>
         <translation>Impossible de renommer le fichier, vérifiez les droits d&apos;écriture.</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="667"/>
         <source>Failed to copy the file, check write permissions.</source>
         <translation>Impossible de copier le fichier, vérifiez les droits d&apos;écriture.</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="1093"/>
         <source>No maps found</source>
         <translation>Aucun écran trouvé</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="1105"/>
         <source>Unable to rename the file, check write permissions.</source>
         <translation>Impossible de renommer le fichier, vérifiez les droits d&apos;écriture.</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="1108"/>
         <source>Unable to copy the file, check write permissions.</source>
         <translation>Impossible de copier le fichier, vérifiez les droits d&apos;écriture.</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="1114"/>
         <source>This feature is not complete</source>
         <translation>Cette fonctionnalité n&apos;est pas terminée</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="1201"/>
-        <location filename="../src/Window.cpp" line="1354"/>
         <source>PC Field Map (*)</source>
         <translation>Fichier Field PC (*)</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="1202"/>
         <source>Data DAT File (*.DAT)</source>
         <translation>Fichier DAT (*.DAT)</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="1203"/>
         <source>Textures MIM File (*.MIM)</source>
         <translation>Fichier MIM (*.MIM)</translation>
     </message>
@@ -9643,27 +7847,22 @@ scene %1 (%2), group %3 (%4), script %5, line %6: %7</source>
         <translation type="vanished">Écran PC décompressé (*)</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="1242"/>
         <source>Archive is inaccessible</source>
         <translation>L&apos;archive est inaccessible</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="1245"/>
         <source>Error reopening file</source>
         <translation>Erreur lors de l&apos;ouverture du fichier</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="1248"/>
         <source>Unable to create the new file</source>
         <translation>Impossible de créer le nouveau fichier</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="1300"/>
         <source>An error occured when exporting</source>
         <translation>Une erreur s&apos;est produite lors de l&apos;exportation</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="1328"/>
         <source>An error occurred when importing</source>
         <translation>Une erreur s&apos;est produite lors de l&apos;importation</translation>
     </message>
@@ -9676,35 +7875,28 @@ scene %1 (%2), group %3 (%4), script %5, line %6: %7</source>
         <translation type="vanished">L&apos;algorithme d&apos;importation des décors donne de mauvais résultats en jeu, vous êtes prévenus !</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="1422"/>
         <source>Final Fantasy VII couldn&apos;t be launched
 %1</source>
         <translation>Final Fantasy VII n&apos;a pas pu être lancé.
 %1</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="1538"/>
-        <location filename="../src/Window.cpp" line="1616"/>
         <source>Opening error</source>
         <translation>Erreur d&apos;ouverture</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="1538"/>
         <source>Can not open encounters!</source>
         <translation>Impossible d&apos;ouvrir les combats aléatoires !</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="1616"/>
         <source>Can not open miscellaneous informations!</source>
         <translation>Impossible d&apos;ouvrir les infos diverses !</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="1627"/>
         <source>Go back to field map editor...</source>
         <translation>Revenir sur l&apos;éditeur d&apos;écrans de jeu...</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="1647"/>
         <source>Applying...</source>
         <translation>Application en cours...</translation>
     </message>
@@ -9718,59 +7910,41 @@ scene %1 (%2), group %3 (%4), script %5, line %6: %7</source>
         <translation type="vanished">Fermer</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="655"/>
-        <location filename="../src/Window.cpp" line="1096"/>
         <source>The file is inaccessible</source>
         <oldsource>Le fichier est inaccessible</oldsource>
         <translation>Le fichier est inaccessible</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="658"/>
-        <location filename="../src/Window.cpp" line="1099"/>
         <source>Can not create temporary file</source>
         <oldsource>Impossible de créer un fichier temporaire</oldsource>
         <translation>Impossible de créer un fichier temporaire</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="670"/>
         <source>Invalid file</source>
         <oldsource>Le fichier est invalide</oldsource>
         <translation>Fichier invalide</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="584"/>
-        <location filename="../src/Window.cpp" line="677"/>
-        <location filename="../src/Window.cpp" line="1118"/>
-        <location filename="../src/Window.cpp" line="1255"/>
-        <location filename="../src/Window.cpp" line="1300"/>
-        <location filename="../src/Window.cpp" line="1328"/>
-        <location filename="../src/Window.cpp" line="1387"/>
-        <location filename="../src/Window.cpp" line="1422"/>
         <source>Error</source>
         <oldsource>Erreur</oldsource>
         <translation>Erreur</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="941"/>
-        <location filename="../src/Window.cpp" line="1612"/>
         <source>Author: %1</source>
         <oldsource>Auteur : %1</oldsource>
         <translation>Auteur : %1</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="1061"/>
         <source>Lgp File (*.lgp)</source>
         <oldsource>Fichier Lgp (*.lgp)</oldsource>
         <translation>Fichier Lgp (*.lgp)</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="1065"/>
         <source>Iso File (*.iso *.bin *.img)</source>
         <oldsource>Fichier Iso (*.iso *.bin *.img)</oldsource>
         <translation>Fichier Iso (*.iso *.bin *.img)</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="1111"/>
         <source>Invalid archive</source>
         <oldsource>L&apos;archive est invalide</oldsource>
         <translation>Invalid archive</translation>
@@ -9786,7 +7960,6 @@ scene %1 (%2), group %3 (%4), script %5, line %6: %7</source>
         <translation type="vanished">Écran PC décompressé (*)</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="1216"/>
         <source>Export the current file</source>
         <oldsource>Exporter le fichier courant</oldsource>
         <translation>Exporter le fichier courant</translation>
@@ -9797,19 +7970,16 @@ scene %1 (%2), group %3 (%4), script %5, line %6: %7</source>
         <translation type="vanished">L&apos;archive Lgp est inaccessible</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="1251"/>
         <source>Not yet implemented!</source>
         <oldsource>Pas encore implémenté !</oldsource>
         <translation>Pas encore implémenté !</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="1270"/>
         <source>Export...</source>
         <oldsource>Exportation...</oldsource>
         <translation>Exporter...</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="1319"/>
         <source>Import...</source>
         <oldsource>Importation...</oldsource>
         <translation>Importer...</translation>
@@ -9820,7 +7990,6 @@ scene %1 (%2), group %3 (%4), script %5, line %6: %7</source>
         <translation type="vanished">Fichier DAT décompressé (*)</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="1365"/>
         <source>Import a file</source>
         <oldsource>Importer un fichier</oldsource>
         <translation>Importer un fichier</translation>
@@ -9829,12 +7998,10 @@ scene %1 (%2), group %3 (%4), script %5, line %6: %7</source>
 <context>
     <name>main</name>
     <message>
-        <location filename="../src/main.cpp" line="110"/>
         <source>Error</source>
         <translation type="unfinished">Erreur</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="111"/>
         <source>The file &apos;var.cfg&apos; could not be loaded.
 Make sure it is valid or delete it.</source>
         <translation type="unfinished">Le fichier &apos;var.cfg&apos; n&apos;a pas pu être chargé.

--- a/lang/Makou_Reactor_ja.ts
+++ b/lang/Makou_Reactor_ja.ts
@@ -4,12 +4,10 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../src/widgets/AboutDialog.cpp" line="28"/>
         <source>By Jérôme &amp;lt;myst6re&amp;gt; Arzel &lt;br/&gt;&lt;a href=&quot;https://github.com/myst6re/makoureactor/&quot;&gt;github.com/myst6re/makoureactor&lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/AboutDialog.cpp" line="34"/>
         <source>Thanks to:&lt;ul style=&quot;margin:0&quot;&gt;&lt;li&gt;Squall78&lt;/li&gt;&lt;li&gt;Synergy Blades&lt;/li&gt;&lt;li&gt;TrueOdin&lt;/li&gt;&lt;li&gt;Akari&lt;/li&gt;&lt;li&gt;Asa&lt;/li&gt;&lt;li&gt;Aali&lt;/li&gt;&lt;li&gt;DLPB&lt;/li&gt;&lt;/ul&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17,7 +15,6 @@
 <context>
     <name>AnimEditorDialog</name>
     <message>
-        <location filename="../src/widgets/AnimEditorDialog.cpp" line="25"/>
         <source>Animation Selector</source>
         <oldsource>Sélection d&apos;une animation</oldsource>
         <translatorcomment>Animation Selector</translatorcomment>
@@ -27,7 +24,6 @@
 <context>
     <name>ApercuBG</name>
     <message>
-        <location filename="../src/widgets/ApercuBG.cpp" line="82"/>
         <source>Error</source>
         <translation>エラー</translation>
     </message>
@@ -48,22 +44,18 @@
 <context>
     <name>ArchivePreview</name>
     <message>
-        <location filename="../src/widgets/ArchivePreview.cpp" line="103"/>
         <source>Image %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ArchivePreview.cpp" line="116"/>
         <source>Palette %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ArchivePreview.cpp" line="131"/>
         <source>Save Background</source>
         <translation>背景を保存</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ArchivePreview.cpp" line="133"/>
         <source>PNG image (*.png);;JPG image (*.jpg);;BMP image (*.bmp);;Portable Pixmap (*.ppm)</source>
         <translation>PNG 画像 (*.png);;JPG 画像 (*.jpg);;BMP 画像 (*.bmp);;Portable Pixmap (*.ppm)</translation>
     </message>
@@ -71,22 +63,18 @@
 <context>
     <name>Arguments</name>
     <message>
-        <location filename="../src/Arguments.cpp" line="47"/>
         <source>Input file or directory.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Arguments.cpp" line="116"/>
         <source>Warning: cannot open file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Arguments.cpp" line="150"/>
         <source>Command to execute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Arguments.cpp" line="155"/>
         <source>
 List of available commands:
   export  Export various assets from archive to files
@@ -96,38 +84,30 @@ List of available commands:
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Arguments.cpp" line="175"/>
         <source>Please specify a command</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Arguments.cpp" line="186"/>
         <source>Unknown command type:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ArgumentsExport.cpp" line="79"/>
         <source>Error: you cannot specify both background and bg-layer parameters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ArgumentsExport.cpp" line="86"/>
-        <location filename="../src/ArgumentsPatch.cpp" line="83"/>
         <source>Error: too much parameters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ArgumentsExport.cpp" line="92"/>
         <source>Error: --psf-lib-path is required with --music psf</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ArgumentsExport.cpp" line="103"/>
         <source>Error: target directory does not exist:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/ArgumentsPatch.cpp" line="31"/>
         <source>Output file (optional).</source>
         <translation type="unfinished"></translation>
     </message>
@@ -135,7 +115,6 @@ List of available commands:
 <context>
     <name>ArgumentsExport</name>
     <message>
-        <location filename="../src/ArgumentsExport.cpp" line="32"/>
         <source>Output directory.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -143,78 +122,63 @@ List of available commands:
 <context>
     <name>BGDialog</name>
     <message>
-        <location filename="../src/widgets/BGDialog.cpp" line="24"/>
         <source>Background</source>
         <translation>のプレビュー</translation>
     </message>
     <message>
-        <location filename="../src/widgets/BGDialog.cpp" line="53"/>
         <source>Z :</source>
         <translatorcomment>Z:</translatorcomment>
         <translation>Z:</translation>
     </message>
     <message>
-        <location filename="../src/widgets/BGDialog.cpp" line="62"/>
         <source>Layers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/BGDialog.cpp" line="63"/>
         <source>Sections (layer 1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/BGDialog.cpp" line="65"/>
         <source>Repair</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/BGDialog.cpp" line="149"/>
         <source>Parameter %1</source>
         <translation>パラメータ %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/BGDialog.cpp" line="159"/>
         <source>Section %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/BGDialog.cpp" line="175"/>
         <source>Layer %1</source>
         <translation>レイヤー %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/BGDialog.cpp" line="221"/>
         <source>State %1</source>
         <translation>ステート %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/BGDialog.cpp" line="330"/>
         <source>Save Background</source>
         <translation type="unfinished">背景を保存</translation>
     </message>
     <message>
-        <location filename="../src/widgets/BGDialog.cpp" line="332"/>
         <source>PNG image (*.png);;JPG image (*.jpg);;BMP image (*.bmp);;Portable Pixmap (*.ppm)</source>
         <translation type="unfinished">PNG 画像 (*.png);;JPG 画像 (*.jpg);;BMP 画像 (*.bmp);;Portable Pixmap (*.ppm)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/BGDialog.cpp" line="344"/>
         <source>Background Repaired</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/BGDialog.cpp" line="344"/>
         <source>Errors were found and repaired, save to apply the changes.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/BGDialog.cpp" line="348"/>
         <source>Repair Failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/BGDialog.cpp" line="348"/>
         <source>The errors were not corrected.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -222,67 +186,54 @@ List of available commands:
 <context>
     <name>CLI</name>
     <message>
-        <location filename="../src/CLI.cpp" line="46"/>
         <source>Retry? [Yn] </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/CLI.cpp" line="55"/>
         <source>y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/CLI.cpp" line="125"/>
         <source>An error occured when exporting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/CLI.cpp" line="290"/>
         <source>Nothing found!</source>
         <translation type="unfinished">見つかりませんでした！</translation>
     </message>
     <message>
-        <location filename="../src/CLI.cpp" line="293"/>
         <source>The file already exists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/CLI.cpp" line="296"/>
         <source>The file is inaccessible</source>
         <translation type="unfinished">ファイルにアクセスできません</translation>
     </message>
     <message>
-        <location filename="../src/CLI.cpp" line="299"/>
         <source>Can not create temporary file</source>
         <translation type="unfinished">一時ファイルが作成できません</translation>
     </message>
     <message>
-        <location filename="../src/CLI.cpp" line="302"/>
         <source>Unable to remove the file, check write permissions.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/CLI.cpp" line="305"/>
         <source>Failed to rename the file, check write permissions.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/CLI.cpp" line="308"/>
         <source>Failed to copy the file, check write permissions.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/CLI.cpp" line="311"/>
         <source>Invalid file</source>
         <translation type="unfinished">無効なファイル</translation>
     </message>
     <message>
-        <location filename="../src/CLI.cpp" line="314"/>
         <source>This error should not appear, thank you for reporting it</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/CLI.cpp" line="319"/>
         <source>Error</source>
         <translation type="unfinished">エラー</translation>
     </message>
@@ -295,7 +246,6 @@ List of available commands:
         <translation type="obsolete">変更する色の選択</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ColorDisplay.cpp" line="173"/>
         <source>Choose a new color</source>
         <translation>変更する色の選択</translation>
     </message>
@@ -303,67 +253,53 @@ List of available commands:
 <context>
     <name>ConfigWindow</name>
     <message>
-        <location filename="../src/widgets/ConfigWindow.cpp" line="28"/>
         <source>Configuration</source>
         <translation>構成設定</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ConfigWindow.cpp" line="30"/>
         <source>Dependencies</source>
         <oldsource>Dépendances</oldsource>
         <translatorcomment>Dependencies</translatorcomment>
         <translation>依存関係</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ConfigWindow.cpp" line="35"/>
         <source>Final Fantasy VII Installs</source>
         <oldsource>Final Fantasy VII installés</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ConfigWindow.cpp" line="39"/>
         <source>Delete</source>
         <translation>削除</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ConfigWindow.cpp" line="43"/>
-        <location filename="../src/widgets/ConfigWindow.cpp" line="46"/>
-        <location filename="../src/widgets/ConfigWindow.cpp" line="49"/>
         <source>Change</source>
         <translation>変更</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ConfigWindow.cpp" line="71"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ConfigWindow.cpp" line="73"/>
         <source>Dark mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ConfigWindow.cpp" line="80"/>
         <source>Disable OpenGL</source>
         <translation>OpenGL を無効化</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ConfigWindow.cpp" line="85"/>
         <source>Text Editor</source>
         <translation>テキスト エディター</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ConfigWindow.cpp" line="88"/>
         <source>Defaults</source>
         <translation>デフォルト</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ConfigWindow.cpp" line="122"/>
         <source>Dialog Background</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ConfigWindow.cpp" line="481"/>
         <source>You must restart %1 to apply all changes.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -372,32 +308,26 @@ List of available commands:
         <translation type="vanished">日本語版文字コード</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ConfigWindow.cpp" line="133"/>
         <source>Autosize: margin right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ConfigWindow.cpp" line="135"/>
         <source>{SPACED CHARACTERS} width</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ConfigWindow.cpp" line="137"/>
         <source>{CHOICE} width</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ConfigWindow.cpp" line="139"/>
         <source>Tabulation width</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ConfigWindow.cpp" line="143"/>
         <source>Script Editor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ConfigWindow.cpp" line="145"/>
         <source>Expand lines by default</source>
         <translation type="unfinished"></translation>
     </message>
@@ -406,46 +336,34 @@ List of available commands:
         <translation type="vanished">各種情報</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ConfigWindow.cpp" line="295"/>
         <source>Edit</source>
         <translation>編集</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ConfigWindow.cpp" line="298"/>
-        <location filename="../src/widgets/ConfigWindow.cpp" line="302"/>
         <source>Add</source>
         <translation>追加</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ConfigWindow.cpp" line="322"/>
-        <location filename="../src/widgets/ConfigWindow.cpp" line="332"/>
         <source>Find ff7.exe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ConfigWindow.cpp" line="322"/>
-        <location filename="../src/widgets/ConfigWindow.cpp" line="332"/>
         <source>EXE files (*.exe)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ConfigWindow.cpp" line="377"/>
         <source>Find kernel2.bin</source>
         <translation>kernel2.bin の選択</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ConfigWindow.cpp" line="377"/>
-        <location filename="../src/widgets/ConfigWindow.cpp" line="384"/>
         <source>Bin Files (*.bin);;All Files (*)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ConfigWindow.cpp" line="384"/>
         <source>Find window.bin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ConfigWindow.cpp" line="393"/>
         <source>Find char.lgp</source>
         <translation>char.lgp の検出</translation>
     </message>
@@ -454,53 +372,43 @@ List of available commands:
         <translation type="vanished">変更を適用するために Makou Reactor を再起動してください。</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ConfigWindow.cpp" line="41"/>
         <source>kernel2.bin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ConfigWindow.cpp" line="44"/>
         <source>window.bin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ConfigWindow.cpp" line="47"/>
         <source>char.lgp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ConfigWindow.cpp" line="78"/>
         <source>OpenGL</source>
         <translatorcomment>OpenGL</translatorcomment>
         <translation>OpenGL</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ConfigWindow.cpp" line="94"/>
         <source>Latin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ConfigWindow.cpp" line="95"/>
         <source>Japanese</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ConfigWindow.cpp" line="51"/>
         <source>Edit...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ConfigWindow.cpp" line="126"/>
         <source>Encoding</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ConfigWindow.cpp" line="393"/>
         <source>Lgp Archives (*.lgp);;All Files (*)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ConfigWindow.cpp" line="481"/>
         <source>Information</source>
         <translatorcomment>Information</translatorcomment>
         <translation>インフォメーション</translation>
@@ -509,65 +417,53 @@ List of available commands:
 <context>
     <name>EncounterTableWidget</name>
     <message>
-        <location filename="../src/widgets/EncounterTableWidget.cpp" line="35"/>
         <source>-</source>
         <translation>-</translation>
     </message>
     <message>
-        <location filename="../src/widgets/EncounterTableWidget.cpp" line="37"/>
         <source>+</source>
         <translation>+</translation>
     </message>
     <message>
-        <location filename="../src/widgets/EncounterTableWidget.cpp" line="42"/>
         <source>Battle ID</source>
         <oldsource>ID Combat</oldsource>
         <translatorcomment>Battle ID</translatorcomment>
         <translation>バトル ID</translation>
     </message>
     <message>
-        <location filename="../src/widgets/EncounterTableWidget.cpp" line="43"/>
         <source>Probability</source>
         <oldsource>Probabilité</oldsource>
         <translatorcomment>Probability</translatorcomment>
         <translation>レート値</translation>
     </message>
     <message>
-        <location filename="../src/widgets/EncounterTableWidget.cpp" line="45"/>
         <source>Back Attack 1</source>
         <translation>バックアタック 1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/EncounterTableWidget.cpp" line="45"/>
         <source>Back Attack 2</source>
         <translation>バックアタック 2</translation>
     </message>
     <message>
-        <location filename="../src/widgets/EncounterTableWidget.cpp" line="45"/>
         <source>Side Attack</source>
         <translation>サイドアタック</translation>
     </message>
     <message>
-        <location filename="../src/widgets/EncounterTableWidget.cpp" line="45"/>
         <source>Attack From Both Sides</source>
         <translation>はさみうち</translation>
     </message>
     <message>
-        <location filename="../src/widgets/EncounterTableWidget.cpp" line="49"/>
         <source>Battle %1</source>
         <oldsource>Combat %1</oldsource>
         <translatorcomment>Battle %1</translatorcomment>
         <translation>バトル %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/EncounterTableWidget.cpp" line="123"/>
         <source>Battle rate: %1/255</source>
         <oldsource>Fréquence des combats : %1/255</oldsource>
         <translation>バトル レート: %1/255</translation>
     </message>
     <message>
-        <location filename="../src/widgets/EncounterTableWidget.cpp" line="143"/>
-        <location filename="../src/widgets/EncounterTableWidget.cpp" line="151"/>
         <source>Remaining probability points: %1</source>
         <oldsource>Points de probabilité restants : %1</oldsource>
         <translatorcomment>Remaining probability points: %1</translatorcomment>
@@ -582,26 +478,22 @@ List of available commands:
         <translation type="obsolete">ランダム エンカウント</translation>
     </message>
     <message>
-        <location filename="../src/widgets/EncounterWidget.cpp" line="23"/>
         <source>Encounters</source>
         <translation>ランダム エンカウント</translation>
     </message>
     <message>
-        <location filename="../src/widgets/EncounterWidget.cpp" line="25"/>
         <source>Encounters 1</source>
         <oldsource>Rencontres 1</oldsource>
         <translatorcomment>Encounters 1</translatorcomment>
         <translation>エンカウント 1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/EncounterWidget.cpp" line="26"/>
         <source>Encounters 2</source>
         <oldsource>Rencontres 2</oldsource>
         <translatorcomment>Encounters 2</translatorcomment>
         <translation>エンカウント 2</translation>
     </message>
     <message>
-        <location filename="../src/widgets/EncounterWidget.cpp" line="30"/>
         <source>&lt;b&gt;Encounters:&lt;/b&gt; There are two groups of independent encounters, by default it is the group 1 that is active, but the opcode BTLTB (in scripts) can modify to the group 2.&lt;br/&gt;&lt;b&gt;Battle Rate:&lt;/b&gt; The lower the percentage, the higher the fighting will be frequent.</source>
         <oldsource>&lt;b&gt;Les rencontres :&lt;/b&gt; Il y a deux groupes de rencontres aléatoires indépendants, par défaut c&apos;est le groupe 1 qui est actif, mais la commande BTLTB (dans les scripts) permet de passer au groupe 2.&lt;br/&gt;&lt;b&gt;Fréquence des combats :&lt;/b&gt; Plus la valeur est basse, plus les combats seront fréquents.</oldsource>
         <translation>&lt;b&gt;エンカウント:&lt;/b&gt; エンカウトには二つのグループが存在します。 グループ 1 は通常有効化されている既定のエンカウントです。 スクリプト中のオプコード BTLTB によってグループ 2 に変更することができます。&lt;br/&gt;&lt;b&gt;バトル レート:&lt;/b&gt; 高い値はエンカウントの発生頻度を高くします。</translation>
@@ -610,22 +502,18 @@ List of available commands:
 <context>
     <name>FieldList</name>
     <message>
-        <location filename="../src/widgets/FieldList.cpp" line="29"/>
         <source>File</source>
         <translation>ファイル</translation>
     </message>
     <message>
-        <location filename="../src/widgets/FieldList.cpp" line="29"/>
         <source>Id</source>
         <translation type="unfinished">ID</translation>
     </message>
     <message>
-        <location filename="../src/widgets/FieldList.cpp" line="40"/>
         <source>Quick search</source>
         <translation type="unfinished">クイック検索</translation>
     </message>
     <message>
-        <location filename="../src/widgets/FieldList.cpp" line="41"/>
         <source>Search...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -634,99 +522,75 @@ List of available commands:
         <translation type="obsolete">DAT ファイル (*.DAT)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/FieldList.cpp" line="46"/>
         <source>Rename field</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/FieldList.cpp" line="49"/>
         <source>Add field</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/FieldList.cpp" line="52"/>
         <source>Delete field</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/FieldList.cpp" line="73"/>
         <source>&amp;Field List Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/FieldList.cpp" line="76"/>
         <source>Add a field</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/FieldList.cpp" line="78"/>
         <source>Remove a field</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/FieldList.cpp" line="246"/>
-        <location filename="../src/widgets/FieldList.cpp" line="289"/>
         <source>Not implemented for PS.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/FieldList.cpp" line="255"/>
         <source>Choose a name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/FieldList.cpp" line="256"/>
         <source>Field name:</source>
         <translation type="unfinished">フィールド名 :</translation>
     </message>
     <message>
-        <location filename="../src/widgets/FieldList.cpp" line="211"/>
-        <location filename="../src/widgets/FieldList.cpp" line="263"/>
         <source>Name not filled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/FieldList.cpp" line="212"/>
-        <location filename="../src/widgets/FieldList.cpp" line="264"/>
         <source>Please set a new field name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/FieldList.cpp" line="216"/>
-        <location filename="../src/widgets/FieldList.cpp" line="267"/>
         <source>Name already present in archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/FieldList.cpp" line="217"/>
-        <location filename="../src/widgets/FieldList.cpp" line="268"/>
         <source>Please choose another name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/FieldList.cpp" line="303"/>
         <source>Are you sure you want to remove %1?
 Other maps can refer to it!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/FieldList.cpp" line="306"/>
         <source>the selected field</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/FieldList.cpp" line="307"/>
         <source>the selected fields</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/FieldList.cpp" line="309"/>
         <source>Delete</source>
         <translation>削除</translation>
     </message>
     <message>
-        <location filename="../src/widgets/FieldList.cpp" line="246"/>
-        <location filename="../src/widgets/FieldList.cpp" line="289"/>
         <source>Error</source>
         <translation>エラー</translation>
     </message>
@@ -734,7 +598,6 @@ Other maps can refer to it!</source>
 <context>
     <name>FieldSaveIO</name>
     <message>
-        <location filename="../src/core/field/FieldIO.cpp" line="66"/>
         <source>Cannot save field map %1</source>
         <oldsource>Cannot save field %1</oldsource>
         <translation type="unfinished"></translation>
@@ -743,37 +606,30 @@ Other maps can refer to it!</source>
 <context>
     <name>FontManager</name>
     <message>
-        <location filename="../src/widgets/FontManager.cpp" line="25"/>
         <source>Font Manager</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/FontManager.cpp" line="56"/>
         <source>Japanese</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/FontManager.cpp" line="115"/>
         <source>&amp;Displayed name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/FontManager.cpp" line="116"/>
         <source>&amp;File name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/FontManager.cpp" line="132"/>
         <source>This name already exist or is invalid, please choose another.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/FontManager.cpp" line="149"/>
         <source>Remove font</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/FontManager.cpp" line="150"/>
         <source>Do you want to remove the selected font?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -786,17 +642,14 @@ Other maps can refer to it!</source>
         <translation type="obsolete">削除</translation>
     </message>
     <message>
-        <location filename="../src/widgets/FontManager.cpp" line="56"/>
         <source>Latin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/FontManager.cpp" line="111"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/widgets/FontManager.cpp" line="132"/>
         <source>Choose another name</source>
         <oldsource>Choisissez un autre nom</oldsource>
         <translation type="unfinished"></translation>
@@ -805,148 +658,115 @@ Other maps can refer to it!</source>
 <context>
     <name>FontWidget</name>
     <message>
-        <location filename="../src/widgets/FontWidget.cpp" line="30"/>
         <source>Grey</source>
         <oldsource>Gris</oldsource>
         <translation>灰色</translation>
     </message>
     <message>
-        <location filename="../src/widgets/FontWidget.cpp" line="30"/>
         <source>Violet</source>
         <translation>紫色</translation>
     </message>
     <message>
-        <location filename="../src/widgets/FontWidget.cpp" line="30"/>
         <source>Cyan</source>
         <translation>シアン</translation>
     </message>
     <message>
-        <location filename="../src/widgets/FontWidget.cpp" line="30"/>
         <source>Green</source>
         <translation type="unfinished">緑色</translation>
     </message>
     <message>
-        <location filename="../src/widgets/FontWidget.cpp" line="46"/>
         <source>Export...</source>
         <oldsource>Exporter...</oldsource>
         <translation>エクスポート...</translation>
     </message>
     <message>
-        <location filename="../src/widgets/FontWidget.cpp" line="47"/>
         <source>Import...</source>
         <oldsource>Importer...</oldsource>
         <translation>インポート...</translation>
     </message>
     <message>
-        <location filename="../src/widgets/FontWidget.cpp" line="30"/>
         <source>Blue</source>
         <translation>青色</translation>
     </message>
     <message>
-        <location filename="../src/widgets/FontWidget.cpp" line="30"/>
         <source>Red</source>
         <translation>赤色</translation>
     </message>
     <message>
-        <location filename="../src/widgets/FontWidget.cpp" line="30"/>
         <source>Yellow</source>
         <translation>黄色</translation>
     </message>
     <message>
-        <location filename="../src/widgets/FontWidget.cpp" line="30"/>
         <source>White</source>
         <translation>白色</translation>
     </message>
     <message>
-        <location filename="../src/widgets/FontWidget.cpp" line="48"/>
         <source>Cancel Changes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/FontWidget.cpp" line="64"/>
         <source>Text:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/FontWidget.cpp" line="66"/>
         <source>Width:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/FontWidget.cpp" line="68"/>
         <source>Left padding:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/FontWidget.cpp" line="117"/>
         <source>Table %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/FontWidget.cpp" line="219"/>
-        <location filename="../src/widgets/FontWidget.cpp" line="295"/>
         <source>FF7 font file (*.bin)</source>
         <oldsource>Fichier police FF7 (*.bin)</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/FontWidget.cpp" line="221"/>
         <source>Image File (*.png)</source>
         <oldsource>Fichier image PNG (*.png)</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/FontWidget.cpp" line="222"/>
         <source>Image File (*.jpg)</source>
         <oldsource>Image File (*.jpg))</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/FontWidget.cpp" line="223"/>
         <source>Image File (*.bmp)</source>
         <oldsource>Fichier image BMP (*.bmp)</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/FontWidget.cpp" line="227"/>
         <source>Translation file %1 (*.txt)</source>
         <oldsource>Fichier traduction %1 (*.txt)</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/FontWidget.cpp" line="231"/>
         <source>Export font</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/FontWidget.cpp" line="244"/>
-        <location filename="../src/widgets/FontWidget.cpp" line="247"/>
-        <location filename="../src/widgets/FontWidget.cpp" line="270"/>
-        <location filename="../src/widgets/FontWidget.cpp" line="313"/>
-        <location filename="../src/widgets/FontWidget.cpp" line="317"/>
         <source>Error</source>
         <oldsource>Erreur</oldsource>
         <translation type="unfinished">エラー</translation>
     </message>
     <message>
-        <location filename="../src/widgets/FontWidget.cpp" line="244"/>
-        <location filename="../src/widgets/FontWidget.cpp" line="270"/>
-        <location filename="../src/widgets/FontWidget.cpp" line="317"/>
         <source>Error opening file (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/FontWidget.cpp" line="247"/>
         <source>Error saving file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/FontWidget.cpp" line="299"/>
         <source>Import font</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/FontWidget.cpp" line="313"/>
         <source>Invalid file</source>
         <translation type="unfinished">無効なファイル</translation>
     </message>
@@ -954,130 +774,108 @@ Other maps can refer to it!</source>
 <context>
     <name>GrpScriptList</name>
     <message>
-        <location filename="../src/widgets/GrpScriptList.cpp" line="26"/>
         <source>Id</source>
         <translation>ID</translation>
     </message>
     <message>
-        <location filename="../src/widgets/GrpScriptList.cpp" line="26"/>
         <source>Type</source>
         <translation>タイプ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/GrpScriptList.cpp" line="26"/>
         <source>Group</source>
         <translation type="unfinished">グループ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/GrpScriptList.cpp" line="37"/>
         <source>Rename group</source>
         <oldsource>Renommer groupe</oldsource>
         <translatorcomment>Rename group</translatorcomment>
         <translation type="unfinished">グループのリネーム</translation>
     </message>
     <message>
-        <location filename="../src/widgets/GrpScriptList.cpp" line="40"/>
         <source>Add group</source>
         <oldsource>Ajouter groupe</oldsource>
         <translatorcomment>Add group</translatorcomment>
         <translation type="unfinished">グループの追加</translation>
     </message>
     <message>
-        <location filename="../src/widgets/GrpScriptList.cpp" line="43"/>
         <source>Delete group</source>
         <oldsource>Supprimer groupe</oldsource>
         <translatorcomment>Delete group</translatorcomment>
         <translation type="unfinished">グループの削除</translation>
     </message>
     <message>
-        <location filename="../src/widgets/GrpScriptList.cpp" line="47"/>
         <source>Cut group</source>
         <oldsource>Couper groupe</oldsource>
         <translatorcomment>Cut group</translatorcomment>
         <translation type="unfinished">グループの切り取り</translation>
     </message>
     <message>
-        <location filename="../src/widgets/GrpScriptList.cpp" line="51"/>
         <source>Copy group</source>
         <oldsource>Copier groupe</oldsource>
         <translatorcomment>Copy group</translatorcomment>
         <translation type="unfinished">グループのコピー</translation>
     </message>
     <message>
-        <location filename="../src/widgets/GrpScriptList.cpp" line="55"/>
         <source>Paste group</source>
         <oldsource>Coller groupe</oldsource>
         <translatorcomment>Paste group</translatorcomment>
         <translation type="unfinished">グループの貼り付け</translation>
     </message>
     <message>
-        <location filename="../src/widgets/GrpScriptList.cpp" line="59"/>
         <source>Move up</source>
         <translation type="unfinished">上へ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/GrpScriptList.cpp" line="63"/>
         <source>Move down</source>
         <translation type="unfinished">下へ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/GrpScriptList.cpp" line="107"/>
         <source>Remove a group</source>
         <translation type="unfinished">グループの削除</translation>
     </message>
     <message>
-        <location filename="../src/widgets/GrpScriptList.cpp" line="110"/>
         <source>Up</source>
         <translation type="unfinished">上に</translation>
     </message>
     <message>
-        <location filename="../src/widgets/GrpScriptList.cpp" line="112"/>
         <source>Down</source>
         <translation type="unfinished">下に</translation>
     </message>
     <message>
-        <location filename="../src/widgets/GrpScriptList.cpp" line="255"/>
         <source>You have more than 16 models in this field, the game may crash.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/GrpScriptList.cpp" line="261"/>
         <source>You have more than 48 groups in this field, the game may crash.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/GrpScriptList.cpp" line="319"/>
         <source>Delete</source>
         <translation type="unfinished">削除</translation>
     </message>
     <message>
-        <location filename="../src/widgets/GrpScriptList.cpp" line="319"/>
         <source>Are you sure you want to remove %1?
 Some scripts can refer to it!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/GrpScriptList.cpp" line="102"/>
         <source>&amp;Group Editor</source>
         <oldsource>Édition des &amp;groupes</oldsource>
         <translation type="unfinished">グループ エディター(&amp;G)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/GrpScriptList.cpp" line="105"/>
         <source>Add a group</source>
         <oldsource>Ajouter un groupe</oldsource>
         <translatorcomment>Add a group</translatorcomment>
         <translation type="unfinished">グループの追加</translation>
     </message>
     <message>
-        <location filename="../src/widgets/GrpScriptList.cpp" line="322"/>
         <source>the group selected</source>
         <oldsource>le groupe sélectionné</oldsource>
         <translatorcomment>the group selected</translatorcomment>
         <translation type="unfinished">選択グループ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/GrpScriptList.cpp" line="323"/>
         <source>the selected groups</source>
         <oldsource>les groupes sélectionnés</oldsource>
         <translatorcomment>the selected groups</translatorcomment>
@@ -1087,53 +885,42 @@ Some scripts can refer to it!</source>
 <context>
     <name>GrpScriptWizardPageType</name>
     <message>
-        <location filename="../src/widgets/GrpScriptWizard.cpp" line="69"/>
-        <location filename="../src/widgets/GrpScriptWizard.cpp" line="102"/>
         <source>Empty</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/GrpScriptWizard.cpp" line="70"/>
         <source>3D Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/GrpScriptWizard.cpp" line="71"/>
         <source>Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/GrpScriptWizard.cpp" line="72"/>
         <source>Animation</source>
         <translation type="unfinished">アニメーション</translation>
     </message>
     <message>
-        <location filename="../src/widgets/GrpScriptWizard.cpp" line="73"/>
         <source>Other</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/GrpScriptWizard.cpp" line="96"/>
         <source>Main Character</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/GrpScriptWizard.cpp" line="97"/>
         <source>Non Playable Character</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/GrpScriptWizard.cpp" line="98"/>
         <source>Item</source>
         <translation type="unfinished">アイテム</translation>
     </message>
     <message>
-        <location filename="../src/widgets/GrpScriptWizard.cpp" line="99"/>
         <source>Save Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/GrpScriptWizard.cpp" line="103"/>
         <source>Position debugging</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1141,112 +928,91 @@ Some scripts can refer to it!</source>
 <context>
     <name>ImportDialog</name>
     <message>
-        <location filename="../src/widgets/ImportDialog.cpp" line="23"/>
-        <location filename="../src/widgets/ImportDialog.cpp" line="25"/>
         <source>Import</source>
         <oldsource>Importer</oldsource>
         <translatorcomment>Import</translatorcomment>
         <translation type="unfinished">インポート</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ImportDialog.cpp" line="26"/>
         <source>Scripts/Texts</source>
         <oldsource>Scripts/Textes</oldsource>
         <translatorcomment>Scripts/Texts</translatorcomment>
         <translation type="unfinished">スクリプト/テキスト</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ImportDialog.cpp" line="27"/>
         <source>Sounds/Tutorials</source>
         <oldsource>Musiques/Tutoriels</oldsource>
         <translatorcomment>Sounds/Tutorials</translatorcomment>
         <translation type="unfinished">サウンド/解説</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ImportDialog.cpp" line="28"/>
         <source>Camera</source>
         <oldsource>Caméra</oldsource>
         <translatorcomment>Camera</translatorcomment>
         <translation type="unfinished">カメラ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ImportDialog.cpp" line="29"/>
         <source>Walkmesh</source>
         <translatorcomment>Walkmesh</translatorcomment>
         <translation>ウォークメッシュ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ImportDialog.cpp" line="30"/>
         <source>Encounters</source>
         <translation type="unfinished">バトル エンカウント</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ImportDialog.cpp" line="31"/>
         <source>Triggers/gateways</source>
         <translation type="unfinished">トリガー/出入り口</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ImportDialog.cpp" line="32"/>
         <source>Model loader</source>
         <translation type="unfinished">モデル ローダー</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ImportDialog.cpp" line="35"/>
         <source>File is not compressed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ImportDialog.cpp" line="55"/>
         <source> (partial: models and animations are not linked properly)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ImportDialog.cpp" line="56"/>
         <source> (partial: Z-depth might be a little broken)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ImportDialog.cpp" line="75"/>
         <source>BSX file:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ImportDialog.cpp" line="155"/>
         <source>Select the associated BSX file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ImportDialog.cpp" line="156"/>
         <source>BSX File (*.BSX);;All Files (*)</source>
         <oldsource>BSX File (*.BSX);;All Files(*)</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ImportDialog.cpp" line="167"/>
         <source>MIM File (*.MIM);;All Files (*)</source>
         <oldsource>MIM File (*.MIM);;All Files(*)</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ImportDialog.cpp" line="33"/>
         <source>Background</source>
         <translation type="unfinished">背景</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ImportDialog.cpp" line="61"/>
-        <location filename="../src/widgets/ImportDialog.cpp" line="71"/>
         <source>Change</source>
         <oldsource>Changer</oldsource>
         <translation type="unfinished">変更</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ImportDialog.cpp" line="65"/>
         <source>MIM file:</source>
         <oldsource>Fichier MIM :</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ImportDialog.cpp" line="166"/>
         <source>Select the associated MIM file</source>
         <oldsource>Sélectionner le fichier MIM associé</oldsource>
         <translation type="unfinished"></translation>
@@ -1260,7 +1026,6 @@ Some scripts can refer to it!</source>
         <translation type="obsolete">キー</translation>
     </message>
     <message>
-        <location filename="../src/widgets/KeyEditorDialog.cpp" line="24"/>
         <source>Keys</source>
         <translation>キー</translation>
     </message>
@@ -1305,18 +1070,15 @@ Some scripts can refer to it!</source>
 <context>
     <name>LgpItemModel</name>
     <message>
-        <location filename="../src/widgets/LgpWidget.cpp" line="512"/>
         <source>?</source>
         <translation>?</translation>
     </message>
     <message>
-        <location filename="../src/widgets/LgpWidget.cpp" line="587"/>
         <source>Name</source>
         <oldsource>Nom</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/LgpWidget.cpp" line="588"/>
         <source>Size</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1324,161 +1086,115 @@ Some scripts can refer to it!</source>
 <context>
     <name>LgpWidget</name>
     <message>
-        <location filename="../src/widgets/LgpWidget.cpp" line="679"/>
         <source>LGP archive manager</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/LgpWidget.cpp" line="690"/>
-        <location filename="../src/widgets/LgpWidget.cpp" line="838"/>
-        <location filename="../src/widgets/LgpWidget.cpp" line="1056"/>
         <source>Rename</source>
         <translation type="unfinished">リネーム</translation>
     </message>
     <message>
-        <location filename="../src/widgets/LgpWidget.cpp" line="692"/>
         <source>Replace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/LgpWidget.cpp" line="694"/>
         <source>Extract</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/LgpWidget.cpp" line="696"/>
         <source>Extract All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/LgpWidget.cpp" line="698"/>
         <source>Add</source>
         <translation type="unfinished">追加</translation>
     </message>
     <message>
-        <location filename="../src/widgets/LgpWidget.cpp" line="700"/>
         <source>Delete</source>
         <translation type="unfinished">削除</translation>
     </message>
     <message>
-        <location filename="../src/widgets/LgpWidget.cpp" line="838"/>
-        <location filename="../src/widgets/LgpWidget.cpp" line="1057"/>
         <source>New Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/LgpWidget.cpp" line="845"/>
-        <location filename="../src/widgets/LgpWidget.cpp" line="848"/>
-        <location filename="../src/widgets/LgpWidget.cpp" line="851"/>
-        <location filename="../src/widgets/LgpWidget.cpp" line="888"/>
-        <location filename="../src/widgets/LgpWidget.cpp" line="1002"/>
-        <location filename="../src/widgets/LgpWidget.cpp" line="1041"/>
-        <location filename="../src/widgets/LgpWidget.cpp" line="1046"/>
-        <location filename="../src/widgets/LgpWidget.cpp" line="1067"/>
-        <location filename="../src/widgets/LgpWidget.cpp" line="1091"/>
-        <location filename="../src/widgets/LgpWidget.cpp" line="1119"/>
         <source>Error</source>
         <translation type="unfinished">エラー</translation>
     </message>
     <message>
-        <location filename="../src/widgets/LgpWidget.cpp" line="845"/>
-        <location filename="../src/widgets/LgpWidget.cpp" line="1042"/>
         <source>The name &apos;%1&apos; is invalid, don&apos;t put special characters.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/LgpWidget.cpp" line="848"/>
-        <location filename="../src/widgets/LgpWidget.cpp" line="1047"/>
         <source>A file named &apos;%1&apos; already exists, please choose another name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/LgpWidget.cpp" line="851"/>
         <source>Can not Rename the file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/LgpWidget.cpp" line="871"/>
-        <location filename="../src/widgets/LgpWidget.cpp" line="907"/>
         <source>%1 file (*.%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/LgpWidget.cpp" line="873"/>
-        <location filename="../src/widgets/LgpWidget.cpp" line="909"/>
-        <location filename="../src/widgets/LgpWidget.cpp" line="1020"/>
         <source>All files (*)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/LgpWidget.cpp" line="880"/>
-        <location filename="../src/widgets/LgpWidget.cpp" line="1021"/>
         <source>New File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/LgpWidget.cpp" line="888"/>
         <source>Can not modify the archive!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/LgpWidget.cpp" line="916"/>
         <source>Extract file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/LgpWidget.cpp" line="931"/>
         <source>Write error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/LgpWidget.cpp" line="931"/>
         <source>Can not write to file (message: %1).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/LgpWidget.cpp" line="936"/>
         <source>Opening error</source>
         <translation type="unfinished">オープン エラー</translation>
     </message>
     <message>
-        <location filename="../src/widgets/LgpWidget.cpp" line="936"/>
         <source>Can not open the file (message: %1).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/LgpWidget.cpp" line="949"/>
         <source>Extract all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/LgpWidget.cpp" line="956"/>
         <source>Extracting...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/LgpWidget.cpp" line="956"/>
         <source>Cancel</source>
         <translation type="unfinished">キャンセル</translation>
     </message>
     <message>
-        <location filename="../src/widgets/LgpWidget.cpp" line="1068"/>
         <source>Can not add the file &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/LgpWidget.cpp" line="1081"/>
         <source>Delete?</source>
         <oldsource>Delete ?</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/LgpWidget.cpp" line="1082"/>
         <source>Are you sure you want to delete this file from the archive?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/LgpWidget.cpp" line="1091"/>
         <source>Cannot delete the file!</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1486,140 +1202,113 @@ Some scripts can refer to it!</source>
 <context>
     <name>MassExportDialog</name>
     <message>
-        <location filename="../src/widgets/MassExportDialog.cpp" line="25"/>
         <source>Mass Export</source>
         <oldsource>Exporter en masse</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/MassExportDialog.cpp" line="32"/>
         <source>Current</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/MassExportDialog.cpp" line="33"/>
         <source>+</source>
         <translation>+</translation>
     </message>
     <message>
-        <location filename="../src/widgets/MassExportDialog.cpp" line="34"/>
         <source>-</source>
         <translation>-</translation>
     </message>
     <message>
-        <location filename="../src/widgets/MassExportDialog.cpp" line="41"/>
         <source>Export fields</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/MassExportDialog.cpp" line="44"/>
         <source>Export backgrounds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/MassExportDialog.cpp" line="46"/>
         <source>Flatten PNG image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/MassExportDialog.cpp" line="47"/>
         <source>Flatten JPG image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/MassExportDialog.cpp" line="48"/>
         <source>Flatten BMP image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/MassExportDialog.cpp" line="49"/>
         <source>Multi-layers PNG images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/MassExportDialog.cpp" line="50"/>
         <source>Multi-layers JPG images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/MassExportDialog.cpp" line="51"/>
         <source>Multi-layers BMP images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/MassExportDialog.cpp" line="53"/>
         <source>Export musics</source>
         <oldsource>Export sounds</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/MassExportDialog.cpp" line="55"/>
         <source>AKAO music</source>
         <oldsource>AKAO sound</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/MassExportDialog.cpp" line="56"/>
         <source>PSF MIDI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/MassExportDialog.cpp" line="58"/>
         <source>Export texts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/MassExportDialog.cpp" line="60"/>
         <source>XML Text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/MassExportDialog.cpp" line="61"/>
         <source>Simple text TXT</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/MassExportDialog.cpp" line="67"/>
         <source>Choose...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/MassExportDialog.cpp" line="69"/>
         <source>Overwrite existing files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/MassExportDialog.cpp" line="73"/>
         <source>Export</source>
         <translation type="unfinished">エクスポート</translation>
     </message>
     <message>
-        <location filename="../src/widgets/MassExportDialog.cpp" line="83"/>
         <source>Export directory:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/MassExportDialog.cpp" line="104"/>
         <source>FIELD File %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/MassExportDialog.cpp" line="105"/>
         <source>Uncompressed FIELD %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/MassExportDialog.cpp" line="124"/>
         <source>Choose a directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/MassExportDialog.cpp" line="102"/>
         <source>PC</source>
         <translation type="unfinished">PC</translation>
     </message>
     <message>
-        <location filename="../src/widgets/MassExportDialog.cpp" line="102"/>
         <source>PS</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1627,99 +1316,81 @@ Some scripts can refer to it!</source>
 <context>
     <name>MassImportDialog</name>
     <message>
-        <location filename="../src/widgets/MassImportDialog.cpp" line="25"/>
         <source>Mass Import</source>
         <oldsource>Importer en masse</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/MassImportDialog.cpp" line="28"/>
         <source>Import fields</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/MassImportDialog.cpp" line="31"/>
         <source>Import sounds</source>
         <oldsource>Importer les sons</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/MassImportDialog.cpp" line="33"/>
         <source>AKAO sound</source>
         <oldsource>Son AKAO</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/MassImportDialog.cpp" line="35"/>
         <source>Import text</source>
         <oldsource>Importer les textes</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/MassImportDialog.cpp" line="37"/>
         <source>XML Text</source>
         <oldsource>Texte XML</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/MassImportDialog.cpp" line="38"/>
         <source>Simple text TXT</source>
         <oldsource>Texte simple TXT</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/MassImportDialog.cpp" line="42"/>
         <source>Choose...</source>
         <oldsource>Choisir...</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/MassImportDialog.cpp" line="49"/>
         <source>Current</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/MassImportDialog.cpp" line="58"/>
         <source>Import</source>
         <translation type="unfinished">インポート</translation>
     </message>
     <message>
-        <location filename="../src/widgets/MassImportDialog.cpp" line="67"/>
         <source>Source directory:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/MassImportDialog.cpp" line="87"/>
         <source>FIELD File %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/MassImportDialog.cpp" line="88"/>
         <source>Uncompressed FIELD %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/MassImportDialog.cpp" line="107"/>
         <source>Choose a directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/MassImportDialog.cpp" line="50"/>
         <source>+</source>
         <translation type="unfinished">+</translation>
     </message>
     <message>
-        <location filename="../src/widgets/MassImportDialog.cpp" line="51"/>
         <source>-</source>
         <translation type="unfinished">-</translation>
     </message>
     <message>
-        <location filename="../src/widgets/MassImportDialog.cpp" line="85"/>
         <source>PC</source>
         <translation type="unfinished">PC</translation>
     </message>
     <message>
-        <location filename="../src/widgets/MassImportDialog.cpp" line="85"/>
         <source>PS</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1727,17 +1398,14 @@ Some scripts can refer to it!</source>
 <context>
     <name>MiscWidget</name>
     <message>
-        <location filename="../src/widgets/MiscWidget.cpp" line="24"/>
         <source>Miscellaneous</source>
         <translation type="unfinished">各種情報</translation>
     </message>
     <message>
-        <location filename="../src/widgets/MiscWidget.cpp" line="34"/>
         <source>Field name:</source>
         <translation type="unfinished">フィールド名 :</translation>
     </message>
     <message>
-        <location filename="../src/widgets/MiscWidget.cpp" line="36"/>
         <source>Author:</source>
         <oldsource>Auteur :</oldsource>
         <translatorcomment>Author:</translatorcomment>
@@ -1747,22 +1415,18 @@ Some scripts can refer to it!</source>
 <context>
     <name>ModelColorsLayout</name>
     <message>
-        <location filename="../src/widgets/ModelColorsLayout.cpp" line="67"/>
         <source>Color</source>
         <translation type="unfinished">カラー</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ModelColorsLayout.cpp" line="68"/>
         <source>X</source>
         <translation>X</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ModelColorsLayout.cpp" line="69"/>
         <source>Y</source>
         <translation>Y</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ModelColorsLayout.cpp" line="70"/>
         <source>Z</source>
         <translation>Z</translation>
     </message>
@@ -1775,8 +1439,6 @@ Some scripts can refer to it!</source>
         <translation type="obsolete">3Dモデル</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ModelManager.cpp" line="25"/>
-        <location filename="../src/widgets/ModelManager.cpp" line="32"/>
         <source>Field Models</source>
         <translation>3Dモデル</translation>
     </message>
@@ -1784,71 +1446,56 @@ Some scripts can refer to it!</source>
 <context>
     <name>ModelManagerPC</name>
     <message>
-        <location filename="../src/widgets/ModelManagerPC.cpp" line="41"/>
         <source>Copy</source>
         <oldsource>Copier</oldsource>
         <translation type="unfinished">コピー</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ModelManagerPC.cpp" line="40"/>
         <source>Cut</source>
         <translation type="unfinished">切り取り</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ModelManagerPC.cpp" line="42"/>
         <source>Paste</source>
         <translation type="unfinished">貼り付け</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ModelManagerPC.cpp" line="61"/>
         <source>?</source>
         <translation type="unfinished">?</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ModelManagerPC.cpp" line="61"/>
         <source>Id</source>
         <translation type="unfinished">ID</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ModelManagerPC.cpp" line="61"/>
         <source>Animation</source>
         <translation type="unfinished">アニメーション</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ModelManagerPC.cpp" line="64"/>
         <source>Name (unused)</source>
         <translation type="unfinished">名称 (未使用)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ModelManagerPC.cpp" line="66"/>
         <source>Unknown</source>
         <translation type="unfinished">不明</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ModelManagerPC.cpp" line="68"/>
         <source>Model size</source>
         <translation type="unfinished">モデル サイズ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ModelManagerPC.cpp" line="70"/>
         <source>Global light</source>
         <oldsource>Light</oldsource>
         <translation type="unfinished">光源</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ModelManagerPC.cpp" line="72"/>
         <source>Directional light</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ModelManagerPC.cpp" line="147"/>
-        <location filename="../src/widgets/ModelManagerPC.cpp" line="354"/>
         <source>Add a field model</source>
         <translation type="unfinished">3Dモデルの追加</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ModelManagerPC.cpp" line="157"/>
-        <location filename="../src/widgets/ModelManagerPC.cpp" line="385"/>
         <source>OK</source>
         <translation type="unfinished">OK</translation>
     </message>
@@ -1856,28 +1503,23 @@ Some scripts can refer to it!</source>
 <context>
     <name>ModelManagerPS</name>
     <message>
-        <location filename="../src/widgets/ModelManagerPS.cpp" line="26"/>
         <source>Animation</source>
         <oldsource>Animations</oldsource>
         <translation type="unfinished">アニメーション</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ModelManagerPS.cpp" line="29"/>
         <source>Unknown</source>
         <translation type="unfinished">不明</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ModelManagerPS.cpp" line="31"/>
         <source>Model size</source>
         <translation type="unfinished">モデル サイズ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ModelManagerPS.cpp" line="33"/>
         <source>Global light</source>
         <translation type="unfinished">光源</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ModelManagerPS.cpp" line="35"/>
         <source>Directional light</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1889,36 +1531,26 @@ Some scripts can refer to it!</source>
 <context>
     <name>Opcode</name>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4900"/>
-        <location filename="../src/core/field/Opcode.cpp" line="4916"/>
-        <location filename="../src/core/field/Opcode.cpp" line="4922"/>
-        <location filename="../src/core/field/Opcode.cpp" line="4928"/>
-        <location filename="../src/core/field/Opcode.cpp" line="4938"/>
-        <location filename="../src/core/field/Opcode.cpp" line="4944"/>
         <source>No%1</source>
         <oldsource>n°%1</oldsource>
         <translatorcomment>No%1</translatorcomment>
         <translation>No.%1</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5051"/>
         <source>Pan transitions (channel #4)</source>
         <oldsource>Tempo transitions sur tous les canaux</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5067"/>
         <source>Tempo transitions (channel #4)</source>
         <oldsource>Transition sur le tempo de la musique</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2272"/>
         <source>Label %1</source>
         <translation type="unfinished">レイヤー %1</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3048"/>
         <source>main (parameter %1)</source>
         <oldsource>%1? (paramètre %2)</oldsource>
         <translatorcomment>%1? (parameter %2)</translatorcomment>
@@ -1929,117 +1561,94 @@ Some scripts can refer to it!</source>
         <translation type="obsolete">LIGHT</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4974"/>
         <source>Play music [param1: music ID, 0-based]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4977"/>
         <source>Play music and resume from last position [param1: music ID, 0-based]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4980"/>
         <source>Play a sound effect (will be terminated if another effect is played on channel) [param1: panning, param2: effect ID]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4985"/>
         <source>Play a sound effect (will be terminated if another effect is played on channel) [param1: panning, param2: effect ID, param3: ?]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4990"/>
         <source>Play a sound effect (will be terminated if another effect is played on channel) [param1: panning, param2: effect ID, param3: ?, param4: ?]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4995"/>
         <source>Play a sound effect (will be terminated if another effect is played on channel) [param1: panning, param2: effect ID, param3: ?, param4: ?, param5: ?]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4999"/>
         <source>Play a sound effect on channel #1 [param1: panning, param2: effect ID]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5001"/>
         <source>Play a sound effect on channel #2 [param1: panning, param2: effect ID]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5003"/>
         <source>Play a sound effect on channel #3 [param1: panning, param2: effect ID]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5005"/>
         <source>Play a sound effect on channel #4 [param1: panning, param2: effect ID]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5007"/>
         <source>Play a sound effect (cannot be stopped) [param1: effect ID]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5029"/>
         <source>Volume transitions (channel #1) [param1: transition time, param2: target volume]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5031"/>
         <source>Volume transitions (channel #2) [param1: transition time, param2: target volume]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5033"/>
         <source>Volume transitions (channel #3) [param1: transition time, param2: target volume]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5035"/>
         <source>Volume transitions (channel #4) [param1: transition time, param2: target volume]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5069"/>
         <source>Volume control for all channels [param1: volume]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5071"/>
         <source>Volume transitions for all channels [param1: transition time, param2: target volume]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5081"/>
         <source>Set music volume [param1: volume]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5083"/>
         <source>Music volume transition [param1: transition time, param2: target volume]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5087"/>
         <source>Set music pan (noop in PC version)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5089"/>
         <source>Music pan transition (noop in PC version)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5091"/>
         <source>Music pan fade (noop in PC version)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5093"/>
         <source>Set music tempo [param1: tempo, 0x20 is normal]</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2056,48 +1665,38 @@ Some scripts can refer to it!</source>
         <translation type="obsolete">RESET</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3022"/>
         <source>Exit program (parameter %1)</source>
         <oldsource>? (paramètre %1)</oldsource>
         <translatorcomment>? (parameter %1)</translatorcomment>
         <translation>プログラムの終了 (パラメータ %1)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3026"/>
         <source>Encount Error (parameter %1)</source>
         <oldsource>HPs à 1 (paramètre %1)</oldsource>
         <translatorcomment>エンカウント エラー (パラメータ %1)</translatorcomment>
         <translation>エンカウント エラー (パラメータ %1)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3108"/>
         <source>Check if %1 and store the result in var[15][111]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4413"/>
         <source>Create line (X1=%1, Y1=%2, Z1=%3, X2=%4, Y2=%5, Z2=%6)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4425"/>
         <source>%1 line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2594"/>
-        <location filename="../src/core/field/Opcode.cpp" line="4426"/>
         <source>Enable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2594"/>
-        <location filename="../src/core/field/Opcode.cpp" line="4426"/>
         <source>Disable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4439"/>
         <source>Set line (X1=%1, Y1=%2, Z1=%3, X2=%4, Y2=%5, Z2=%6)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2114,12 +1713,10 @@ Some scripts can refer to it!</source>
         <translation type="obsolete">ADPAL2 %1</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4750"/>
         <source>Play music #%1</source>
         <translation>BGM #%1 を再生</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4757"/>
         <source>Play sound #%1 (position=%2/127)</source>
         <translation>効果音 #%1 を再生 (位置=%2/127)</translation>
     </message>
@@ -2128,53 +1725,43 @@ Some scripts can refer to it!</source>
         <translation type="vanished">MUSVT (BGM #%1)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4788"/>
         <source>MUSVM (music #%1)</source>
         <translation>MUSVM (BGM #%1)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4795"/>
         <source>%1 music</source>
         <translation>BGM を%1</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4796"/>
         <source>Unlock</source>
         <translation>アンロック</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4796"/>
         <source>Lock</source>
         <comment>test</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4802"/>
         <source>Set the music #%1 for next battle</source>
         <translation>次のバトル BGM に #%1 をセット</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4809"/>
         <source>CHMPH: Save (unknown) in %1 and (unknown) in %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4819"/>
         <source>Set next movie: %1</source>
         <translation>次のムービーをセット : %1</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4827"/>
         <source>Play movie</source>
         <translation>ムービーを再生</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4833"/>
         <source>Save Movie frame in %1</source>
         <translation>ムービー フレームを %1 に保存</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4840"/>
         <source>Camera Movie: %1</source>
         <translation>カメラ ムービー : %1</translation>
     </message>
@@ -2183,24 +1770,11 @@ Some scripts can refer to it!</source>
         <translation type="obsolete">FMUSC (?=%1)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5205"/>
         <source>normal</source>
         <translatorcomment>normal</translatorcomment>
         <translation>ノーマル</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2318"/>
-        <location filename="../src/core/field/Opcode.cpp" line="2332"/>
-        <location filename="../src/core/field/Opcode.cpp" line="2346"/>
-        <location filename="../src/core/field/Opcode.cpp" line="2360"/>
-        <location filename="../src/core/field/Opcode.cpp" line="2374"/>
-        <location filename="../src/core/field/Opcode.cpp" line="2388"/>
-        <location filename="../src/core/field/Opcode.cpp" line="2435"/>
-        <location filename="../src/core/field/Opcode.cpp" line="2793"/>
-        <location filename="../src/core/field/Opcode.cpp" line="2806"/>
-        <location filename="../src/core/field/Opcode.cpp" line="2819"/>
-        <location filename="../src/core/field/Opcode.cpp" line="4370"/>
-        <location filename="../src/core/field/Opcode.cpp" line="4382"/>
         <source>else goto label %1</source>
         <oldsource>aller au label %1 sinon</oldsource>
         <translation type="unfinished"></translation>
@@ -2211,537 +1785,426 @@ Some scripts can refer to it!</source>
         <translation type="vanished">SPECIAL -</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2601"/>
-        <location filename="../src/core/field/Opcode.cpp" line="2745"/>
-        <location filename="../src/core/field/Opcode.cpp" line="4433"/>
         <source>ON</source>
         <translatorcomment>許可</translatorcomment>
         <translation>オン</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2601"/>
-        <location filename="../src/core/field/Opcode.cpp" line="2745"/>
-        <location filename="../src/core/field/Opcode.cpp" line="4433"/>
         <source>OFF</source>
         <translatorcomment>禁止</translatorcomment>
         <translation>オフ</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2600"/>
         <source>BGMOVIE : %1</source>
         <translation>BGMOVIE : %1</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2098"/>
         <source>Return and execute script #%2 from the current entity (Priority %1/6)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2139"/>
         <source>Get party to memory: %1 | %2 | %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2151"/>
         <source>Unused opcode 0x%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2177"/>
         <source>PNAME - Disable right menu (%1, bank=%2, size=%3)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2186"/>
         <source>%1 = Game Speed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2193"/>
         <source>Set field message speed: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2265"/>
         <source>SPECIAL - Unknown %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2441"/>
         <source>Write bytes to address 0x%1 (length=%2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2593"/>
         <source>%1 Field Model blinking</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2607"/>
         <source>Field Model graphic filter - Change the state of the eye/mouth texture (eye 1=%1, eye 2=%2, mouth=%3, 3D object ID=%4)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2617"/>
         <source>Field Model graphic filter - %1 blending</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2624"/>
         <source>Field Model graphic filter - Change the ambient color of the model: RGB(%1, %2, %3) RGB(%4, %5, %6) (flags=%7)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2638"/>
         <source>Field Model graphic filter - UNKNOWN4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2645"/>
         <source>Field Model graphic filter - LIGHT</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2652"/>
         <source>Field Model graphic filter - UNKNOWN7</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2659"/>
         <source>Field Model graphic filter - UNKNOWN8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2666"/>
         <source>Field Model graphic filter - UNKNOWN9</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2673"/>
         <source>Field Model graphic filter - SBOBJ</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2680"/>
         <source>Field Model graphic filter - UNKNOWNB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2687"/>
         <source>Field Model graphic filter - UNKNOWNC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2694"/>
         <source>Field Model graphic filter - SHINE</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2701"/>
         <source>Field Model graphic filter - RESET</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2723"/>
         <source>Field Model graphic filter - Unknown %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2731"/>
         <source>Wait for Field Model graphic filter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2744"/>
         <source>SLIP : %1</source>
         <translatorcomment>SLIP: %1</translatorcomment>
         <translation>SLIP: %1</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3036"/>
-        <location filename="../src/core/field/Opcode.cpp" line="3070"/>
         <source>%1 (char ID)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3335"/>
         <source>%4 = amount of materia %1 in the inventory (AP=%2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3346"/>
         <source>Shake (type=%1, xAmplitude=%2, xFrames=%3, yAmplitude=%2, yFrames=%3)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3445"/>
         <source>MPDSP : %1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3452"/>
         <source>Scroll to location (?=%1, ?=%2, enable=%3)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3665"/>
         <source>Seed Random Generator : %1</source>
         <translatorcomment>Seed Random Generator: %1</translatorcomment>
         <translation>乱数ジェネレータをシード: %1</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3917"/>
         <source>%1 = %2 &amp; 0xFF (low byte)</source>
         <translation>%1 = %2 &amp; 0xFF (下位バイト)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3927"/>
         <source>%1 = (%2 &gt;&gt; 8) &amp; 0xFF (high byte)</source>
         <translation>%1 = (%2 &gt;&gt; 8) &amp; 0xFF (上位バイト)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3937"/>
         <source>%1 = (%2 &amp; 0xFF) | ((%3 &amp; 0xFF) &lt;&lt; 8)</source>
         <translation>%1 = (%2 &amp; 0xFF) | ((%3 &amp; 0xFF) &lt;&lt; 8)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3948"/>
         <source>SETX[%1][%2 + %3] = %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3960"/>
         <source>%1 = GETX[%2][%3 + %4]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4453"/>
         <source>%4 = ((Sinus(%1) * %2) + %3) &gt;&gt; 12</source>
         <translation>%4 = ((サイン (%1) * %2) + %3) &gt;&gt; 12</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4465"/>
         <source>%4 = ((Cosinus(%1) * %2) + %3) &gt;&gt; 12</source>
         <translation>%4 = ((コサイン (%1) * %2) + %3) &gt;&gt; 12</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4491"/>
         <source>Preload the field map %1</source>
         <translation>フィールド マップ %1 の先読み</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4499"/>
         <source>PMJMP2</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4519"/>
         <source>%1 rotation</source>
         <translation>回転を %1</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4705"/>
         <source>Copy palette 2 (sourceTile=%1, targetTile=%2, sourcePal=%3, targetPal=%4, color count=%3 + 1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4719"/>
         <source>Copy partially palette 2 %1 (sourceTile=%1, targetTile=%2, sourcePal=%3, targetPal=%4, first color=%5)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4735"/>
         <source>Add RGB(%6, %5, %4) on the colors in a palette (2) (sourceTile=%1, targetTile=%2, first color=%3, color count=%7)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4781"/>
         <source>Play temporary music #%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4847"/>
         <source>Set next field music for when we will be back to the map: #%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4854"/>
         <source>CMUSC (music #%1, operation=%2, param1=%3, param2=%4)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4880"/>
         <source> (No%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4882"/>
         <source>? (No%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4894"/>
         <source>(no text)</source>
         <translation>(テキストなし)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4934"/>
         <source>%1 (#%2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4952"/>
         <source>%1 (disc %2)</source>
         <translation>%1 (ディスク %2)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5009"/>
         <source>Resumes music and sound effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5011"/>
         <source>Pauses music and sound effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5013"/>
         <source>Resumes only the music</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5015"/>
         <source>Pauses only the music</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5017"/>
         <source>Resumes only sound effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5019"/>
         <source>Pauses only sound effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5021"/>
         <source>Volume control (channel #1) [param1: volume]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5023"/>
         <source>Volume control (channel #2) [param1: volume]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5025"/>
         <source>Volume control (channel #3) [param1: volume]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5027"/>
         <source>Volume control (channel #4) [param1: volume]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5037"/>
         <source>Pan control (channel #1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5039"/>
         <source>Pan control (channel #2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5041"/>
         <source>Pan control (channel #3)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5043"/>
         <source>Pan control (channel #4)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5045"/>
         <source>Pan transitions (channel #1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5047"/>
         <source>Pan transitions (channel #2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5049"/>
         <source>Pan transitions (channel #3)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5053"/>
         <source>Tempo control (channel #1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5055"/>
         <source>Tempo control (channel #2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5057"/>
         <source>Tempo control (channel #3)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5059"/>
         <source>Tempo control (channel #4)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5061"/>
         <source>Tempo transitions (channel #1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5063"/>
         <source>Tempo transitions (channel #2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5065"/>
         <source>Tempo transitions (channel #3)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5073"/>
         <source>Pan control for all channels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5075"/>
         <source>Pan transitions for all channels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5077"/>
         <source>Tempo control for all channels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5079"/>
         <source>Tempo transitions for all channels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5085"/>
         <source>Fade music volume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5095"/>
         <source>Music tempo transition</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5097"/>
         <source>Music tempo fade</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5099"/>
         <source>Stop music-like (noop in PC version)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5101"/>
         <source>Stop music</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5103"/>
         <source>Stop sound effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5109"/>
         <source>AKAO: %1?</source>
         <translation>AKAO: %1?</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5147"/>
         <source>%1 and %2 and %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5160"/>
         <source>%1 and %2 and %3 and %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5177"/>
         <source>(Empty)</source>
         <translation type="unfinished">(なし)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5192"/>
         <source>Top Left</source>
         <translation>左上</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5193"/>
         <source>Bottom Left</source>
         <translation>左下</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5194"/>
         <source>Top Right</source>
         <translation>右上</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5195"/>
         <source>Bottom Right</source>
         <translation>右下</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5203"/>
-        <location filename="../src/core/field/Opcode.cpp" line="5204"/>
         <source>reverse</source>
         <translation>反転</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2041"/>
         <source>Return</source>
         <translation>リターン</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2046"/>
         <source>Execute script #%3 in extern group %1 (priority %2/6) - Only if the script is not already running</source>
         <translation>グループ %1 のスクリプト #%3 を実行 (優先度 %2/6) - スクリプトが実行されていない場合のみ</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2054"/>
         <source>Execute script #%3 in extern group %1 (priority %2/6)</source>
         <translation>グループ %1 のスクリプト #%3 を実行 (優先度 %2/6)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2062"/>
         <source>Execute script #%3 in group %1 (priority %2/6) - Waiting for end of execution to continue</source>
         <translation>外部グループ %1 のスクリプト #%3 を実行 (優先度 %2/6) - 完了してから次へ</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2071"/>
         <source>Execute script #%3 in extern group associated with the character #%1 in the current party (priority %2/6) - Only if the script is not already running</source>
         <translation>現在のパーティのキャラクター #%1 のグループのスクリプト #%3 を実行 (優先度 %2/6) - スクリプトが実行されていない場合のみ</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2080"/>
         <source>Execute script #%3 in extern group associated with the character #%1 in the current party (priority %2/6)</source>
         <translation>現在のパーティのキャラクター #%1 のグループのスクリプト #%3 を実行 (優先度 %2/6)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2089"/>
         <source>Execute script #%3 in group associated with the character #%1 in the current party (priority %2/6) - Waiting for end of execution to continue</source>
         <translation>現在のパーティのキャラクター #%1 のグループのスクリプト #%3 を実行 (優先度 %2/6) - 完了したら次へ</translation>
     </message>
@@ -2750,17 +2213,14 @@ Some scripts can refer to it!</source>
         <translation type="vanished">リターンして呼び出したグループのスクリプト #%2 を実行 (優先度 %1/6)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2106"/>
         <source>Join party field (speed=%1)</source>
         <translation>パーティ合流フィールド (速度=%1)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2113"/>
         <source>Split party field (member 1: X=%1, Y=%2, dir=%3 ; member 2 : X=%4, Y=%5, dir=%6) (speed %7)</source>
         <translation>メンバー分割フィールド (メンバー 1: X=%1, Y=%2, dir=%3 ; メンバー 2 : X=%4, Y=%5, dir=%6) (速度 %7)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2128"/>
         <source>Set party from memory: %1 | %2 | %3</source>
         <translation>パーティをメモリからセット: %1 | %2 | %3</translation>
     </message>
@@ -2769,24 +2229,18 @@ Some scripts can refer to it!</source>
         <translation type="vanished">パーティをメモリに送る: %1 | %2 | %3</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2163"/>
         <source>Ask for disc %1</source>
         <translation>ディスク %1 の確認</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2170"/>
         <source>%1 arrow</source>
         <translation type="unfinished">カーソルを %1</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2171"/>
-        <location filename="../src/core/field/Opcode.cpp" line="4015"/>
         <source>Display</source>
         <translation>表示</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2171"/>
-        <location filename="../src/core/field/Opcode.cpp" line="4015"/>
         <source>Hide</source>
         <translation>隠す</translation>
     </message>
@@ -2799,69 +2253,42 @@ Some scripts can refer to it!</source>
         <translation type="vanished">フィールド メッセージ速度をセット (%2) | %1 |</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2201"/>
         <source>Fill materia menu with all materias in full quantity</source>
         <translation>マテリア メニューのマテリアを最大数に</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2208"/>
         <source>Fills all available item entries in full quantity</source>
         <translation>すべての使用可能な所持アイテムを最大化</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2215"/>
         <source>%1 battles</source>
         <translation type="unfinished">バトルを %1</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2216"/>
-        <location filename="../src/core/field/Opcode.cpp" line="2223"/>
-        <location filename="../src/core/field/Opcode.cpp" line="2618"/>
-        <location filename="../src/core/field/Opcode.cpp" line="2827"/>
-        <location filename="../src/core/field/Opcode.cpp" line="3486"/>
-        <location filename="../src/core/field/Opcode.cpp" line="3516"/>
-        <location filename="../src/core/field/Opcode.cpp" line="3659"/>
-        <location filename="../src/core/field/Opcode.cpp" line="4334"/>
-        <location filename="../src/core/field/Opcode.cpp" line="4520"/>
         <source>Activate</source>
         <translation>有効化</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2216"/>
-        <location filename="../src/core/field/Opcode.cpp" line="2223"/>
-        <location filename="../src/core/field/Opcode.cpp" line="2618"/>
-        <location filename="../src/core/field/Opcode.cpp" line="2827"/>
-        <location filename="../src/core/field/Opcode.cpp" line="3486"/>
-        <location filename="../src/core/field/Opcode.cpp" line="3516"/>
-        <location filename="../src/core/field/Opcode.cpp" line="3659"/>
-        <location filename="../src/core/field/Opcode.cpp" line="4334"/>
-        <location filename="../src/core/field/Opcode.cpp" line="4520"/>
         <source>Deactivate</source>
         <translation>無効化</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2222"/>
         <source>%1 movies</source>
         <translation>ムービーを %1</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2228"/>
         <source>Change name of %1 by text %2</source>
         <translation>%1 の名前をテキスト %2 に変更</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2239"/>
         <source>Set game time to 0, unlock &quot;PHS&quot; and Save menu. New party: Cloud | (empty) | (empty)</source>
         <translation>プレイ時間を 0 に, PHS とセーブを有効化, 新しいパーティ クラウド | (空き) | (空き)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2246"/>
         <source>Remove all items</source>
         <translation>すべてのアイテムを削除</translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/core/field/Opcode.cpp" line="2279"/>
-        <location filename="../src/core/field/Opcode.cpp" line="2287"/>
         <source>Forward %n byte(s)</source>
         <comment>With plural</comment>
         <translation type="unfinished">
@@ -2869,16 +2296,10 @@ Some scripts can refer to it!</source>
         </translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2280"/>
-        <location filename="../src/core/field/Opcode.cpp" line="2288"/>
-        <location filename="../src/core/field/Opcode.cpp" line="2296"/>
-        <location filename="../src/core/field/Opcode.cpp" line="2304"/>
         <source>Goto label %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/core/field/Opcode.cpp" line="2295"/>
-        <location filename="../src/core/field/Opcode.cpp" line="2303"/>
         <source>Back %n byte(s)</source>
         <comment>With plural</comment>
         <translation type="unfinished">
@@ -2886,28 +2307,10 @@ Some scripts can refer to it!</source>
         </translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2311"/>
-        <location filename="../src/core/field/Opcode.cpp" line="2325"/>
-        <location filename="../src/core/field/Opcode.cpp" line="2339"/>
-        <location filename="../src/core/field/Opcode.cpp" line="2353"/>
-        <location filename="../src/core/field/Opcode.cpp" line="2367"/>
-        <location filename="../src/core/field/Opcode.cpp" line="2381"/>
         <source>If %1 %3 %2 (%4)</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location filename="../src/core/field/Opcode.cpp" line="2317"/>
-        <location filename="../src/core/field/Opcode.cpp" line="2331"/>
-        <location filename="../src/core/field/Opcode.cpp" line="2345"/>
-        <location filename="../src/core/field/Opcode.cpp" line="2359"/>
-        <location filename="../src/core/field/Opcode.cpp" line="2373"/>
-        <location filename="../src/core/field/Opcode.cpp" line="2387"/>
-        <location filename="../src/core/field/Opcode.cpp" line="2434"/>
-        <location filename="../src/core/field/Opcode.cpp" line="2792"/>
-        <location filename="../src/core/field/Opcode.cpp" line="2805"/>
-        <location filename="../src/core/field/Opcode.cpp" line="2818"/>
-        <location filename="../src/core/field/Opcode.cpp" line="4369"/>
-        <location filename="../src/core/field/Opcode.cpp" line="4381"/>
         <source>else forward %n byte(s)</source>
         <comment>With plural</comment>
         <translation type="unfinished">
@@ -2915,168 +2318,126 @@ Some scripts can refer to it!</source>
         </translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2399"/>
         <source>8 bit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2402"/>
         <source>16 bit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2405"/>
         <source>24 bit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2408"/>
         <source>32 bit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2415"/>
         <source>From is a pointer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2419"/>
         <source>To is a pointer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2422"/>
         <source>Write/Read entire savemap (from=%1, to=%2, absValue=%3, flags={%4})</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2432"/>
         <source>If Red XIII is named Nanaki (%2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2471"/>
-        <location filename="../src/core/field/Opcode.cpp" line="3052"/>
         <source>Bike (parameter %1)</source>
         <translation>バイク (パラメータ %1)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2475"/>
         <source>Chocobo Races (parameter %1)</source>
         <translation>チョコボ レース (パラメータ %1)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2479"/>
         <source>Snowboard -normal mode- (parameter %1)</source>
         <translation>スノーボード・アイシクル (パラメータ %1)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2483"/>
         <source>Fort Condor (parameter %1)</source>
         <translation>コンドルフォート (パラメータ %1)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2487"/>
         <source>Submarine (parameter %1)</source>
         <translation>潜水艦 (パラメータ %1)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2491"/>
         <source>Speed Square (parameter %1)</source>
         <translation>スピードスクエア (パラメータ %1)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2495"/>
         <source>Snowboard -Gold Saucer mode- (parameter %1)</source>
         <translation>スノーボード・ゴールドソーサー (パラメータ %1)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2499"/>
-        <location filename="../src/core/field/Opcode.cpp" line="3140"/>
         <source>%1? (parameter %2)</source>
         <translation>%1? (パラメータ %2)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2505"/>
         <source>Mini-game: %5 (After the game goto field %1 (X=%2, Y=%3, triangle ID=%4))</source>
         <translation>ミニゲーム: %5 (ゲームがフィールド %1 (X=%2, Y=%3, ポリゴンID=%4) に達したとき)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2516"/>
         <source>Tutorial #%1</source>
         <translation>解説 No.%1</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2529"/>
-        <location filename="../src/core/field/Opcode.cpp" line="3527"/>
         <source>Countdown</source>
         <translation>カウントダウン</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2532"/>
-        <location filename="../src/core/field/Opcode.cpp" line="3530"/>
         <source>Pre-emptive attack</source>
         <translation>先制攻撃</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2535"/>
-        <location filename="../src/core/field/Opcode.cpp" line="3533"/>
         <source>The party cannot escape the battle</source>
         <translation>パーティはバトルから逃走不能</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2538"/>
-        <location filename="../src/core/field/Opcode.cpp" line="3536"/>
         <source>Do not play the battle victory music</source>
         <translation>バトル勝利時の BGM を再生しない</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2541"/>
-        <location filename="../src/core/field/Opcode.cpp" line="3539"/>
         <source>Activates the battle arena</source>
         <translation>バトル アリーナの有効化</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2544"/>
-        <location filename="../src/core/field/Opcode.cpp" line="3542"/>
         <source>Do not show battle rewards</source>
         <translation>バトル後の AP/EXP/ギル/アイテム 精算画面を表示しない</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2547"/>
         <source>The party members do not perform their victory celebrations at the end of battle</source>
         <translation>バトル後のメンバーの決めポーズをやめる</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2550"/>
-        <location filename="../src/core/field/Opcode.cpp" line="3545"/>
         <source>Disable game over</source>
         <translation>ゲーム オーバーを無効化</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2559"/>
-        <location filename="../src/core/field/Opcode.cpp" line="3554"/>
         <source>Battle mode: %1</source>
         <translation>バトル モード : %1</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2560"/>
-        <location filename="../src/core/field/Opcode.cpp" line="3555"/>
         <source>None</source>
         <translation type="unfinished">なし</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2566"/>
         <source>Stores the result of the last battle in %1</source>
         <translation>最後のバトル結果を %1 に保存</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2573"/>
         <source>Wait %1 frame</source>
         <translation>%1 フレーム待機</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2580"/>
         <source>Fades the screen to the colour RGB(%2, %3, %4) (speed=%5, type=%1)</source>
         <translation>画面を RGB(%2, %3, %4) にフェード (速度=%5, タイプ=%1)</translation>
     </message>
@@ -3097,267 +2458,210 @@ Some scripts can refer to it!</source>
         <translation type="vanished">グラフィック フィルター待ち</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2737"/>
         <source>Move Field Model to Party Member #%1</source>
         <translation>3Dモデルをパーティ メンバー #%1 に移動</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2751"/>
         <source>Set Z-deph for the background layer #%1 (Z=%2)</source>
         <translation>背景レイヤー #%1 の Z 値をセット (Z=%2)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2759"/>
         <source>Animate the background layer #%1 (Horizontally=%2, Vertically=%3)</source>
         <translation>背景レイヤー  #%1 をアニメーション (水平=%2, 垂直=%3)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2770"/>
         <source>Close the window #%1</source>
         <translation>ウィンドウを閉じる (ウィンドウ #%1)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2777"/>
         <source>Resizes/Repositions the window #%1 (X=%2, Y=%3, width=%4, height=%5)</source>
         <translation>ウィンドウ #%1 のリサイズと移動 (X=%2, Y=%3, 幅=%4, 高さ=%5)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5218"/>
         <source>(no key)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="5220"/>
         <source> or </source>
         <translation>または</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2788"/>
         <source>If key %1 pressed (%2)</source>
         <translation type="unfinished">キー %1 が押された場合 (%2)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2801"/>
         <source>If key %1 pressed once (%2)</source>
         <translation type="unfinished">キー %1 が一度押された場合 (%2)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2814"/>
         <source>If key %1 released once (%2)</source>
         <translation type="unfinished">キー %1 が一度離された場合 (%2)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2826"/>
         <source>%1 the movability of the playable character</source>
         <translation>操作可能キャラクターの移動能力を %1</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2833"/>
         <source>Instantly turns the field model to face the party member #%1</source>
         <translation>3Dモデルの向きをパーティ メンバー #%1 の方へただちにターン</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2840"/>
         <source>Turns the field model to face the party member #%1 (Speed=%2, Rotation=%3)</source>
         <translation>3Dモデルの向きをパーティ メンバー #%1 の方へターン (速度=%2, 回転=%3)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2852"/>
         <source>(none)</source>
         <translation>(なし)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2855"/>
         <source>Clock (00:00)</source>
         <translation>クロック (00:00)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2858"/>
         <source>Numeric (000000)</source>
         <translation>数値 (000000)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2866"/>
         <source>%2 in the window #%1 (left=%3, top=%4)</source>
         <translation>ウィンドウ #%1 内の %2 (左=%3, 上=%4)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2876"/>
         <source>Sets %2 in window #%1 (show %3 digits)</source>
         <translation>%2 をウィンドウ #%1 にセット (%3 回表示)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2885"/>
         <source>Set Timer (H=%1, M=%2, S=%3)</source>
         <translation>タイマーをセット (H=%1, M=%2, S=%3)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2896"/>
         <source>Add %1 gil to the party </source>
         <translation>パーティの所持ギルに %1 を加える</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2903"/>
         <source>Remove %1 gils from the party</source>
         <translation>パーティの所持ギルから %1 を減らす</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2910"/>
         <source>Copies the amount of gil in %1 and %2</source>
         <translation>%1 と %2 にギルの総額をコピー</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2921"/>
-        <location filename="../src/core/field/Opcode.cpp" line="2928"/>
-        <location filename="../src/core/field/Opcode.cpp" line="2942"/>
         <source>Restores full HP and MP of every party member</source>
         <translation>すべてのパーティメンバーの HP, MP を回復</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2935"/>
         <source>Restores full HP and MP of every available character and removing status effects</source>
         <translation>利用可能なすべてのキャラクターの HP, MP を回復してステータス異常も解消</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2947"/>
         <source>Displays the dialog %2 in the window #%1</source>
         <translation>ダイアログ %2 をウィンドウ #%1 に表示</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2955"/>
-        <location filename="../src/core/field/Opcode.cpp" line="2964"/>
         <source>Set %3 to the variable #%2 in the window #%1</source>
         <translation>ウィンドウ #%1 の変数 #%2 に %3 をセット</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2972"/>
         <source>Display %1 in the main menu</source>
         <translation>%1 をメイン メニューに表示</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2985"/>
         <source>Add %2 MP to party member #%1</source>
         <translation>パーティ メンバー #%1 の MP を %2 増やす</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="2999"/>
         <source>Remove %2 MP to party member #%1</source>
         <translation>パーティ メンバー #%1 の MP を %2 減らす</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3006"/>
         <source>Ask Question %2 in the window #%1 (and put selected answer in %5) first line=%3, last line=%4</source>
         <translation>ウィンドウ #%1 に選択肢 %2 を表示 (続いてプレーヤーの選択を %5 にセット) 最初の行=%3, 最後の行=%4</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3092"/>
         <source>all magic materias are present and mastered</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3095"/>
         <source>all summon materias are present and mastered</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3098"/>
         <source>necessary command materias are present and mastered</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3101"/>
         <source>Bahamut and Neo Bahamut materias are present</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3104"/>
         <source>22? (parameter %1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3114"/>
         <source>Remove mastered magic materias and add Master Magic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3117"/>
         <source>Remove mastered summon materias and add Master Summon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3120"/>
         <source>Remove mastered meaning command materias and add Master Command</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3123"/>
         <source>Add Bahamut Zero to the inventory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3126"/>
         <source>23? (parameter %1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3030"/>
         <source>ff7 credits (parameter %1)</source>
         <translation>FF7 クレジット (パラメータ %1)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3034"/>
         <source>Change name of %1</source>
         <translation>名前の変更: %1</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3040"/>
         <source>Change party (parameter %1)</source>
         <translation>パーティ変更 (パラメータ %1)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3044"/>
         <source>Shop No%1</source>
         <translation>ショップ No.%1</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3056"/>
         <source>Save (parameter %1)</source>
         <translation>セーブ (パラメータ %1)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3060"/>
         <source>Remove all materias (parameter %1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3064"/>
         <source>Restore all materias (parameter %1)</source>
         <translation>すべてのマテリアを解除 (パラメータ %1)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3068"/>
         <source>Remove %1&apos;s Materia</source>
         <translation>%1 のマテリアを解除</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3074"/>
         <source>Clear Cloud&apos;s materias (parameter %1)</source>
         <translation>クラウドのマテリアを解除 (パラメータ %1)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3078"/>
         <source>Restore Cloud&apos;s materias (parameter %1)</source>
         <translation>クラウドのマテリアを戻す (パラメータ %1)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3082"/>
-        <location filename="../src/core/field/Opcode.cpp" line="3132"/>
-        <location filename="../src/core/field/Opcode.cpp" line="3136"/>
         <source>? (parameter %1)</source>
         <translation>? (パラメータ %1)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3086"/>
         <source>HP to 1 (parameter %1)</source>
         <translatorcomment>エンカウント エラー (パラメータ %1)</translatorcomment>
         <translation>HP を 1 に (パラメータ %1)</translation>
@@ -3367,127 +2671,102 @@ Some scripts can refer to it!</source>
         <translation type="vanished">マスター ? (パラメータ %1)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3146"/>
         <source>Show menu %1</source>
         <translation>メニュー %1 を表示</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3153"/>
         <source>%1 access to the main menu</source>
         <translation type="unfinished">メイン メニューへのアクセスを %1</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3154"/>
         <source>Enables</source>
         <translation>有効化</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3154"/>
         <source>Disables</source>
         <translation>無効化</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3160"/>
         <source>Set battle table: %1</source>
         <translation>バトル テーブル %1 をセット</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3173"/>
         <source>Add %2 HP to party member #%1</source>
         <translation>パーティ メンバー #%1 の HP を %2 増やす</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3187"/>
         <source>Remove %2 HP to party member #%1</source>
         <translation>パーティ メンバー  #%1 の HP を %2 減らす</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3195"/>
         <source>Create window #%1 (X=%2, Y=%3, Width=%4, Height=%5)</source>
         <translation>ウィンドウ #%1 の作成 (X=%2, Y=%3, 幅=%4, 高さ=%5)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3206"/>
         <source>Move the window #%1 (Move : X=%2, Y=%3)</source>
         <translation>ウィンドウ #%1 を移動 (X=%2, Y=%3)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3219"/>
         <source>Normal</source>
         <translation>ノーマル</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3222"/>
         <source>No Background/Border</source>
         <translation>背景/ボーダーなし</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3225"/>
         <source>Transparent Background</source>
         <translation>背景の透過</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3233"/>
         <source>Set the window #%1 mode: %2 (%3 the closing of the window by the player)</source>
         <translation>ウィンドウ #%1 モード: %2 をセット (プレーヤーがウィンドウを閉じる操作を %3)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3237"/>
         <source>Authorize</source>
         <translation>許可</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3237"/>
         <source>prevent</source>
         <translation>禁止</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3244"/>
         <source>Reset the window #%1</source>
         <translation>ウィンドウ #%1 をリセット</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3251"/>
         <source>Close the window #%1 (stronger)</source>
         <translation>ウィンドウを閉じる (ウィンドウ #%1)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3258"/>
         <source>Number of row in the window #%1 = %2</source>
         <translation>ウィンドウ #%1 の桁数 = %2</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3266"/>
         <source>Get windows %1 color to %2 (R), %3 (G) and %4 (B)</source>
         <translation>ウィンドウ %1 の色を  %2 (R), %3 (G), %4 (B) に変更</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3278"/>
         <source>Set windows %1 color: RGB(%2, %3, %4)</source>
         <translation>ウィンドウ %1 の色をセット: RGB(%2, %3, %4)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3290"/>
         <source>Add %2 item(s) %1 to the inventory</source>
         <translation>アイテム %1 の所持数を %2 増やす</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3299"/>
         <source>Remove %2 item(s) %1 from the inventory</source>
         <translation>アイテム %1 の所持数を %2 減らす</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3308"/>
         <source>%2 = amount of item %1 in the inventory</source>
         <translation>%2 = アイテム %1 の所持数</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3317"/>
         <source>Add %1 materia to the inventory (AP=%2)</source>
         <translation>所持アイテムにマテリア %1 を追加 (AP=%2)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3326"/>
         <source>Remove %3 materia(s) %1 from the inventory (AP=%2)</source>
         <translation>所持アイテムから%3 マテリア %1 を減らす (AP=%2)</translation>
     </message>
@@ -3500,38 +2779,30 @@ Some scripts can refer to it!</source>
         <translation type="vanished">揺らす (nb周期=%1, 拡がり=%2, 速度=%3)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3358"/>
         <source>Perform no operation...</source>
         <translation>何もしない...</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3364"/>
         <source>Jump to map %1 (X=%2, Y=%3, triangle ID=%4, direction=%5)</source>
         <translation>マップ %1 にジャンプ (X=%2, Y=%3, ポリゴンID=%4, 方向=%5)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3388"/>
         <source>Scroll to group %2 (speed=%1, type=%3)</source>
         <translation>グループ %2 へスクロール (速度=%1, タイプ=%3)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3399"/>
         <source>Scroll to location (X=%1, Y=%2)</source>
         <translation>エリアにスクロール (X=%1, Y=%2)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3410"/>
         <source>Scroll to playable character</source>
         <translation>操作可能なキャラクターへスクロール</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3416"/>
-        <location filename="../src/core/field/Opcode.cpp" line="3434"/>
         <source>Scroll to location (X=%1, Y=%2, speed=%3)</source>
         <translation>エリアにスクロール (X=%1, Y=%2, 速度=%3)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3428"/>
         <source>Wait for scroll</source>
         <translation>スクロール待ち</translation>
     </message>
@@ -3540,432 +2811,335 @@ Some scripts can refer to it!</source>
         <translation type="vanished">エリアにスクロール (?=%1, ?=%2, ?=%3)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3463"/>
         <source>Fades the screen to the colour RGB(%1, %2, %3) (speed=%4, type=%5, adjust=%6)</source>
         <translation>画面の色を RGB(%1, %2, %3) にフェード (速度=%4, タイプ=%5, アジャスト=%6)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3478"/>
         <source>Wait for fade</source>
         <translation>フェード待ち</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3484"/>
         <source>%2 the triangle #%1</source>
         <translation>ポリゴン #%1 を %2</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3492"/>
         <source>Retrieves the field ID number of the last field in %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3499"/>
         <source>Scroll to party member #%2 (speed=%1 frames, type=%3)</source>
         <translation>パーティ メンバー#%2 にスクロール (速度=%1 フレーム, タイプ=%3)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3508"/>
         <source>Start battle #%1</source>
         <translation>バトル #%1 の開始</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3515"/>
         <source>%1 random battle</source>
         <translation>ランダム バトルを %1</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3561"/>
         <source>Get direction of the party member #%1 to %2</source>
         <translation>パーティ メンバー #%1 の向きを取得して %2 へ保存</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3569"/>
         <source>Get group ID of the party member #%1 to %2</source>
         <translation>パーティ メンバー #%1 のグループID を取得して %2 へ保存</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3577"/>
         <source>Get coordinates of the party member #%1 (store : X in %2, Y in %3, Z in %4 and triangle ID in %5)</source>
         <translation>パーティ メンバー #%1 の座標を取得して保存 (X → %2 , Y → %3, Z → %4, ポリゴンID → %5)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3590"/>
-        <location filename="../src/core/field/Opcode.cpp" line="3722"/>
         <source>%1 = %1 + %2 (8 bit)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3600"/>
-        <location filename="../src/core/field/Opcode.cpp" line="3732"/>
         <source>%1 = %1 + %2 (16 bit)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3610"/>
-        <location filename="../src/core/field/Opcode.cpp" line="3742"/>
         <source>%1 = %1 - %2 (8 bit)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3620"/>
-        <location filename="../src/core/field/Opcode.cpp" line="3752"/>
         <source>%1 = %1 - %2 (16 bit)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3630"/>
-        <location filename="../src/core/field/Opcode.cpp" line="3882"/>
         <source>%1 = %1 + 1 (8 bit)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3637"/>
-        <location filename="../src/core/field/Opcode.cpp" line="3889"/>
         <source>%1 = %1 + 1 (16 bit)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3644"/>
-        <location filename="../src/core/field/Opcode.cpp" line="3896"/>
         <source>%1 = %1 - 1 (8 bit)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3651"/>
-        <location filename="../src/core/field/Opcode.cpp" line="3903"/>
         <source>%1 = %1 - 1 (16 bit)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3658"/>
         <source>%1 talk script for the current field model</source>
         <translation>3Dモデルのダイアログ スクリプトを %1</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3672"/>
         <source>%1 = %2 (8 bit)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3682"/>
         <source>%1 = %2 (16 bit)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3692"/>
         <source>Bit %2 ON in %1</source>
         <translation>%1 の %2 ビット目を 1 にセット</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3702"/>
         <source>Bit %2 OFF in %1</source>
         <translation>%1 の %2 ビット目を 0 にセット</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3712"/>
         <source>Toggle bit %2 in %1</source>
         <translation>%1 の %2 ビット目を切り替え</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3762"/>
         <source>%1 = %1 * %2 (8 bit)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3772"/>
         <source>%1 = %1 * %2 (16 bit)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3782"/>
         <source>%1 = %1 / %2 (8 bit)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3792"/>
         <source>%1 = %1 / %2 (16 bit)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3802"/>
         <source>%1 = %1 mod %2 (8 bit)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3812"/>
         <source>%1 = %1 mod %2 (16 bit)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3822"/>
         <source>%1 = %1 &amp; %2 (8 bit)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3832"/>
         <source>%1 = %1 &amp; %2 (16 bit)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3842"/>
         <source>%1 = %1 | %2 (8 bit)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3852"/>
         <source>%1 = %1 | %2 (16 bit)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3862"/>
         <source>%1 = %1 ^ %2 (8 bit)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3872"/>
         <source>%1 = %1 ^ %2 (16 bit)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3910"/>
         <source>Set random value to %1 (8-bit)</source>
         <translation>%1 にランダムな値をセット (8-bit)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3970"/>
         <source>Search the value %5 in the memory (bank=%1, start=%2+%3, end=%2+%4) and put the position in %6</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3984"/>
         <source>Field model is playable and it is %1</source>
         <translation>操作可能な 3Dモデル %1</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3991"/>
         <source>This group is a field model (ID=%1)</source>
         <translation>この項は 3Dモデル (ID=%1) のグループ</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3998"/>
         <source>Play loop animation #%1 of the field model (speed=%2)</source>
         <oldsource>Play animation #%1 of the field model (speed=%2)</oldsource>
         <translation type="unfinished">3Dモデルのアニメーション #%1 を再生 (速度=%2)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4006"/>
-        <location filename="../src/core/field/Opcode.cpp" line="4108"/>
         <source>Play animation #%1 of the field model and reset to previous state (speed=%2)</source>
         <translation>3Dモデルのアニメーション #%1 を再生して前のステートをリセット (速度=%2)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4014"/>
         <source>%1 field model</source>
         <translation type="unfinished">3Dモデルを %1</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4021"/>
         <source>Place field Model (X=%1, Y=%2, Z=%3, triangle ID=%4)</source>
         <translation>3Dモデルを配置 (X=%1, Y=%2, Z=%3, ポリゴンID=%4)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4033"/>
         <source>Place field Model (X=%1, Y=%2, triangle ID=%4)</source>
         <translation>3Dモデルを配置 (X=%1, Y=%2, ポリゴンID=%4)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4044"/>
         <source>Place field Model (X=%1, Y=%2, Z=%3)</source>
         <translation>3Dモデルを配置 (X=%1, Y=%2, Z=%3)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4055"/>
         <source>Move field Model (X=%1, Y=%2)</source>
         <translation>3Dモデルを移動 (X=%1, Y=%2)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4065"/>
-        <location filename="../src/core/field/Opcode.cpp" line="4098"/>
         <source>Place field Model without animation (X=%1, Y=%2)</source>
         <translation>3Dモデルをアニメーション抜きで移動 (X=%1, Y=%2)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4074"/>
         <source>Move field Model to the group %1</source>
         <translation>3Dモデルをグループ %1 に移動</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4080"/>
         <source>Rotation of the field model to group %1 (Speed=%3, Rotation=%2)</source>
         <translation>3Dモデルをグループ %1 の方向へ回転 (速度=%3, 回転=%2)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4092"/>
         <source>Wait for animation</source>
         <translation>アニメーション待ち</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4116"/>
         <source>Play animation #%1 of the field model (speed=%2, type=1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4124"/>
-        <location filename="../src/core/field/Opcode.cpp" line="4220"/>
         <source>Play partially the animation #%1 of the field model and reset to initial state (first frame=%2, last frame=%3, speed=%4)</source>
         <translation>3Dモデルのアニメーション #%1 の一部を再生して初期状態にリセット (最初のフレーム=%2, 最後のフレーム=%3, 速度=%4)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4134"/>
-        <location filename="../src/core/field/Opcode.cpp" line="4230"/>
         <source>Play partially the animation #%1 of the field model (first frame=%2, last frame=%3, speed=%4)</source>
         <translation>3Dモデルのアニメーション #%1 の一部を再生 (最初のフレーム=%2, 最後のフレーム=%3, 速度=%4)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4144"/>
         <source>Set the field model move speed: %1</source>
         <translation>3Dモデルの移動速度を %1 にセット</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4151"/>
         <source>Set field model direction: %1</source>
         <translation>3Dモデルの向きを %1 にセット</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4158"/>
         <source>Rotation (direction=%1, nbRevolution=%2, speed=%3, ?=%4)</source>
         <translation>回転 (方向=%1, nb回転量=%2, 速度=%3, ?=%4)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4168"/>
         <source>Inversed rotation (direction=%1, nbRevolution=%2, speed=%3, ?=%4)</source>
         <translation>反回転 (方向=%1, nb回転量=%2, 速度=%3, ?=%4)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4177"/>
         <source>Direct the field model towards the group %1</source>
         <translation>3Dモデルの向きグループ %1の方向へセット</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4183"/>
         <source>Store direction of the group %1 in %2</source>
         <translation>グループ %1 の向きを %2 に保存</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4192"/>
         <source>Store position of the group %1 in %2 (X) and %3 (Y)</source>
         <translation>グループ %1 の向きを %2 (X), %3 (Y) に保存</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4202"/>
         <source>Store triangle ID of the group %1 in %2</source>
         <translation>グループ %1 のポリゴンを %2 に保存</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4212"/>
         <source>Play animation #%1 of the field model (speed=%2, type=2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4240"/>
         <source>Set the field model animations speed: %1</source>
         <translation>3D アニメーションの速度を %1 にセット</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4252"/>
         <source>Control the group %1</source>
         <translation>グループ %1 のコントロール</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4259"/>
         <source>Field model jump (X=%1, Y=%2, triangle ID=%3, Steps=%4)</source>
         <translation>3Dモデルのジャンプ (X=%1, Y=%2, ポリゴンID=%3, 歩数=%4)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4270"/>
         <source>Store position of the group %1 in %2 (X), %3 (Y), %4 (Z) and %5 (triangle ID)</source>
         <translation>グループ %1 の位置を保存 %2(X), %3(Y), %4(Z), %5(ポリゴンID) </translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4283"/>
         <source>Climb a ladder with the animation #%6 (X=%1, Y=%2, Z=%3, triangle ID=%4, direction1=%5, direction2=%7, speed=%8)</source>
         <translation>匍匐アニメーション #%6 (X=%1, Y=%2, Z=%3, ポリゴンID=%4, 方向1=%5, 方向2=%7, 速度=%8)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4299"/>
         <source>Offset Object (movement=%1, X=%2, Y=%3, Z=%4, speed=%5)</source>
         <translation>オブジェの移動 (移動量=%1, X=%2, Y=%3, Z=%4, 速度=%5)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4313"/>
         <source>Wait for offset object</source>
         <translation>オブジェの移動待ち</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4319"/>
-        <location filename="../src/core/field/Opcode.cpp" line="4477"/>
         <source>Set range of the talk circle for the field model: %1</source>
         <translation>3Dモデル %1 のダイアログ範囲の大きさをセット</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4326"/>
-        <location filename="../src/core/field/Opcode.cpp" line="4484"/>
         <source>Set range of the contact circle for the field model: %1</source>
         <translation>3Dモデル %1 のコンタクト範囲の大きさをセット</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4333"/>
         <source>%1 contact with field model</source>
         <translation type="unfinished">3Dモデルとのコンタクトを %1</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4340"/>
         <source>Add %1 to the current party</source>
         <translation>現在のパーティに %1 が加わる</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4347"/>
         <source>Remove %1 from the current party</source>
         <translation>現在のパーティから %1 が離脱</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4354"/>
         <source>New party: %1 | %2 | %3</source>
         <translation>新しいパーティ: %1 | %2 | %3</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4365"/>
         <source>If %1 is in the current party (%2)</source>
         <translation type="unfinished">%1 がパーティにいる場合 (%2)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4377"/>
         <source>If %1 exists (%2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4389"/>
         <source>%2 %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4391"/>
         <source>not available</source>
         <translation>操作不能</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4391"/>
         <source>available</source>
         <translation>使用可能</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4399"/>
         <source>Locks %1 in PHS menu</source>
         <translation>PHS メニューの %1 をロック</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4406"/>
         <source>Unlock %1 in PHS menu</source>
         <translation>PHS メニューの %1 をアンロック</translation>
     </message>
@@ -3986,7 +3160,6 @@ Some scripts can refer to it!</source>
         <translation type="vanished">トレース</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4432"/>
         <source>Gateways %1</source>
         <translation type="unfinished">出入り口 %1</translation>
     </message>
@@ -3995,129 +3168,104 @@ Some scripts can refer to it!</source>
         <translation type="vanished">エリアのリサイズ (X1=%1, Y1=%2, Z1=%3, X2=%4, Y2=%5, Z2=%6)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4505"/>
         <source>%1 (param1=%2, param2=%3, param3=%4, param4=%5, param5=%6)</source>
         <oldsource>%1 (16-bit) (param1=%2, param2=%3, param3=%4, param4=%5, param5=%6)</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4526"/>
         <source>Play animation #%1 for &apos;%3&apos; (speed=%2)</source>
         <translation>&apos;%3&apos; のアニメーション #%1 を再生 (速度=%2)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4530"/>
         <source>stay</source>
         <translation>止まる</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4532"/>
         <source>walk</source>
         <translation>歩く</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4533"/>
         <source>run</source>
         <translation>走る</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4540"/>
         <source>Break field model animation</source>
         <translation>3Dモデルのアニメーションを停止</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4547"/>
         <source>Wait for rotation</source>
         <translation>回転待ち</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4553"/>
         <source>Multiply RGB(%6, %5, %4) on the colors in a palette (sourcePal=%1, targetPal=%2, first color=%3, color count=%7+1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4568"/>
         <source>Show the state #%2 of the background parameter #%1</source>
         <translation>背景パラメータ #%1 のステート #%2 を表示</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4578"/>
         <source>Hide the state #%2 of the background parameter #%1</source>
         <translation>背景パラメータ #%1 のステート #%2 を隠す</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4588"/>
         <source>Show next state of the background parameter #%1</source>
         <translation>背景パラメータ #%1 の次のステートを表示</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4595"/>
         <source>Show previous state of the background parameter #%1</source>
         <translation>背景パラメータ #%1 の前のステートを表示</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4602"/>
         <source>Hide background parameter #%1</source>
         <translation>背景パラメータ #%1 を隠す</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4609"/>
         <source>Load the palette #%1 in the position %2 (color count=%3)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4620"/>
         <source>Load the position %1 in the palette #%2 (color count=%3)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4631"/>
         <source>Copy palette (sourcePal=%1, targetPal=%2, color count=%3)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4642"/>
         <source>Copy partially palette (sourcePal=%1, targetPal=%2, first color=%3, color count=%4)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4654"/>
         <source>Add RGB(%5, %4, %3) on the colors in a palette (sourcePal=%1, targetPal=%2, color count=%6)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4668"/>
         <source>Multiply RGB(%5, %4, %3) on the colors in a palette (sourcePal=%1, targetPal=%2, color count=%6)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4682"/>
         <source>Load the palette #%1 in the position %2 (first color=%3, color count=%4)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4692"/>
         <source>Load the position %1 in the palette #%2 (first color=%3, color count=%4)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4767"/>
         <source>%1 (param1 (8-bit)=%2, param2=%3, param3=%4, param4=%5, param5=%6)</source>
         <oldsource>%1 (8-bit) (param1=%2, param2=%3, param3=%4, param4=%5, param5=%6)</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4866"/>
         <source>If music is currently playing set %1 to 1</source>
         <translation type="unfinished">BGM が再生されたとき %1 に 1 をセット</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3375"/>
         <source>SCRLO (?=%1)</source>
         <translation type="unfinished">SCRLO (?=%1)</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="3382"/>
         <source>SCRLC (?=%1)</source>
         <translation type="unfinished">SCRLC (?=%1)</translation>
     </message>
@@ -4130,7 +3278,6 @@ Some scripts can refer to it!</source>
         <translation type="obsolete">GETX %1</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Opcode.cpp" line="4874"/>
         <source>Game Over</source>
         <translation>ゲーム・オーバー</translation>
     </message>
@@ -4138,163 +3285,131 @@ Some scripts can refer to it!</source>
 <context>
     <name>OpcodeList</name>
     <message>
-        <location filename="../src/widgets/OpcodeList.cpp" line="35"/>
         <source>Action</source>
         <translation>アクション</translation>
     </message>
     <message>
-        <location filename="../src/widgets/OpcodeList.cpp" line="59"/>
         <source>Copy</source>
         <oldsource>Copier</oldsource>
         <translation type="unfinished">コピー</translation>
     </message>
     <message>
-        <location filename="../src/widgets/OpcodeList.cpp" line="79"/>
         <source>Expand the tree</source>
         <oldsource>Étendre l&apos;arbre</oldsource>
         <translation type="unfinished">ツリーを展く</translation>
     </message>
     <message>
-        <location filename="../src/widgets/OpcodeList.cpp" line="44"/>
         <source>Edit</source>
         <translation type="unfinished">編集</translation>
     </message>
     <message>
-        <location filename="../src/widgets/OpcodeList.cpp" line="48"/>
         <source>Add</source>
         <translation type="unfinished">追加</translation>
     </message>
     <message>
-        <location filename="../src/widgets/OpcodeList.cpp" line="51"/>
-        <location filename="../src/widgets/OpcodeList.cpp" line="796"/>
         <source>Delete</source>
         <translation type="unfinished">削除</translation>
     </message>
     <message>
-        <location filename="../src/widgets/OpcodeList.cpp" line="55"/>
         <source>Cut</source>
         <translation type="unfinished">切り取り</translation>
     </message>
     <message>
-        <location filename="../src/widgets/OpcodeList.cpp" line="63"/>
         <source>Copy text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/OpcodeList.cpp" line="67"/>
         <source>Paste</source>
         <translation type="unfinished">貼り付け</translation>
     </message>
     <message>
-        <location filename="../src/widgets/OpcodeList.cpp" line="71"/>
         <source>Up</source>
         <translation type="unfinished">上に</translation>
     </message>
     <message>
-        <location filename="../src/widgets/OpcodeList.cpp" line="75"/>
         <source>Down</source>
         <translation type="unfinished">下に</translation>
     </message>
     <message>
-        <location filename="../src/widgets/OpcodeList.cpp" line="80"/>
         <source>Undo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/OpcodeList.cpp" line="84"/>
         <source>Redo</source>
         <oldsource>Refaire</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/OpcodeList.cpp" line="88"/>
         <source>Edit text</source>
         <oldsource>Modifier texte</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/OpcodeList.cpp" line="92"/>
-        <location filename="../src/widgets/OpcodeList.cpp" line="248"/>
         <source>Disable tree</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/OpcodeList.cpp" line="93"/>
         <source>Search opcode...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/OpcodeList.cpp" line="250"/>
         <source>Enable tree</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/OpcodeList.cpp" line="282"/>
         <source>Goto label</source>
         <oldsource>Aller au label</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/OpcodeList.cpp" line="283"/>
         <source>Alt + Click to go to the label</source>
         <oldsource>Alt + clic pour aller au label</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/OpcodeList.cpp" line="145"/>
         <source>&amp;Script editor</source>
         <oldsource>Édition du &amp;script</oldsource>
         <translation type="unfinished">スクリプト エディター(&amp;S)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/OpcodeList.cpp" line="151"/>
         <source>Add line</source>
         <translation type="unfinished">行の追加</translation>
     </message>
     <message>
-        <location filename="../src/widgets/OpcodeList.cpp" line="153"/>
         <source>Remove line</source>
         <translation type="unfinished">行の削除</translation>
     </message>
     <message>
-        <location filename="../src/widgets/OpcodeList.cpp" line="156"/>
         <source>Move up</source>
         <translation type="unfinished">上へ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/OpcodeList.cpp" line="158"/>
         <source>Move down</source>
         <translation type="unfinished">下へ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/OpcodeList.cpp" line="285"/>
         <source>Goto script</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/OpcodeList.cpp" line="286"/>
         <source>Alt + Click to go to the script</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/OpcodeList.cpp" line="491"/>
         <source>If this script is run,
  assume that the last non-empty script that runs</source>
         <translation type="unfinished">このスクリプトを実行した場合
 空ではないスクリプトの最後のものが実行されます</translation>
     </message>
     <message>
-        <location filename="../src/widgets/OpcodeList.cpp" line="797"/>
         <source>Are you sure you want to delete %1?</source>
         <translation type="unfinished">%1 を削除しますか？</translation>
     </message>
     <message>
-        <location filename="../src/widgets/OpcodeList.cpp" line="799"/>
         <source>the selected command</source>
         <translation type="unfinished">選択コマンド</translation>
     </message>
     <message>
-        <location filename="../src/widgets/OpcodeList.cpp" line="800"/>
         <source>the selected commands</source>
         <translation type="unfinished">選択したコマンド</translation>
     </message>
@@ -4302,48 +3417,39 @@ Some scripts can refer to it!</source>
 <context>
     <name>OperationsManager</name>
     <message>
-        <location filename="../src/widgets/OperationsManager.cpp" line="23"/>
         <source>Batch processing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/OperationsManager.cpp" line="25"/>
         <source>Clean all unused texts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/OperationsManager.cpp" line="26"/>
         <source>Autosize all text windows in the game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/OperationsManager.cpp" line="27"/>
         <source>Disable all texts in the game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/OperationsManager.cpp" line="28"/>
         <source>Disable all battles in the game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/OperationsManager.cpp" line="30"/>
         <source>Clean unused data in field model loaders</source>
         <oldsource>Remove all unused data for field backgrounds</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/OperationsManager.cpp" line="31"/>
         <source>Clean unused data for field backgrounds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/OperationsManager.cpp" line="32"/>
         <source>Repair broken backgrounds (lastmap, fr_e)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/OperationsManager.cpp" line="36"/>
         <source>Apply</source>
         <oldsource>Appliquer</oldsource>
         <translation type="unfinished"></translation>
@@ -4352,8 +3458,6 @@ Some scripts can refer to it!</source>
 <context>
     <name>OrientationWidget</name>
     <message>
-        <location filename="../src/widgets/OrientationWidget.cpp" line="95"/>
-        <location filename="../src/widgets/OrientationWidget.cpp" line="97"/>
         <source>Right</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4361,52 +3465,42 @@ Some scripts can refer to it!</source>
 <context>
     <name>PsfDialog</name>
     <message>
-        <location filename="../src/widgets/PsfDialog.cpp" line="37"/>
         <source>psflib</source>
         <translation>psflib</translation>
     </message>
     <message>
-        <location filename="../src/widgets/PsfDialog.cpp" line="39"/>
         <source>Title</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/PsfDialog.cpp" line="41"/>
         <source>Artist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/PsfDialog.cpp" line="43"/>
         <source>Game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/PsfDialog.cpp" line="45"/>
         <source>Year</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/PsfDialog.cpp" line="47"/>
         <source>Genre</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/PsfDialog.cpp" line="49"/>
         <source>Comment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/PsfDialog.cpp" line="51"/>
         <source>Copyright</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/PsfDialog.cpp" line="53"/>
         <source>Author</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/PsfDialog.cpp" line="78"/>
         <source>(auto)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4414,12 +3508,10 @@ Some scripts can refer to it!</source>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/core/field/GrpScript.cpp" line="117"/>
         <source>Untitled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/GrpScript.cpp" line="151"/>
         <source>Field model</source>
         <translation>3Dモデル</translation>
     </message>
@@ -4428,114 +3520,95 @@ Some scripts can refer to it!</source>
         <translation type="vanished">エリア</translation>
     </message>
     <message>
-        <location filename="../src/core/field/GrpScript.cpp" line="155"/>
         <source>Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/GrpScript.cpp" line="157"/>
         <source>Animation</source>
         <translation>アニメーション</translation>
     </message>
     <message>
-        <location filename="../src/core/field/GrpScript.cpp" line="159"/>
         <source>Main</source>
         <translation>メイン</translation>
     </message>
     <message>
-        <location filename="../src/core/field/GrpScript.cpp" line="187"/>
         <source>S0 - Init</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/core/field/GrpScript.cpp" line="189"/>
         <source>S0 - Main</source>
         <translation>S0 - メイン</translation>
     </message>
     <message>
-        <location filename="../src/core/field/GrpScript.cpp" line="192"/>
         <source>S1 - Talk</source>
         <oldsource>S1 - Parler</oldsource>
         <translatorcomment>S1 - Talk</translatorcomment>
         <translation type="unfinished">S1 - ダイアログ</translation>
     </message>
     <message>
-        <location filename="../src/core/field/GrpScript.cpp" line="195"/>
         <source>S1 - [OK]</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/core/field/GrpScript.cpp" line="200"/>
         <source>S2 - Contact</source>
         <oldsource>S2 - Toucher</oldsource>
         <translatorcomment>S2 - Contact</translatorcomment>
         <translation type="unfinished">S2 - コンタクト</translation>
     </message>
     <message>
-        <location filename="../src/core/field/GrpScript.cpp" line="203"/>
         <source>S2 - Move</source>
         <oldsource>S2 - Bouger</oldsource>
         <translatorcomment>S2 - Move</translatorcomment>
         <translation type="unfinished">S2 - 通過</translation>
     </message>
     <message>
-        <location filename="../src/core/field/GrpScript.cpp" line="208"/>
         <source>S3 - Move</source>
         <oldsource>S3 - Bouger</oldsource>
         <translatorcomment>S3 - Move</translatorcomment>
         <translation type="unfinished">S3 - 通過</translation>
     </message>
     <message>
-        <location filename="../src/core/field/GrpScript.cpp" line="213"/>
         <source>S4 - Go</source>
         <oldsource>S4 - Aller</oldsource>
         <translatorcomment>S4 - Go</translatorcomment>
         <translation type="unfinished">S4 - 進入</translation>
     </message>
     <message>
-        <location filename="../src/core/field/GrpScript.cpp" line="218"/>
         <source>S5 - Go 1x</source>
         <oldsource>S5 - Aller 1x</oldsource>
         <translatorcomment>S5 - Go 1x</translatorcomment>
         <translation type="unfinished">S5 - 進入 1x</translation>
     </message>
     <message>
-        <location filename="../src/core/field/GrpScript.cpp" line="223"/>
         <source>S6 - Go away</source>
         <oldsource>S6 - Partir</oldsource>
         <translatorcomment>S6 - Go away</translatorcomment>
         <translation type="unfinished">S6 - 離れる</translation>
     </message>
     <message>
-        <location filename="../src/core/field/GrpScript.cpp" line="228"/>
         <source>Script %1</source>
         <translation>スクリプト %1</translation>
     </message>
     <message>
-        <location filename="../src/core/field/GrpScript.cpp" line="492"/>
         <source>Group &apos;%1&apos;:</source>
         <oldsource>Groupe &apos;%1&apos; :</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/GrpScript.cpp" line="500"/>
         <source>Script &apos;%1&apos; :</source>
         <translation type="unfinished">スクリプト %1 :</translation>
     </message>
     <message>
-        <location filename="../src/Data.cpp" line="506"/>
         <source>Cloud</source>
         <oldsource>Clad</oldsource>
         <translatorcomment>Cloud</translatorcomment>
         <translation type="unfinished">クラウド</translation>
     </message>
     <message>
-        <location filename="../src/Data.cpp" line="506"/>
         <source>Barret</source>
         <translation>バレット</translation>
     </message>
     <message>
-        <location filename="../src/Data.cpp" line="506"/>
         <source>Tifa</source>
         <translation>ティファ</translation>
     </message>
@@ -4545,201 +3618,165 @@ Some scripts can refer to it!</source>
         <translation type="vanished">エアリス</translation>
     </message>
     <message>
-        <location filename="../src/Data.cpp" line="507"/>
         <source>Red XIII</source>
         <translation>レッドXIII</translation>
     </message>
     <message>
-        <location filename="../src/Data.cpp" line="507"/>
         <source>Yuffie</source>
         <translation>ユフィ</translation>
     </message>
     <message>
-        <location filename="../src/Data.cpp" line="507"/>
         <source>Aerith</source>
         <translation>エアリス</translation>
     </message>
     <message>
-        <location filename="../src/Data.cpp" line="508"/>
         <source>Cait Sith</source>
         <translation>ケット・シー</translation>
     </message>
     <message>
-        <location filename="../src/Data.cpp" line="508"/>
         <source>Vincent</source>
         <translation>ヴィンセント</translation>
     </message>
     <message>
-        <location filename="../src/Data.cpp" line="508"/>
         <source>Cid</source>
         <translation>シド</translation>
     </message>
     <message>
-        <location filename="../src/Data.cpp" line="509"/>
         <source>Yound Cloud</source>
         <oldsource>Jeune Clad</oldsource>
         <translatorcomment>Young Cloud</translatorcomment>
         <translation type="unfinished">昔のクラウド</translation>
     </message>
     <message>
-        <location filename="../src/Data.cpp" line="509"/>
         <source>Sephiroth</source>
         <translation>セフィロス</translation>
     </message>
     <message>
-        <location filename="../src/Data.cpp" line="509"/>
         <source>Chocobo</source>
         <translation>チョコボ</translation>
     </message>
     <message>
-        <location filename="../src/Data.cpp" line="514"/>
         <source>[CAMERA|L2]</source>
         <translation>[視点|L2]ボタン</translation>
     </message>
     <message>
-        <location filename="../src/Data.cpp" line="514"/>
         <source>[TARGET|R2]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Data.cpp" line="515"/>
         <source>[PAGE UP|L1]</source>
         <oldsource>[PAGE HAUT|L1]</oldsource>
         <translatorcomment>[PAGE UP|L1]</translatorcomment>
         <translation type="unfinished">|ページ送り|L1}ボタン</translation>
     </message>
     <message>
-        <location filename="../src/Data.cpp" line="515"/>
         <source>[PAGE DOWN|R1]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Data.cpp" line="516"/>
         <source>[MENU|TRIANGLE]</source>
         <translation>[メニュー|△]ボタン</translation>
     </message>
     <message>
-        <location filename="../src/Data.cpp" line="516"/>
         <source>[OK|CIRCLE]</source>
         <translation type="unfinished">[決定|○]ボタン</translation>
     </message>
     <message>
-        <location filename="../src/Data.cpp" line="520"/>
         <source>[UP]</source>
         <translation type="unfinished">[↑]ボタン</translation>
     </message>
     <message>
-        <location filename="../src/Data.cpp" line="520"/>
         <source>[RIGHT]</source>
         <translation type="unfinished">[→]ボタン</translation>
     </message>
     <message>
-        <location filename="../src/Data.cpp" line="521"/>
         <source>[DOWN]</source>
         <translation type="unfinished">[↓]ボタン</translation>
     </message>
     <message>
-        <location filename="../src/Data.cpp" line="521"/>
         <source>[LEFT]</source>
         <translation type="unfinished">[←]ボタン</translation>
     </message>
     <message>
-        <location filename="../src/Data.cpp" line="517"/>
         <source>[CANCEL|CROSS]</source>
         <oldsource>[ANNULER|CROIX]</oldsource>
         <translatorcomment>[CANCEL|CROSS]</translatorcomment>
         <translation type="unfinished">[キャンセル|×]ボタン</translation>
     </message>
     <message>
-        <location filename="../src/Data.cpp" line="517"/>
         <source>[SWITCH|SQUARE]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Data.cpp" line="518"/>
         <source>[ASSIST|SELECT]</source>
         <oldsource>[ASSISTER|SELECT]</oldsource>
         <translatorcomment>[ヘルプ|ASSIST|SELECT]</translatorcomment>
         <translation type="unfinished">[SELECT]ボタン</translation>
     </message>
     <message>
-        <location filename="../src/Data.cpp" line="519"/>
         <source>[START]</source>
         <oldsource>[DEMARRER|START]</oldsource>
         <translatorcomment>[START]</translatorcomment>
         <translation type="unfinished">[START]ボタン</translation>
     </message>
     <message>
-        <location filename="../src/core/field/TutFileStandard.cpp" line="163"/>
         <source>Error</source>
         <oldsource>Erreur</oldsource>
         <translatorcomment>Error</translatorcomment>
         <translation>エラー</translation>
     </message>
     <message>
-        <location filename="../src/core/field/TutFileStandard.cpp" line="167"/>
         <source>totalLength=%1
 id=%2
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/TutFileStandard.cpp" line="174"/>
         <source>length=%1
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/TutFileStandard.cpp" line="181"/>
         <source>ChannelCount=%1
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Script.cpp" line="167"/>
         <source>Label %1 is declared several times.</source>
         <oldsource>Le label %1 est déclaré plusieurs fois.</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Script.cpp" line="198"/>
         <source>Label %1 not found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Script.cpp" line="216"/>
         <source>Invalid jump, you must point to a valid label.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Script.cpp" line="222"/>
         <source>Label %1 is unreachable, please bring this instruction closer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Script.cpp" line="219"/>
         <source>The label %1 is unreachable because it is located before the opcode.</source>
         <oldsource>Le label %1 est inaccessible car il se trouve avant la commande.</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Script.cpp" line="225"/>
         <source>Invalid jump to the label %1 which is after the maximum possible size of the script.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Script.cpp" line="228"/>
         <source>Invalid jump to before the script.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Script.cpp" line="237"/>
         <source>Script too big, it should not exceed 65535 bytes. Actual size: %1.</source>
         <oldsource>Script trop grand, il ne doit pas dépasser les 65535 octets. Taille actuelle : %1.</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/IsoArchiveFF7.cpp" line="531"/>
         <source>Cannot update game binaries.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4750,86 +3787,62 @@ Make sure it is valid or delete it.</source>
 ファイルが有効か確認するか、または削除してください。。</translation>
     </message>
     <message>
-        <location filename="../src/core/field/Section1File.cpp" line="45"/>
         <source>Map name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Section1File.cpp" line="46"/>
         <source>Hello world!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/FieldArchiveIOPS.cpp" line="418"/>
         <source>Cannot remove destination archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/FieldArchiveIOPS.cpp" line="434"/>
         <source>Cannot rename temporary file to destination path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Field.cpp" line="411"/>
         <source>File size greater than 10000000</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Field.cpp" line="424"/>
         <source>Malformed LZS header</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Field.cpp" line="452"/>
-        <location filename="../src/core/field/Field.cpp" line="556"/>
         <source>Incorrect field file size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Field.cpp" line="465"/>
-        <location filename="../src/core/field/Field.cpp" line="564"/>
         <source>Cannot open section 1 (texts, scripts and musics)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Field.cpp" line="473"/>
-        <location filename="../src/core/field/Field.cpp" line="572"/>
         <source>Cannot open tutos section</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Field.cpp" line="481"/>
-        <location filename="../src/core/field/Field.cpp" line="587"/>
         <source>Cannot open encounters section</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Field.cpp" line="489"/>
-        <location filename="../src/core/field/Field.cpp" line="595"/>
         <source>Cannot open walkmesh section</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Field.cpp" line="497"/>
-        <location filename="../src/core/field/Field.cpp" line="603"/>
         <source>Cannot open camera section</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Field.cpp" line="505"/>
-        <location filename="../src/core/field/Field.cpp" line="611"/>
         <source>Cannot open info section</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Field.cpp" line="513"/>
-        <location filename="../src/core/field/Field.cpp" line="580"/>
         <source>Cannot open model loader section</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/field/Field.cpp" line="542"/>
-        <location filename="../src/core/field/Field.cpp" line="633"/>
         <source>Cannot open background section</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4837,69 +3850,58 @@ Make sure it is valid or delete it.</source>
 <context>
     <name>ScriptEditor</name>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="48"/>
         <source>Script Editor%1</source>
         <oldsource>Éditeur de script%1</oldsource>
         <translatorcomment>Editor%1</translatorcomment>
         <translation type="unfinished">エディター%1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="48"/>
         <source> (init mode)</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="52"/>
         <source>Control Structures</source>
         <oldsource>Structures de contrôle</oldsource>
         <translatorcomment>Control Structures</translatorcomment>
         <translation type="unfinished">コントロール ストラクチャ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="54"/>
         <source>Windowing and messages</source>
         <oldsource>Fenêtres et messages</oldsource>
         <translatorcomment>Windowing and messages</translatorcomment>
         <translation>ウィンドウとメッセージ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="55"/>
         <source>Party and inventory</source>
         <oldsource>Équipe et inventaire</oldsource>
         <translatorcomment>Party and inventory</translatorcomment>
         <translation>パーティと所持アイテム</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="56"/>
         <source>Field Models and animations</source>
         <oldsource>Objets 3D et animations</oldsource>
         <translatorcomment>Field Models and animations</translatorcomment>
         <translation type="unfinished">3Dモデルとアニメーション</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="58"/>
         <source>Background</source>
         <translation>背景</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="60"/>
         <source>Audio and video</source>
         <oldsource>Audio et vidéo</oldsource>
         <translatorcomment>Audio and video</translatorcomment>
         <translation type="unfinished">サウンドとビデオ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="61"/>
         <source>Modules</source>
         <translation>モジュール</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="78"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="523"/>
         <source>Seed Random Generator</source>
         <translation>乱数ジェネレータをシード</translation>
     </message>
@@ -4912,154 +3914,128 @@ Make sure it is valid or delete it.</source>
         <translation type="vanished">コサイン</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="498"/>
         <source>Label</source>
         <translation type="unfinished">レイヤー</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="509"/>
         <source>No Operation</source>
         <oldsource>Opération binaire</oldsource>
         <translation>命令なし</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="517"/>
         <source>Unary operation</source>
         <oldsource>Opération bit à bit</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="551"/>
         <source>HP/MP Maximum (1)</source>
         <oldsource>HP/MP restaurés (3)</oldsource>
         <translatorcomment>HP/MP Maximum (3)</translatorcomment>
         <translation>HP/MP 最大化 (1)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="592"/>
         <source>Place (X,Y,Z)</source>
         <oldsource>Placer (Dir)</oldsource>
         <translatorcomment>Place (Dir)</translatorcomment>
         <translation>位置 (X,Y,Z)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="677"/>
         <source>Store Palette</source>
         <oldsource>ST (Store) Palette</oldsource>
         <translatorcomment>●</translatorcomment>
         <translation type="unfinished">ST (保存) Palette</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="678"/>
         <source>Store Palette (S)</source>
         <oldsource>ST (Store) PLS</oldsource>
         <translatorcomment>●</translatorcomment>
         <translation type="unfinished">ST (保存) PLS</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="679"/>
         <source>Load Palette</source>
         <oldsource>LD (Load) Palette</oldsource>
         <translatorcomment>●</translatorcomment>
         <translation type="unfinished">LD (読み込み) Palette</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="680"/>
         <source>Load Palette (S)</source>
         <oldsource>LD (Load) PLS</oldsource>
         <translatorcomment>●</translatorcomment>
         <translation type="unfinished">LD (読み込み) PLS</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="681"/>
         <source>Copy Palette</source>
         <oldsource>CP (Copy) Palette</oldsource>
         <translatorcomment>●</translatorcomment>
         <translation type="unfinished">CP (コピー) Palette</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="682"/>
         <source>Copy Palette (2)</source>
         <oldsource>CP (Copy) Palette (2)</oldsource>
         <translatorcomment>●</translatorcomment>
         <translation type="unfinished">CP (コピー) Palette (2)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="683"/>
         <source>Partial Copy Palette</source>
         <oldsource>RT Palette</oldsource>
         <translatorcomment>●</translatorcomment>
         <translation type="unfinished">RT Palette</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="684"/>
         <source>Partial Copy Palette (2)</source>
         <oldsource>RT Palette (2)</oldsource>
         <translatorcomment>●</translatorcomment>
         <translation type="unfinished">RT Palette (2)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="53"/>
         <source>Mathematics</source>
         <translation>演算命令</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="57"/>
         <source>Walkmesh and locations</source>
         <translation>ウォーク メッシュとエリア</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="59"/>
         <source>Fade and camera</source>
         <translation>フェードとカメラ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="62"/>
         <source>Unknown</source>
         <translation type="unfinished">不明</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="80"/>
         <source>Cancel</source>
         <translation>キャンセル</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="490"/>
         <source>Return</source>
         <translation>リターン</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="491"/>
         <source>Return to</source>
         <translation>リターン →</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="493"/>
         <source>Execute a script</source>
         <translation>スクリプトの実行</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="495"/>
         <source>Execute a script from a party member</source>
         <translation>パーティ メンバーのスクリプトを実行</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="499"/>
         <source>Goto label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="501"/>
         <source>If...then</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="503"/>
         <source>If key pressed</source>
         <translation>キーが押された場合</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="504"/>
         <source>If Party Member</source>
         <translation>パーティ メンバーの場合</translation>
     </message>
@@ -5068,77 +4044,62 @@ Make sure it is valid or delete it.</source>
         <translation type="vanished">キャラクターが存在する場合</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="506"/>
         <source>[DLPB&apos;s custom opcode] If Red XIII is named Nanaki</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="508"/>
         <source>Wait</source>
         <translation>完了待ち</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="512"/>
         <source>Binary operation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="520"/>
         <source>Bitwise operation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="524"/>
         <source>Two Byte from two one-byte</source>
         <translation>1-バイト二つからなる 2-バイト</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="525"/>
         <source>Sinus / Cosinus</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="528"/>
         <source>Window creation</source>
         <translation>ウィンドウの作成</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="529"/>
         <source>Resizes/Repositions a window</source>
         <translation>ウィンドウの大きさ,位置の変更</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="530"/>
         <source>Set line count in window</source>
         <translation>ウィンドウの行数をセット</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="531"/>
         <source>Move a window</source>
         <translation>ウィンドウの移動</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="532"/>
         <source>Set window type</source>
         <translation>ウィンドウ タイプのセット</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="533"/>
         <source>Reset a window</source>
         <translation>ウィンドウのリセット</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="534"/>
         <source>Close a window (1)</source>
         <translation>ウィンドウを閉じる (1)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="535"/>
         <source>Close a window (2)</source>
         <translation>ウィンドウを閉じる (2)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="537"/>
         <source>Numerical Display</source>
         <translation>数値表示</translation>
     </message>
@@ -5147,12 +4108,10 @@ Make sure it is valid or delete it.</source>
         <translation type="vanished">ウィンドウの変数をセット (16-ビット)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="539"/>
         <source>Countdown</source>
         <translation>カウントダウン</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="538"/>
         <source>Set numerical display value</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5161,616 +4120,494 @@ Make sure it is valid or delete it.</source>
         <translation type="vanished">ウィンドウの変数をセット (8-ビット)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="542"/>
         <source>Set window Text</source>
         <translation>ウィンドウにテキストをセット</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="543"/>
         <source>Ask Question</source>
         <translation>選択肢を表示</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="545"/>
         <source>Set map name</source>
         <translation>マップ名をセット</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="546"/>
         <source>Enable/Disable menu</source>
         <translation>メニューの有効化/無効化</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="547"/>
         <source>Get window color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="548"/>
         <source>Set window color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="552"/>
         <source>HP/MP Maximum (2)</source>
         <translation>HP/MP 最大化 (2)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="553"/>
         <source>HP/MP Maximum with Status Clear</source>
         <translation>HP/MP を最大化してステータス異常を解消</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="554"/>
         <source>HP/MP Maximum (3)</source>
         <translation>HP/MP 最大化 (3)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="556"/>
         <source>Increase MP</source>
         <translation>MP を増加</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="557"/>
         <source>Decrease MP</source>
         <translation>MP を増加</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="558"/>
         <source>Increase HP</source>
         <translation>HP を増加</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="559"/>
         <source>Decrease HP</source>
         <translation>HP を減少</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="560"/>
         <source>Add gil</source>
         <translation>所持ギルを増加</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="561"/>
         <source>Remove gil</source>
         <translation>所持ギルを減少</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="562"/>
         <source>Amount of gil</source>
         <translation>所持ギル</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="563"/>
         <source>Add Item</source>
         <translation>アイテムを追加</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="564"/>
         <source>Remove item</source>
         <translation>アイテムを削除</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="565"/>
         <source>Amount of item</source>
         <translation>アイテムの数</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="566"/>
         <source>Add Materia</source>
         <translation>マテリアを追加</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="567"/>
         <source>Remove Materia</source>
         <translation>マテリアを削除</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="568"/>
         <source>Amount of Materia</source>
         <translation>マテリアの数</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="570"/>
         <source>Party Change</source>
         <translation>パーティ変更</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="571"/>
         <source>Add Character to the party</source>
         <translation>パーティにキャラクターを追加</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="572"/>
         <source>Remove Character from the party</source>
         <translation>パーティからキャラクターをはずす</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="573"/>
         <source>Save party</source>
         <translation>パーティを保存</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="574"/>
         <source>Load party</source>
         <translation>パーティを読み込み</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="575"/>
         <source>Create/Delete character</source>
         <translation>キャラクターの作成/削除</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="576"/>
         <source>Lock character</source>
         <translation>キャラクターをロック</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="577"/>
         <source>Unlock character</source>
         <translation>キャラクターをアンロック</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="580"/>
         <source>Set Field Model</source>
         <translation>3Dモデルをセット</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="581"/>
         <source>Set character to Field Model</source>
         <translation>3Dモデルにキャラクターを追加</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="582"/>
         <source>Group control</source>
         <translation>グループ コントロール</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="584"/>
         <source>Get Group Direction (Dir)</source>
         <translation>グループの向きを取得 (Dir)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="585"/>
         <source>Get Party Member Direction (Dir)</source>
         <translation>パーティ メンバーの向きを取得 (Dir)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="586"/>
         <source>Get Group Triangle ID (I)</source>
         <translation>グループのポリゴンID を取得 (I)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="587"/>
         <source>Get Party Member Triangle ID (I)</source>
         <translation>パーティ メンバーのポリゴンID を取得 (I)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="588"/>
         <source>Get Group coordinates (X,Y)</source>
         <translation>グループの座標を取得 (X,Y)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="589"/>
         <source>Get Group coordinates (X,Y,Z,I)</source>
         <translation>グループの座標を取得 (X,Y,Z,I)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="590"/>
         <source>Get Party coordinates (X,Y,Z,I)</source>
         <translation>他のメンバーの座標を取得 (X,Y,Z,I)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="593"/>
         <source>Place (X,Y,I)</source>
         <translation>位置 (X,Y,I)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="594"/>
         <source>Place (X,Y,Z,I)</source>
         <translation>位置 (X,Y,Z,I)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="595"/>
         <source>Place (Dir)</source>
         <translation>位置 (Dir)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="597"/>
         <source>Move</source>
         <translation>移動</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="598"/>
         <source>Move without animation</source>
         <translation>アニメーションぬきで移動</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="599"/>
         <source>Move without animation or rotation</source>
         <translation>アニメーション・回転せずに移動</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="600"/>
         <source>Move to Group</source>
         <translation>グループに移動</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="601"/>
         <source>Move to Party Member</source>
         <translation>パーティ メンバーの方へ移動</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="603"/>
         <source>Turn</source>
         <translation>回転</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="604"/>
         <source>Direction to Group</source>
         <translation>グループへの方向</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="605"/>
         <source>Direction to Party Member</source>
         <translation>パーティ メンバーへの方向</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="606"/>
         <source>Inversed Turn</source>
         <translation>反転</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="607"/>
         <source>Direction (inversed) to Group</source>
         <translation>向きをグループの方へ反転</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="608"/>
         <source>Direction (inversed) to Party Member</source>
         <translation>向きをパーティ メンバーの方へ反転</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="609"/>
         <source>Wait for Turn</source>
         <translation>回転待ち</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="618"/>
         <source>Play partial animation and return (1)</source>
         <translation>アニメーションの一部を再生してリターン (1)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="619"/>
         <source>Play partial animation and return (2)</source>
         <translation>アニメーションの一部を再生してリターン (2)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="620"/>
         <source>Play Stand/Walk/Run animation</source>
         <translation>直立/歩行/走行 アニメーションを再生</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="621"/>
         <source>Play jump animation</source>
         <translation>ジャンプ アニメーションを再生</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="623"/>
         <source>Party field join</source>
         <translation>パーティ合流フィールド</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="624"/>
         <source>Party field split</source>
         <translation>パーティ分割フィールド</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="625"/>
         <source>Stop animation</source>
         <translation>アニメーション停止</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="626"/>
         <source>Wait for animation</source>
         <translation>アニメーション待ち</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="628"/>
         <source>Character Graphics - Eye open/close</source>
         <translation>キャラクター グラフィック - 目を開ける/閉じる</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="629"/>
         <source>Character Graphics - Activate/Deactivate blending</source>
         <translation type="unfinished">キャラクター グラフィック - 透過のオン/オフ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="640"/>
         <source>Character Graphics - ??? (8)</source>
         <translation>キャラクター グラフィック - ??? (8)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="641"/>
         <source>Character Graphics - SHINE</source>
         <translation>キャラクター グラフィック - SHINE</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="642"/>
         <source>Character Graphics - RESET</source>
         <translation>キャラクター グラフィック - RESET</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="643"/>
         <source>Wait For Character Graphics</source>
         <translation>キャラクター グラフィック待ち</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="648"/>
         <source>Movement Speed</source>
         <translation>移動速度</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="649"/>
         <source>Animation Speed</source>
         <translation>アニメーション速度</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="650"/>
         <source>Hide/Display Field Model</source>
         <translation>3Dモデルを表示/隠す</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="651"/>
         <source>Enable/Disable rotation</source>
         <translation>回転のオン/オフ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="652"/>
         <source>Character Blink</source>
         <translation>キャラクターの瞬き</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="653"/>
         <source>Talk On/Off</source>
         <translation>ダイアログのオン/オフ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="654"/>
         <source>Contact On/Off</source>
         <translation>コンタクトのオン/オフ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="655"/>
         <source>Talk Range (8-bit)</source>
         <translation>ダイアログ範囲 (8-bit)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="656"/>
         <source>Contact range (8-bit)</source>
         <translation>コンタクト範囲 (8-bit)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="657"/>
         <source>Talk Range (16-bit)</source>
         <translation>ダイアログ範囲 (16-bit)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="658"/>
         <source>Contact range (16-bit)</source>
         <translation>コンタクト範囲 (16-bit)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="661"/>
         <source>Create line</source>
         <oldsource>Create location</oldsource>
         <translation type="unfinished">エリアを作成</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="662"/>
         <source>Set line</source>
         <oldsource>Set location</oldsource>
         <translation type="unfinished">エリアをセット</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="663"/>
         <source>Line On/Off</source>
         <oldsource>Location On/Off</oldsource>
         <translation type="unfinished">エリアをオン/オフ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="664"/>
         <source>Triangle On/Off</source>
         <translation>ポリゴンをオン/オフ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="669"/>
         <source>Move background Z layer</source>
         <translation>背景レイヤーを移動 (Z)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="670"/>
         <source>Animate background layer</source>
         <translation>背景レイヤーをアニメーション</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="671"/>
         <source>Show a background state</source>
         <translation>背景ステートを表示</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="672"/>
         <source>Hide background state</source>
         <translation>背景ステートを隠す</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="673"/>
         <source>Show next background state</source>
         <translation>次の背景ステートを表示</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="674"/>
         <source>Show previous background state</source>
         <translation>前の背景ステートを表示</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="675"/>
         <source>Hide background parameters</source>
         <translation>背景パラメータを隠す</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="686"/>
         <source>Multiply Palette (2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="687"/>
         <source>Add Palette</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="688"/>
         <source>Add Palette (2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="691"/>
         <source>Scroll to playable character</source>
         <translation>操作可能なキャラクターへスクロール</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="692"/>
         <source>Scroll to party member</source>
         <translation>パーティ メンバーにスクロール</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="693"/>
         <source>Scroll to group</source>
         <translation>グループにスクロール</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="695"/>
         <source>Scroll (X,Y)</source>
         <translation>スクロール (X,Y)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="696"/>
         <source>Scroll (X,Y,Smooth)</source>
         <translation>スクロール (X,Y,リスムース)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="697"/>
         <source>Scroll (X,Y,Linear)</source>
         <translation>スクロール (X,Y,リニア)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="701"/>
         <source>Shake</source>
         <translation>画面を揺らす</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="702"/>
         <source>Wait for scroll</source>
         <translation>スクロール待ち</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="710"/>
         <source>Play sound</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="711"/>
         <source>Alter sound (8-bit)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="712"/>
         <source>Alter sound (16-bit)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="714"/>
         <source>Play music</source>
         <translation>BGM を再生</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="715"/>
         <source>Play temporary music</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="716"/>
         <source>MUSVM (unused)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="717"/>
         <source>Music Unlock/Lock</source>
         <oldsource>Music On/Off</oldsource>
         <translation type="unfinished">BGM のオン/オフ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="718"/>
         <source>Battle music</source>
         <translation>バトル BGM</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="719"/>
         <source>CHMPH (unused)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="720"/>
         <source>Get music status</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="721"/>
         <source>Field music</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="722"/>
         <source>Play basic akao operation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="724"/>
         <source>Set next movie</source>
         <translation>次のムービーをセット</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="725"/>
         <source>Play movie</source>
         <translation>ムービーの再生</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="731"/>
         <source>Play tutorial</source>
         <translation>解説を再生</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="732"/>
         <source>Display a menu</source>
         <translation>メニューの表示</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="733"/>
         <source>Disc change screen</source>
         <translation>デスクの変更画面</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="734"/>
         <source>Minigame</source>
         <translation>ミニゲーム</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="735"/>
         <source>Battle result load</source>
         <translation>バトル結果の読み込み</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="736"/>
         <source>Battle Table</source>
         <translation>バトル テーブル</translation>
     </message>
@@ -5779,343 +4616,282 @@ Make sure it is valid or delete it.</source>
         <translation type="vanished">フィールドの変更</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="738"/>
         <source>Last Map ID</source>
         <translation>最後のマップ ID</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="739"/>
         <source>Start Battle</source>
         <translation>バトル開始</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="740"/>
         <source>Battle On/Off</source>
         <translation>バトルをオン/オフ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="741"/>
         <source>Battle mode</source>
         <translation>バトル モード</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="742"/>
         <source>Battle mode (2)</source>
         <translation>バトル モード</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="743"/>
         <source>Map Jump On/Off</source>
         <translation>マップのジャンプをオン/オフ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="744"/>
         <source>Character movability On/Off</source>
         <translation>キャラクターの移動をオン/オフ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="745"/>
         <source>Preload field Map</source>
         <translation>フィールド マップの先読み</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="748"/>
         <source>[DLPB&apos;s custom opcode] Write/Read to entire Savemap</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="749"/>
         <source>[DLPB&apos;s custom opcode] Write to any memory address via array</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="756"/>
         <source>SPECIAL - Battle On/Off</source>
         <translation>SPECIAL - バトルをオン/オフ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="757"/>
         <source>SPECIAL - Character movability On/Off</source>
         <translation>SPECIAL - キャラクターの移動をオン/オフ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="611"/>
         <source>Play animation (loop)</source>
         <oldsource>Jouer animation et revenir (1)</oldsource>
         <translation>アニメーションを再生 (ループ)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="505"/>
         <source>If character exists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="540"/>
         <source>Set window variable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="612"/>
         <source>Play animation (1)</source>
         <oldsource>Jouer animation et revenir (2)</oldsource>
         <translatorcomment>Play animation and return (2)</translatorcomment>
         <translation>アニメーションを再生 (1)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="613"/>
         <source>Play animation (2)</source>
         <oldsource>Jouer partiellement animation (1)</oldsource>
         <translatorcomment>Play partial animation (1)</translatorcomment>
         <translation>アニメーションを再生 (2)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="614"/>
         <source>Play animation and return (1)</source>
         <oldsource>Jouer partiellement animation (2)</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="615"/>
         <source>Play animation and return (2)</source>
         <oldsource>Jouer partiellement animation et revenir (1)</oldsource>
         <translation type="unfinished">アニメーションの一部を再生してリターン (1)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="616"/>
         <source>Play partial animation (1)</source>
         <oldsource>Jouer partiellement animation et revenir (2)</oldsource>
         <translatorcomment>Play partial animation and return (2)</translatorcomment>
         <translation type="unfinished">アニメーションの一部を再生してリターン (2)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="617"/>
         <source>Play partial animation (2)</source>
         <oldsource>Jouer animation Stand/Walk/Run</oldsource>
         <translatorcomment>Play Stand/Walk/Run animation</translatorcomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="622"/>
         <source>Play climb animation</source>
         <oldsource>Arrêter animation</oldsource>
         <translation>登攀アニメーションを再生</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="630"/>
         <source>Character Graphics - ??? - AMBNT</source>
         <oldsource>Filtre graphique - ??? (3)</oldsource>
         <translatorcomment>Character Graphics - ??? (3)</translatorcomment>
         <translation>キャラクター グラフィック - AMBNT</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="631"/>
         <source>Character Graphics - ??? (1)</source>
         <oldsource>Filtre graphique - LIGHT</oldsource>
         <translatorcomment>Character Graphics - LIGHT</translatorcomment>
         <translation>キャラクター グラフィック - ??? (1)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="632"/>
         <source>Character Graphics - ??? (2)</source>
         <oldsource>Filtre graphique - ??? (4)</oldsource>
         <translatorcomment>Character Graphics - ??? (4)</translatorcomment>
         <translation>キャラクター グラフィック - ??? (2)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="633"/>
         <source>Character Graphics - ??? (3)</source>
         <oldsource>Filtre graphique - ??? (5)</oldsource>
         <translatorcomment>Character Graphics - ??? (5)</translatorcomment>
         <translation>キャラクター グラフィック - ??? (3)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="634"/>
         <source>Character Graphics - LIGHT</source>
         <oldsource>Filtre graphique - ??? (6)</oldsource>
         <translatorcomment>Character Graphics - ??? (6)</translatorcomment>
         <translation>キャラクター グラフィック - LIGHT</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="635"/>
         <source>Character Graphics - ??? (4)</source>
         <oldsource>Filtre graphique - SBOBJ</oldsource>
         <translatorcomment>Character Graphics - SBOBJ</translatorcomment>
         <translation>キャラクター グラフィック - ??? (4)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="636"/>
         <source>Character Graphics - ??? (5)</source>
         <oldsource>Filtre graphique - ??? (7)</oldsource>
         <translatorcomment>Character Graphics - ??? (7)</translatorcomment>
         <translation>キャラクター グラフィック - ??? (5)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="637"/>
         <source>Character Graphics - ??? (6)</source>
         <oldsource>Filtre graphique - ??? (8)</oldsource>
         <translatorcomment>Character Graphics - ??? (8)</translatorcomment>
         <translation>キャラクター グラフィック - ??? (6)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="638"/>
         <source>Character Graphics - SBOBJ</source>
         <oldsource>Filtre graphique - SHINE</oldsource>
         <translatorcomment>Character Graphics - SHINE</translatorcomment>
         <translation>キャラクター グラフィック - SBOBJ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="639"/>
         <source>Character Graphics - ??? (7)</source>
         <oldsource>Filtre graphique - RESET</oldsource>
         <translatorcomment>Character Graphics - RESET</translatorcomment>
         <translation>キャラクター グラフィック - ??? (7)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="645"/>
         <source>OFST</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="646"/>
         <source>OFSTW</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="666"/>
         <source>SLIP</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="698"/>
         <source>SCRLO</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="699"/>
         <source>SCRLC</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="704"/>
         <source>VWOFT</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="705"/>
         <source>FADE</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="706"/>
         <source>FADEW</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="707"/>
         <source>NFADE</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="726"/>
         <source>MVIEF</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="727"/>
         <source>MVCAM</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="728"/>
         <source>BGMOVIE</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="685"/>
         <source>Multiply Palette</source>
         <oldsource>Additionner Palette (2)</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="746"/>
         <source>PMJMP2</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="747"/>
         <source>Game Over</source>
         <translation>ゲーム オーバー</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="751"/>
         <source>SPECIAL - PNAME</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="750"/>
         <source>SPECIAL - Cursor On/Off</source>
         <oldsource>SPECIAL - Vitesse des message</oldsource>
         <translatorcomment>SPECIAL - Messages Speed</translatorcomment>
         <translation>SPECIAL - カーソルのオン/オフ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="752"/>
         <source>SPECIAL - Game Speed</source>
         <translation>SPECIAL - ゲーム速度</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="754"/>
         <source>SPECIAL - Full Materia</source>
         <translation>SPECIAL - フル マテリア</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="755"/>
         <source>SPECIAL - Full Item</source>
         <translation>SPECIAL - フル アイテム</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="753"/>
         <source>SPECIAL - Messages Speed</source>
         <oldsource>SPECIAL - Activer/Désactiver combats</oldsource>
         <translation>SPECIAL - メッセージ速度</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="737"/>
         <source>Change Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="758"/>
         <source>SPECIAL - Rename character</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="759"/>
         <source>SPECIAL - Clear Game</source>
         <translation>SPECIAL - ゲームをクリア</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="760"/>
         <source>SPECIAL - Clear Items</source>
         <translation>SPECIAL - アイテムをクリア</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="763"/>
         <source>MPDSP</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="764"/>
         <source>SETX</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="765"/>
         <source>GETX</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditor.cpp" line="766"/>
         <source>SEARCHX</source>
         <translation></translation>
     </message>
@@ -6123,88 +4899,72 @@ Make sure it is valid or delete it.</source>
 <context>
     <name>ScriptEditorBinaryOpPage</name>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorMathPage.cpp" line="31"/>
         <source>Assignment</source>
         <translation type="unfinished">代入</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorMathPage.cpp" line="32"/>
         <source>Addition (wrapped)</source>
         <oldsource>Addition (cyclique)</oldsource>
         <translation type="unfinished">加算</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorMathPage.cpp" line="33"/>
         <source>Addition (capped)</source>
         <oldsource>Addition (plafonnée)</oldsource>
         <translation type="unfinished">加算</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorMathPage.cpp" line="34"/>
         <source>Subtraction (wrapped)</source>
         <oldsource>Soustraction (cyclique)</oldsource>
         <translation type="unfinished">減算</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorMathPage.cpp" line="35"/>
         <source>Subtraction (capped)</source>
         <translation type="unfinished">減算</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorMathPage.cpp" line="38"/>
         <source>Modulo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorMathPage.cpp" line="39"/>
         <source>And</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorMathPage.cpp" line="42"/>
         <source>Low-byte</source>
         <translation type="unfinished">下位バイト</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorMathPage.cpp" line="43"/>
         <source>High-byte</source>
         <translation type="unfinished">上位バイト</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorMathPage.cpp" line="58"/>
         <source>It is not possible to divide per 0 or use mod 0, or the game will crash.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorMathPage.cpp" line="36"/>
         <source>Multiplication</source>
         <translation type="unfinished">乗算</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorMathPage.cpp" line="37"/>
         <source>Division</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorMathPage.cpp" line="40"/>
         <source>Or</source>
         <oldsource>Ou</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorMathPage.cpp" line="41"/>
         <source>Exclusive or</source>
         <oldsource>Ou exclusif</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorMathPage.cpp" line="46"/>
         <source>8-bit</source>
         <oldsource>8 bits</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorMathPage.cpp" line="47"/>
         <source>16-bit</source>
         <oldsource>16 bits</oldsource>
         <translation type="unfinished"></translation>
@@ -6213,34 +4973,28 @@ Make sure it is valid or delete it.</source>
 <context>
     <name>ScriptEditorBitOpPage</name>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorMathPage.cpp" line="605"/>
         <source>Set a bit to 1</source>
         <oldsource>Mettre un bit à 1</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorMathPage.cpp" line="606"/>
         <source>Set a bit to 0</source>
         <oldsource>Mettre un bit à 0</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorMathPage.cpp" line="607"/>
         <source>Toggles a bit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorMathPage.cpp" line="610"/>
         <source>Variable</source>
         <translation type="unfinished">変数</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorMathPage.cpp" line="612"/>
         <source>Position</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorMathPage.cpp" line="614"/>
         <source>Operation</source>
         <oldsource>Opération</oldsource>
         <translation type="unfinished"></translation>
@@ -6249,68 +5003,38 @@ Make sure it is valid or delete it.</source>
 <context>
     <name>ScriptEditorBooleanPage</name>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="775"/>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="779"/>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="787"/>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="791"/>
         <source>Enable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="775"/>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="779"/>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="787"/>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="791"/>
         <source>Disable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="783"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="783"/>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="825"/>
         <source>Hide</source>
         <translation type="unfinished">隠す</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="795"/>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="799"/>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="811"/>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="815"/>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="819"/>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="829"/>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="833"/>
         <source>Activate</source>
         <translation type="unfinished">有効化</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="795"/>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="799"/>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="811"/>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="815"/>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="819"/>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="829"/>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="833"/>
         <source>Deactivate</source>
         <translation type="unfinished">無効化</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="803"/>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="807"/>
         <source>ON</source>
         <translation type="unfinished">オン</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="803"/>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="807"/>
         <source>OFF</source>
         <translation type="unfinished">オフ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="825"/>
         <source>Display</source>
         <translation type="unfinished">表示</translation>
     </message>
@@ -6318,52 +5042,42 @@ Make sure it is valid or delete it.</source>
 <context>
     <name>ScriptEditorDLPBSavemap</name>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorSpecialPage.cpp" line="38"/>
         <source>8 bit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorSpecialPage.cpp" line="39"/>
         <source>16 bit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorSpecialPage.cpp" line="40"/>
         <source>24 bit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorSpecialPage.cpp" line="41"/>
         <source>32 bit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorSpecialPage.cpp" line="43"/>
         <source>From is a pointer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorSpecialPage.cpp" line="44"/>
         <source>To is a pointer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorSpecialPage.cpp" line="47"/>
         <source>From</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorSpecialPage.cpp" line="49"/>
         <source>To</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorSpecialPage.cpp" line="51"/>
         <source>Abs Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorSpecialPage.cpp" line="53"/>
         <source>Size</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6371,12 +5085,10 @@ Make sure it is valid or delete it.</source>
 <context>
     <name>ScriptEditorDLPBWriteToMemory</name>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorSpecialPage.cpp" line="111"/>
         <source>Address</source>
         <translation type="unfinished">アドレス</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorSpecialPage.cpp" line="113"/>
         <source>Bytes</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6384,46 +5096,38 @@ Make sure it is valid or delete it.</source>
 <context>
     <name>ScriptEditorExecCharPage</name>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorStructPage.cpp" line="237"/>
         <source>Script %1</source>
         <translation type="unfinished">スクリプト %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorStructPage.cpp" line="241"/>
         <source>Asynchronous, no wait</source>
         <oldsource>Asynchrone, n&apos;attend pas</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorStructPage.cpp" line="242"/>
         <source>Asynchronous, wait</source>
         <oldsource>Asynchrone, attend</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorStructPage.cpp" line="243"/>
         <source>Synchronous, wait</source>
         <oldsource>Synchrone, attend</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorStructPage.cpp" line="246"/>
         <source>Team member</source>
         <translation>チーム メンバー</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorStructPage.cpp" line="248"/>
         <source>Script</source>
         <translation type="unfinished">スクリプト</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorStructPage.cpp" line="250"/>
         <source>Priority</source>
         <oldsource>Priorité</oldsource>
         <translation type="unfinished">優先度</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorStructPage.cpp" line="252"/>
         <source>Type</source>
         <translation type="unfinished">タイプ</translation>
     </message>
@@ -6431,42 +5135,35 @@ Make sure it is valid or delete it.</source>
 <context>
     <name>ScriptEditorExecPage</name>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorStructPage.cpp" line="107"/>
         <source>Asynchronous, no wait</source>
         <oldsource>Asynchrone, n&apos;attend pas</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorStructPage.cpp" line="108"/>
         <source>Asynchronous, wait</source>
         <oldsource>Asynchrone, attend</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorStructPage.cpp" line="109"/>
         <source>Synchronous, wait</source>
         <oldsource>Synchrone, attend</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorStructPage.cpp" line="112"/>
         <source>Group</source>
         <oldsource>Groupe</oldsource>
         <translation type="unfinished">グループ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorStructPage.cpp" line="114"/>
         <source>Script</source>
         <translation type="unfinished">スクリプト</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorStructPage.cpp" line="116"/>
         <source>Priority</source>
         <oldsource>Priorité</oldsource>
         <translation type="unfinished">優先度</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorStructPage.cpp" line="118"/>
         <source>Type</source>
         <translation type="unfinished">タイプ</translation>
     </message>
@@ -6474,323 +5171,264 @@ Make sure it is valid or delete it.</source>
 <context>
     <name>ScriptEditorGenericList</name>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="615"/>
         <source>Long</source>
         <oldsource>Entier long</oldsource>
         <translation type="unfinished">Long</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="616"/>
         <source>Signed long</source>
         <oldsource>Entier long signé</oldsource>
         <translation type="unfinished">符号付き long</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="617"/>
         <source>X coordinate</source>
         <oldsource>Coordonnée X</oldsource>
         <translation type="unfinished">X 座標</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="618"/>
         <source>Y coordinate</source>
         <oldsource>Coordonnée Y</oldsource>
         <translation type="unfinished">Y 座標</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="619"/>
         <source>Z coordinate</source>
         <oldsource>Coordonnée Z</oldsource>
         <translation type="unfinished">Z 座標</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="621"/>
         <source>Tutorial</source>
         <oldsource>Tutoriel</oldsource>
         <translation type="unfinished">解説</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="623"/>
         <source>Disc</source>
         <oldsource>Disque</oldsource>
         <translation type="unfinished">ディスク</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="624"/>
         <source>Minigame</source>
         <oldsource>Mini-jeu</oldsource>
         <translation type="unfinished">ミニゲーム</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="627"/>
         <source>Speed (16-bit)</source>
         <oldsource>Vitesse (16 bits)</oldsource>
         <translation type="unfinished">速度 (16 ビット)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="628"/>
         <source>Direction</source>
         <translation type="unfinished">方向</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="629"/>
         <source>Triangle</source>
         <translation type="unfinished">△</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="630"/>
         <source>Group</source>
         <oldsource>Groupe</oldsource>
         <translation type="unfinished">グループ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="631"/>
         <source>Script</source>
         <translation type="unfinished">スクリプト</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="633"/>
         <source>Bank</source>
         <translation type="unfinished">バンク</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="634"/>
         <source>Address</source>
         <oldsource>Adresse</oldsource>
         <translation type="unfinished">アドレス</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="635"/>
         <source>Priority</source>
         <oldsource>Priorité</oldsource>
         <translation type="unfinished">優先度</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="636"/>
         <source>Flag</source>
         <translation type="unfinished">フラグ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="639"/>
         <source>Operator</source>
         <oldsource>Opérateur</oldsource>
         <translation type="unfinished">演算子</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="640"/>
         <source>Boolean</source>
         <oldsource>Booléen</oldsource>
         <translation type="unfinished">ブーリアン</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="642"/>
         <source>Parameter</source>
         <oldsource>Paramètre</oldsource>
         <translation type="unfinished">パラメータ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="643"/>
         <source>State</source>
         <oldsource>État</oldsource>
         <translation type="unfinished">ステート</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="647"/>
         <source>Variable</source>
         <translation type="unfinished">変数</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="649"/>
         <source>Rotation</source>
         <oldsource>Sens de rotation</oldsource>
         <translation type="unfinished">回転</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="650"/>
         <source>Display Type</source>
         <oldsource>Type d&apos;affichage</oldsource>
         <translation type="unfinished">表示タイプ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="651"/>
         <source>Text</source>
         <oldsource>Texte</oldsource>
         <translation type="unfinished">テキスト</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="652"/>
         <source>Menu</source>
         <translation type="unfinished">メニュー</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="43"/>
         <source>Add a line</source>
         <translation>行の追加</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="45"/>
         <source>Delete a line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="55"/>
         <source>Arguments:</source>
         <translation>パラメータ :</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="614"/>
         <source>Double long</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="620"/>
         <source>Map</source>
         <translation type="unfinished">マップ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="622"/>
         <source>Character</source>
         <translation type="unfinished">キャラクター</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="625"/>
         <source>Short</source>
         <translation type="unfinished">Short</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="626"/>
         <source>Speed (8-bit)</source>
         <translation type="unfinished">速度 (8 ビット)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="632"/>
         <source>Team member</source>
         <translation>チーム メンバー</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="637"/>
         <source>Jump (short)</source>
         <translation>ジャンプ (short)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="638"/>
         <source>Jump (long)</source>
         <oldsource>Jumb (long)</oldsource>
         <translation>ジャンプ (long)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="641"/>
         <source>Layer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="644"/>
         <source>Window</source>
         <translation>ウィンドウ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="645"/>
         <source>Width</source>
         <translation>幅</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="646"/>
         <source>Height</source>
         <translation>高さ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="648"/>
         <source>Key(s)</source>
         <translation>キー</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="653"/>
         <source>Window Type</source>
         <translation>ウィンドウのタイプ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="654"/>
         <source>Item</source>
         <translation>アイテム</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="655"/>
         <source>Materia</source>
         <oldsource>Matéria</oldsource>
         <translation type="unfinished">マテリア</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="656"/>
         <source>Quantity</source>
         <oldsource>Quantité</oldsource>
         <translation type="unfinished">所持数</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="657"/>
         <source>Color</source>
         <oldsource>Couleur</oldsource>
         <translation type="unfinished">カラー</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="658"/>
         <source>Animation</source>
         <translation type="unfinished">アニメーション</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="659"/>
         <source>Music</source>
         <oldsource>Musique</oldsource>
         <translation type="unfinished">BGM</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="660"/>
         <source>Sound</source>
         <oldsource>Son</oldsource>
         <translation type="unfinished">効果音</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="661"/>
         <source>Video</source>
         <oldsource>Vidéo</oldsource>
         <translation type="unfinished">ビデオ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="662"/>
         <source>Label</source>
         <translation>レイヤー</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="663"/>
         <source>Sound operation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="664"/>
         <source>Shake type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="665"/>
         <source>X Amplitude</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="666"/>
         <source>X Frames</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="667"/>
         <source>Y Amplitude</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="668"/>
         <source>Y Frames</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp" line="670"/>
         <source>???</source>
         <translation>???</translation>
     </message>
@@ -6802,33 +5440,27 @@ Make sure it is valid or delete it.</source>
         <translation type="obsolete">キー</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorStructPage.cpp" line="690"/>
         <source>Key pressed</source>
         <oldsource>Touche pressée</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorStructPage.cpp" line="665"/>
         <source>Keys</source>
         <translation type="unfinished">キー</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorStructPage.cpp" line="691"/>
         <source>Key pressed once</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorStructPage.cpp" line="692"/>
         <source>Key released once</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorStructPage.cpp" line="694"/>
         <source>Type</source>
         <translation type="unfinished">タイプ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorStructPage.cpp" line="696"/>
         <source>Label</source>
         <translation type="unfinished">レイヤー</translation>
     </message>
@@ -6836,34 +5468,28 @@ Make sure it is valid or delete it.</source>
 <context>
     <name>ScriptEditorIfPage</name>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorStructPage.cpp" line="530"/>
         <source>16-bit signed</source>
         <oldsource>Sur 16 bits signés</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorStructPage.cpp" line="529"/>
         <source>8-bit unsigned</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorStructPage.cpp" line="531"/>
         <source>16-bit unsigned</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorStructPage.cpp" line="536"/>
         <source>Test</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorStructPage.cpp" line="540"/>
         <source>Compare type</source>
         <oldsource>Type de comparaison</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorStructPage.cpp" line="542"/>
         <source>Label</source>
         <translation type="unfinished">レイヤー</translation>
     </message>
@@ -6871,18 +5497,14 @@ Make sure it is valid or delete it.</source>
 <context>
     <name>ScriptEditorIfQPage</name>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorStructPage.cpp" line="783"/>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorStructPage.cpp" line="784"/>
         <source>(Empty)</source>
         <translation type="unfinished">(なし)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorStructPage.cpp" line="789"/>
         <source>Character</source>
         <translation type="unfinished">キャラクター</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorStructPage.cpp" line="791"/>
         <source>Label</source>
         <translation type="unfinished">レイヤー</translation>
     </message>
@@ -6890,7 +5512,6 @@ Make sure it is valid or delete it.</source>
 <context>
     <name>ScriptEditorJumpNanakiPage</name>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorStructPage.cpp" line="478"/>
         <source>Label</source>
         <translation type="unfinished">レイヤー</translation>
     </message>
@@ -6898,7 +5519,6 @@ Make sure it is valid or delete it.</source>
 <context>
     <name>ScriptEditorJumpPage</name>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorStructPage.cpp" line="419"/>
         <source>Label</source>
         <translation type="unfinished">レイヤー</translation>
     </message>
@@ -6910,12 +5530,10 @@ Make sure it is valid or delete it.</source>
 <context>
     <name>ScriptEditorJumpPageInterface</name>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorStructPage.cpp" line="388"/>
         <source>Label %1</source>
         <translation type="unfinished">レイヤー %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorStructPage.cpp" line="398"/>
         <source>New label</source>
         <oldsource>Nouveau label</oldsource>
         <translation type="unfinished"></translation>
@@ -6924,7 +5542,6 @@ Make sure it is valid or delete it.</source>
 <context>
     <name>ScriptEditorLabelPage</name>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorStructPage.cpp" line="337"/>
         <source>Label</source>
         <translation type="unfinished">レイヤー</translation>
     </message>
@@ -6932,19 +5549,16 @@ Make sure it is valid or delete it.</source>
 <context>
     <name>ScriptEditorMoviePage</name>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorMoviePage.cpp" line="35"/>
         <source>Disc</source>
         <oldsource>Disque</oldsource>
         <translation type="unfinished">ディスク</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorMoviePage.cpp" line="37"/>
         <source>Video</source>
         <oldsource>Vidéo</oldsource>
         <translation type="unfinished">ビデオ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorMoviePage.cpp" line="49"/>
         <source>Disc %1</source>
         <oldsource>Disque %1</oldsource>
         <translation type="unfinished">ディスク %1</translation>
@@ -6953,17 +5567,14 @@ Make sure it is valid or delete it.</source>
 <context>
     <name>ScriptEditorReturnToPage</name>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorStructPage.cpp" line="47"/>
         <source>Script %1</source>
         <translation type="unfinished">スクリプト %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorStructPage.cpp" line="51"/>
         <source>Script</source>
         <translation type="unfinished">スクリプト</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorStructPage.cpp" line="53"/>
         <source>Priority</source>
         <oldsource>Priorité</oldsource>
         <translation type="unfinished">優先度</translation>
@@ -6972,12 +5583,10 @@ Make sure it is valid or delete it.</source>
 <context>
     <name>ScriptEditorSinCosPage</name>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorMathPage.cpp" line="853"/>
         <source>Sinus</source>
         <translation type="unfinished">サイン</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorMathPage.cpp" line="854"/>
         <source>Cosinus</source>
         <translation type="unfinished">コサイン</translation>
     </message>
@@ -6985,38 +5594,31 @@ Make sure it is valid or delete it.</source>
 <context>
     <name>ScriptEditorUnaryOpPage</name>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorMathPage.cpp" line="391"/>
         <source>Increment (wrapped)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorMathPage.cpp" line="392"/>
         <source>Increment (capped)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorMathPage.cpp" line="393"/>
         <source>Decrement (wrapped)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorMathPage.cpp" line="394"/>
         <source>Decrement (capped)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorMathPage.cpp" line="395"/>
         <source>Random</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorMathPage.cpp" line="398"/>
         <source>8-bit</source>
         <oldsource>8 bits</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorMathPage.cpp" line="399"/>
         <source>16-bit</source>
         <oldsource>16 bits</oldsource>
         <translation type="unfinished"></translation>
@@ -7025,7 +5627,6 @@ Make sure it is valid or delete it.</source>
 <context>
     <name>ScriptEditorWaitPage</name>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorStructPage.cpp" line="841"/>
         <source>Images</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7033,43 +5634,35 @@ Make sure it is valid or delete it.</source>
 <context>
     <name>ScriptEditorWindowModePage</name>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorWindowPage.cpp" line="270"/>
         <source>Normal</source>
         <translation type="unfinished">ノーマル</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorWindowPage.cpp" line="271"/>
         <source>Without frame</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorWindowPage.cpp" line="275"/>
         <source>Allow</source>
         <translation type="unfinished">許可</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorWindowPage.cpp" line="276"/>
         <source>Prevent</source>
         <translation type="unfinished">禁止</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorWindowPage.cpp" line="280"/>
         <source>Window ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorWindowPage.cpp" line="284"/>
         <source>Closing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorWindowPage.cpp" line="272"/>
         <source>Transparency</source>
         <oldsource>Transparent</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorWindowPage.cpp" line="282"/>
         <source>Type</source>
         <translation type="unfinished">タイプ</translation>
     </message>
@@ -7077,18 +5670,15 @@ Make sure it is valid or delete it.</source>
 <context>
     <name>ScriptEditorWindowMovePage</name>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorWindowPage.cpp" line="354"/>
         <source>Window ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorWindowPage.cpp" line="356"/>
         <source>Relative X</source>
         <oldsource>X relatif</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorWindowPage.cpp" line="358"/>
         <source>Relative Y</source>
         <oldsource>Y relatif</oldsource>
         <translation type="unfinished"></translation>
@@ -7097,61 +5687,50 @@ Make sure it is valid or delete it.</source>
 <context>
     <name>ScriptEditorWindowPage</name>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorWindowPage.cpp" line="50"/>
         <source>Align horizontally</source>
         <oldsource>Aligner horizontalement</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorWindowPage.cpp" line="51"/>
         <source>Align vertically</source>
         <oldsource>Aligner verticalement</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorWindowPage.cpp" line="43"/>
         <source>[Keep empty window]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorWindowPage.cpp" line="52"/>
         <source>Autosize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorWindowPage.cpp" line="57"/>
         <source>Window ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorWindowPage.cpp" line="133"/>
         <source>X</source>
         <translation type="unfinished">X</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorWindowPage.cpp" line="61"/>
         <source>Y</source>
         <translation type="unfinished">Y</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorWindowPage.cpp" line="63"/>
         <source>W</source>
         <oldsource>L</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorWindowPage.cpp" line="116"/>
         <source>Lines</source>
         <oldsource>Lignes</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorWindowPage.cpp" line="65"/>
         <source>H</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorWindowPage.cpp" line="67"/>
         <source>Text in preview:</source>
         <oldsource>Texte en aperçu :</oldsource>
         <translation type="unfinished"></translation>
@@ -7160,17 +5739,14 @@ Make sure it is valid or delete it.</source>
 <context>
     <name>ScriptEditorWindowVariablePage</name>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorWindowPage.cpp" line="414"/>
         <source>Window ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorWindowPage.cpp" line="416"/>
         <source>Window Variable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorWindowPage.cpp" line="418"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7178,7 +5754,6 @@ Make sure it is valid or delete it.</source>
 <context>
     <name>ScriptEditorWithPriorityPage</name>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/ScriptEditorStructPage.cpp" line="31"/>
         <source>Lower priority number is higher priority in the game</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7186,7 +5761,6 @@ Make sure it is valid or delete it.</source>
 <context>
     <name>ScriptManager</name>
     <message>
-        <location filename="../src/widgets/ScriptManager.cpp" line="197"/>
         <source>Error on line %1 : %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7194,264 +5768,206 @@ Make sure it is valid or delete it.</source>
 <context>
     <name>Search</name>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="33"/>
         <source>Scripts</source>
         <translation type="unfinished">スクリプト</translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="34"/>
         <source>Texts</source>
         <oldsource>Textes</oldsource>
         <translation type="unfinished">テキスト</translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="30"/>
-        <location filename="../src/widgets/Search.cpp" line="119"/>
-        <location filename="../src/widgets/Search.cpp" line="296"/>
         <source>Find</source>
         <translation type="unfinished">検索</translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="38"/>
         <source>Find next</source>
         <translation type="unfinished">次を検索</translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="39"/>
         <source>Find previous</source>
         <translation type="unfinished">前を検索</translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="40"/>
         <source>Find all</source>
         <translation type="unfinished">検索</translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="106"/>
         <source>Text</source>
         <oldsource>Texte</oldsource>
         <translatorcomment>Text</translatorcomment>
         <translation type="unfinished">テキスト</translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="107"/>
         <source>Variable</source>
         <translation>変数</translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="108"/>
         <source>Opcode</source>
         <translation>オプコード</translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="109"/>
         <source>Run</source>
         <translation type="unfinished">実行</translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="110"/>
         <source>Map jump</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="121"/>
-        <location filename="../src/widgets/Search.cpp" line="305"/>
         <source>Match case</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="177"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="178"/>
         <source>Assignment</source>
         <translation type="unfinished">代入</translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="179"/>
         <source>Bit Assignment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="182"/>
         <source>Assignment ≠</source>
         <translation type="unfinished">代入 ≠</translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="183"/>
         <source>Assignment &lt;</source>
         <translation type="unfinished">代入 &lt;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="184"/>
         <source>Assignment ≤</source>
         <translation type="unfinished">代入 ≤</translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="185"/>
         <source>Assignment &gt;</source>
         <translation type="unfinished">代入 &gt;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="186"/>
         <source>Assignment ≥</source>
         <translation type="unfinished">代入 ≥</translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="217"/>
         <source>Group</source>
         <translation type="unfinished">グループ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="240"/>
-        <location filename="../src/widgets/Search.cpp" line="309"/>
         <source>Scope</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="511"/>
         <source>Last map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="523"/>
         <source>First map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="976"/>
         <source>%1 occurrences replaced.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="243"/>
         <source>Current group script</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="244"/>
         <source>Current script</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="301"/>
-        <location filename="../src/widgets/Search.cpp" line="302"/>
         <source>Replace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="303"/>
         <source>Replace all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="312"/>
         <source>Current text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="512"/>
         <source>Last group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="513"/>
         <source>Last script</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="514"/>
         <source>Last opcode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="515"/>
         <source>Last text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="524"/>
         <source>First group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="525"/>
         <source>First script</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="526"/>
         <source>First opcode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="527"/>
         <source>First text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="597"/>
         <source>%1,
 continued from top.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="717"/>
         <source>%1,
 chase at the end.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="122"/>
-        <location filename="../src/widgets/Search.cpp" line="306"/>
         <source>Regular expression</source>
         <oldsource>Utiliser les expressions régulières</oldsource>
         <translation type="unfinished">正規表現</translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="160"/>
         <source>Var</source>
         <translation>変数</translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="176"/>
-        <location filename="../src/widgets/Search.cpp" line="450"/>
         <source>Value</source>
         <oldsource>Valeur</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="180"/>
         <source>Test</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="181"/>
         <source>Bit test</source>
         <oldsource>Test bit</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="241"/>
-        <location filename="../src/widgets/Search.cpp" line="310"/>
         <source>All maps</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="242"/>
-        <location filename="../src/widgets/Search.cpp" line="311"/>
         <source>Current map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="450"/>
         <source>Position</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/Search.cpp" line="215"/>
         <source>Script</source>
         <translation>スクリプト</translation>
     </message>
@@ -7459,45 +5975,37 @@ chase at the end.</source>
 <context>
     <name>SearchAll</name>
     <message>
-        <location filename="../src/widgets/SearchAll.cpp" line="26"/>
         <source>Find All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/SearchAll.cpp" line="45"/>
         <source>Copy</source>
         <oldsource>Copier</oldsource>
         <translation type="unfinished">コピー</translation>
     </message>
     <message>
-        <location filename="../src/widgets/SearchAll.cpp" line="65"/>
         <source>Group</source>
         <oldsource>Groupe</oldsource>
         <translation type="unfinished">グループ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/SearchAll.cpp" line="65"/>
         <source>Script</source>
         <translation type="unfinished">スクリプト</translation>
     </message>
     <message>
-        <location filename="../src/widgets/SearchAll.cpp" line="65"/>
         <source>Lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/SearchAll.cpp" line="65"/>
         <source>Instruction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/SearchAll.cpp" line="73"/>
         <source>Text #</source>
         <oldsource>Texte n°</oldsource>
         <translation type="unfinished">テキスト</translation>
     </message>
     <message>
-        <location filename="../src/widgets/SearchAll.cpp" line="73"/>
         <source>Text</source>
         <translation type="unfinished">テキスト</translation>
     </message>
@@ -7505,13 +6013,10 @@ chase at the end.</source>
 <context>
     <name>SpinBoxDelegate</name>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/Delegate.cpp" line="106"/>
-        <location filename="../src/widgets/ScriptEditorWidgets/Delegate.cpp" line="107"/>
         <source>(Empty)</source>
         <translation type="unfinished">(なし)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/ScriptEditorWidgets/Delegate.cpp" line="222"/>
         <source>Choose a new color</source>
         <translation type="unfinished">変更する色の選択</translation>
     </message>
@@ -7519,250 +6024,203 @@ chase at the end.</source>
 <context>
     <name>TextManager</name>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="36"/>
         <source>Texts</source>
         <oldsource>Textes</oldsource>
         <translatorcomment>Texts</translatorcomment>
         <translation type="unfinished">テキスト</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="38"/>
         <source>Show unused texts</source>
         <translation type="unfinished">未使用のテキストを表示</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="42"/>
         <source>Add text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="68"/>
         <source>Member 1</source>
         <translation type="unfinished">メンバー 1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="70"/>
         <source>Member 2</source>
         <translation type="unfinished">メンバー 2</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="72"/>
         <source>Member 3</source>
         <translation type="unfinished">メンバー 3</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="75"/>
         <source>New Page</source>
         <translation type="unfinished">新しいページ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="77"/>
         <source>Choice</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="82"/>
         <source>Grey</source>
         <translation type="unfinished">灰色</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="84"/>
         <source>Blue</source>
         <translation type="unfinished">青色</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="86"/>
         <source>Red</source>
         <translation type="unfinished">赤色</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="88"/>
         <source>Purple</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="90"/>
         <source>Green</source>
         <translation type="unfinished">緑色</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="94"/>
         <source>Yellow</source>
         <translation type="unfinished">黄色</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="96"/>
         <source>White</source>
         <translation type="unfinished">白色</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="98"/>
         <source>Blink</source>
         <translation>点滅</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="100"/>
         <source>Multicolor</source>
         <translation>マルチカラー</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="105"/>
         <source>Pause</source>
         <translatorcomment>Pause</translatorcomment>
         <translation>ポーズ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="107"/>
         <source>Pause 0</source>
         <translatorcomment>Pause 0</translatorcomment>
         <translation>ポーズ 0</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="109"/>
         <source>Pause 5</source>
         <translatorcomment>Pause 5</translatorcomment>
         <translation>ポーズ 5</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="111"/>
         <source>Pause 10</source>
         <translatorcomment>Pause 10</translatorcomment>
         <translation>ポーズ 10</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="113"/>
         <source>Pause 15</source>
         <translatorcomment>Pause 15</translatorcomment>
         <translation>ポーズ 15</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="115"/>
         <source>Pause 20</source>
         <translatorcomment>Pause 20</translatorcomment>
         <translation>ポーズ 20</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="117"/>
         <source>Pause 30</source>
         <translatorcomment>Pause 30</translatorcomment>
         <translation>ポーズ 30</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="119"/>
         <source>Pause 40</source>
         <translatorcomment>Pause 40</translatorcomment>
         <translation>ポーズ 40</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="121"/>
         <source>Pause 50</source>
         <translatorcomment>Pause 50</translatorcomment>
         <translation>ポーズ 50</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="123"/>
         <source>Pause 60</source>
         <translatorcomment>Pause 60</translatorcomment>
         <translation>ポーズ 60</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="125"/>
         <source>Pauses</source>
         <translatorcomment>Pauses</translatorcomment>
         <translation>ポーズ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="135"/>
         <source>Var10r</source>
         <translation type="unfinished">変数10右 {10r?}</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="143"/>
         <source>Circle</source>
         <translation>○</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="147"/>
         <source>Square</source>
         <translation>□</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="149"/>
         <source>Cross</source>
         <translation>×</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="151"/>
         <source>Keys</source>
         <translation type="unfinished">キー</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="158"/>
         <source>Spaced characters</source>
         <translation type="unfinished">スペース (空白)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="160"/>
         <source>Memory access</source>
         <translation>メモリー アクセス</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="162"/>
         <source>New Page²</source>
         <translation type="unfinished">新しいページ No,</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="164"/>
         <source>Others</source>
         <translation type="unfinished">その他</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="209"/>
         <source>Align horizontally</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="210"/>
         <source>Align vertically</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="211"/>
         <source>Autosize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="220"/>
         <source>X</source>
         <translation type="unfinished">X</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="221"/>
         <source>Y</source>
         <translation type="unfinished">Y</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="222"/>
         <source>W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="223"/>
         <source>H</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="387"/>
         <source>Text %1</source>
         <translation type="unfinished">テキスト %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="496"/>
         <source>Text used in scripts</source>
         <translation type="unfinished">スクリプトのテキスト</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="496"/>
         <source>This text is used by one or more scripts on this field.
 Removing this text may break scripts that reference it.
 Are you sure you want to continue?</source>
@@ -7771,57 +6229,48 @@ Are you sure you want to continue?</source>
 削除を実行してもかまいませんか？</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="549"/>
         <source>Window %1/%2</source>
         <oldsource>Fenêtre %1/%2</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="92"/>
         <source>Cyan</source>
         <translatorcomment>Cyan</translatorcomment>
         <translation>シアン</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="131"/>
         <source>Var10</source>
         <oldsource>Var1</oldsource>
         <translatorcomment>Var10</translatorcomment>
         <translation>変数10</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="133"/>
         <source>Var16</source>
         <oldsource>Var2</oldsource>
         <translatorcomment>Var16</translatorcomment>
         <translation>変数16</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="137"/>
         <source>Vars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="145"/>
         <source>Triangle</source>
         <translatorcomment>Triangle</translatorcomment>
         <translation>△</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="156"/>
         <source>Scrolling</source>
         <translatorcomment>Scrolling ●</translatorcomment>
         <translation>スクロール</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="43"/>
         <source>Remove text</source>
         <oldsource>Ajouter texte</oldsource>
         <translatorcomment>Add text</translatorcomment>
         <translation type="unfinished">テキストの追加</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextManager.cpp" line="527"/>
         <source>Page %1/%2</source>
         <translatorcomment>Page %1/%2</translatorcomment>
         <translation>ページ %1/%2</translation>
@@ -7830,21 +6279,18 @@ Are you sure you want to continue?</source>
 <context>
     <name>TextPreview</name>
     <message>
-        <location filename="../src/widgets/TextPreview.cpp" line="57"/>
         <source>Member 1</source>
         <oldsource>Membre 1</oldsource>
         <translatorcomment>Member 1</translatorcomment>
         <translation type="unfinished">メンバー 1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextPreview.cpp" line="58"/>
         <source>Member 2</source>
         <oldsource>Membre 2</oldsource>
         <translatorcomment>Member 2</translatorcomment>
         <translation type="unfinished">メンバー 2</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TextPreview.cpp" line="59"/>
         <source>Member 3</source>
         <oldsource>Membre 3</oldsource>
         <translatorcomment>Member 3</translatorcomment>
@@ -7854,130 +6300,102 @@ Are you sure you want to continue?</source>
 <context>
     <name>TutWidget</name>
     <message>
-        <location filename="../src/widgets/TutWidget.cpp" line="28"/>
         <source>Tutorials/Sounds</source>
         <oldsource>Tutoriels/Musiques</oldsource>
         <translatorcomment>Tutorials/Sounds</translatorcomment>
         <translation type="unfinished">解説/サウンド</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TutWidget.cpp" line="47"/>
         <source>Import...</source>
         <oldsource>Exporter...</oldsource>
         <translatorcomment>Export...</translatorcomment>
         <translation type="unfinished">エクスポート...</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TutWidget.cpp" line="31"/>
         <source>Add</source>
         <translation type="unfinished">追加</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TutWidget.cpp" line="32"/>
         <source>Remove</source>
         <translation type="unfinished">削除</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TutWidget.cpp" line="46"/>
         <source>Export...</source>
         <translation type="unfinished">エクスポート...</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TutWidget.cpp" line="54"/>
         <source>PlayStation</source>
         <translatorcomment>PlayStation</translatorcomment>
         <translation>PlayStation</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TutWidget.cpp" line="55"/>
         <source>PC</source>
         <translatorcomment>PC</translatorcomment>
         <translation>PC</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TutWidget.cpp" line="132"/>
         <source>%1 - %2 : %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/TutWidget.cpp" line="145"/>
         <source>Music ID:</source>
         <translation type="unfinished">BGM ID:</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TutWidget.cpp" line="158"/>
         <source>Repair</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/TutWidget.cpp" line="159"/>
         <source>Replace by empty AKAO</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/TutWidget.cpp" line="160"/>
         <source>Replace by empty tuto</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/TutWidget.cpp" line="163"/>
         <source>There is an error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/TutWidget.cpp" line="217"/>
         <source>Broken %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/TutWidget.cpp" line="221"/>
         <source>Music %1</source>
         <translation type="unfinished">BGM %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TutWidget.cpp" line="333"/>
         <source>Tutorial</source>
         <translation>解説解説</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TutWidget.cpp" line="334"/>
         <source>Music</source>
         <translation type="unfinished">BGM</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TutWidget.cpp" line="351"/>
-        <location filename="../src/widgets/TutWidget.cpp" line="547"/>
         <source>Import</source>
         <translation type="unfinished">インポート</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TutWidget.cpp" line="351"/>
-        <location filename="../src/widgets/TutWidget.cpp" line="543"/>
         <source>sound_%1.akao</source>
         <translation>sound_%1.akao</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TutWidget.cpp" line="351"/>
-        <location filename="../src/widgets/TutWidget.cpp" line="490"/>
-        <location filename="../src/widgets/TutWidget.cpp" line="544"/>
         <source>Final Fantasy Sound (*.akao)</source>
         <translation>Final Fantasy Sound (*.akao)</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TutWidget.cpp" line="358"/>
-        <location filename="../src/widgets/TutWidget.cpp" line="385"/>
         <source>Tutorial used in scripts</source>
         <translation>スクリプト内の解説</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TutWidget.cpp" line="358"/>
         <source>Insert a tutorial here will shift the IDs of the tutorials that follows, this may be a problem.
 Are you sure you want to continue?</source>
         <translation>ここに解説を挿入すると以降の解説の ID がずれるためトラブルの原因になるかもしれません。
 挿入を実行してもかまいませんか？</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TutWidget.cpp" line="385"/>
         <source>This tutorial may be used by one or more scripts on this field.
 Delete can cause errors.
 Are you sure you want to continue?</source>
@@ -7986,7 +6404,6 @@ Are you sure you want to continue?</source>
 それでも削除しますか？</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TutWidget.cpp" line="385"/>
         <source>This tutorial is used by one or more scripts on this field.
 Remove will replace calls to this tutorial with calls to the tutorial that follows.
 Are you sure you want to continue?</source>
@@ -7995,57 +6412,43 @@ Are you sure you want to continue?</source>
 それでも削除しますか？</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TutWidget.cpp" line="491"/>
         <source>PSF MIDI file (*.minipsf)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/TutWidget.cpp" line="497"/>
         <source>%1.akao</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/TutWidget.cpp" line="501"/>
         <source>Export</source>
         <translation type="unfinished">エクスポート</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TutWidget.cpp" line="512"/>
-        <location filename="../src/widgets/TutWidget.cpp" line="557"/>
-        <location filename="../src/widgets/TutWidget.cpp" line="562"/>
         <source>Error</source>
         <translation>エラー</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TutWidget.cpp" line="512"/>
         <source>Opening error file</source>
         <translation type="unfinished">オープン エラー</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TutWidget.cpp" line="557"/>
         <source>Opening Error File</source>
         <translation type="unfinished">オープン エラー</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TutWidget.cpp" line="562"/>
         <source>File too large</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/TutWidget.cpp" line="219"/>
         <source>Tuto %1</source>
         <translatorcomment>Tuto %1</translatorcomment>
         <translation>説明 %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TutWidget.cpp" line="494"/>
-        <location filename="../src/widgets/TutWidget.cpp" line="540"/>
         <source>tuto_%1.tutps</source>
         <translation>tuto_%1.tutps</translation>
     </message>
     <message>
-        <location filename="../src/widgets/TutWidget.cpp" line="495"/>
-        <location filename="../src/widgets/TutWidget.cpp" line="541"/>
         <source>Tuto Final Fantasy VII PS (*.tutps)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8053,117 +6456,97 @@ Are you sure you want to continue?</source>
 <context>
     <name>VarManager</name>
     <message>
-        <location filename="../src/widgets/VarManager.cpp" line="25"/>
         <source>Variable manager</source>
         <oldsource>Gestionnaire de variables</oldsource>
         <translatorcomment>Variable manager</translatorcomment>
         <translation type="unfinished">変数マネージャー</translation>
     </message>
     <message>
-        <location filename="../src/widgets/VarManager.cpp" line="35"/>
         <source>Rename</source>
         <oldsource>Renommer</oldsource>
         <translatorcomment>Rename</translatorcomment>
         <translation type="unfinished">リネーム</translation>
     </message>
     <message>
-        <location filename="../src/widgets/VarManager.cpp" line="51"/>
         <source>Address</source>
         <oldsource>Adresse</oldsource>
         <translatorcomment>Adress</translatorcomment>
         <translation type="unfinished">アドレス</translation>
     </message>
     <message>
-        <location filename="../src/widgets/VarManager.cpp" line="74"/>
         <source>Addresses Used</source>
         <oldsource>Adresses utilisées</oldsource>
         <translatorcomment>Adresses used</translatorcomment>
         <translation type="unfinished">アドレスに適用</translation>
     </message>
     <message>
-        <location filename="../src/widgets/VarManager.cpp" line="264"/>
         <source>Error</source>
         <oldsource>Erreur</oldsource>
         <translatorcomment>Error</translatorcomment>
         <translation type="unfinished">エラー</translation>
     </message>
     <message>
-        <location filename="../src/widgets/VarManager.cpp" line="272"/>
         <source>Searching</source>
         <oldsource>Recherche</oldsource>
         <translatorcomment>Searching</translatorcomment>
         <translation type="unfinished">検索中</translation>
     </message>
     <message>
-        <location filename="../src/widgets/VarManager.cpp" line="51"/>
         <source>Nickname</source>
         <translation type="unfinished">ニックネーム</translation>
     </message>
     <message>
-        <location filename="../src/widgets/VarManager.cpp" line="51"/>
         <source>Operation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/VarManager.cpp" line="51"/>
         <source>Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/VarManager.cpp" line="61"/>
         <source>Var banks 08, 09 and 10 are temporary and do not appear in the game save. &lt;br/&gt;Other banks are stored in pair: for example 01-02 is in the same memory location, but the first is used to store 8-bit values and the second is used to store 16-bit values.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/VarManager.cpp" line="75"/>
         <source>Save</source>
         <translation type="unfinished">保存</translation>
     </message>
     <message>
-        <location filename="../src/widgets/VarManager.cpp" line="264"/>
         <source>Save Failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/VarManager.cpp" line="272"/>
         <source>Searching, it may take a minute...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/VarManager.cpp" line="333"/>
         <source>rw</source>
         <translation>rw</translation>
     </message>
     <message>
-        <location filename="../src/widgets/VarManager.cpp" line="335"/>
         <source>r</source>
         <translation>r</translation>
     </message>
     <message>
-        <location filename="../src/widgets/VarManager.cpp" line="337"/>
         <source>w</source>
         <translation>w</translation>
     </message>
     <message>
-        <location filename="../src/widgets/VarManager.cpp" line="340"/>
         <source>bitfield</source>
         <oldsource>bits</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/VarManager.cpp" line="343"/>
         <source>1 Byte</source>
         <oldsource>1 octet</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/VarManager.cpp" line="346"/>
         <source>2 Bytes</source>
         <oldsource>2 octets</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/VarManager.cpp" line="349"/>
         <source>2 Signed Bytes</source>
         <oldsource>2 octets signés</oldsource>
         <translation type="unfinished"></translation>
@@ -8172,18 +6555,15 @@ Are you sure you want to continue?</source>
 <context>
     <name>VarOrValueWidget</name>
     <message>
-        <location filename="../src/widgets/VarOrValueWidget.cpp" line="229"/>
         <source>Value</source>
         <oldsource>Valeur</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/VarOrValueWidget.cpp" line="233"/>
         <source>8-bit Var</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/VarOrValueWidget.cpp" line="237"/>
         <source>16-bit Var</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8195,17 +6575,14 @@ Are you sure you want to continue?</source>
 <context>
     <name>VertexWidget</name>
     <message>
-        <location filename="../src/widgets/VertexWidget.cpp" line="43"/>
         <source>X</source>
         <translation>X</translation>
     </message>
     <message>
-        <location filename="../src/widgets/VertexWidget.cpp" line="45"/>
         <source>Y</source>
         <translation>Y</translation>
     </message>
     <message>
-        <location filename="../src/widgets/VertexWidget.cpp" line="47"/>
         <source>Z</source>
         <translation>Z</translation>
     </message>
@@ -8213,217 +6590,170 @@ Are you sure you want to continue?</source>
 <context>
     <name>WalkmeshManager</name>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="56"/>
         <source>Camera</source>
         <oldsource>Caméra</oldsource>
         <translation type="unfinished">カメラ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="26"/>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="57"/>
         <source>Walkmesh</source>
         <translation type="unfinished">ウォークメッシュ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="105"/>
         <source>Remove camera</source>
         <oldsource>Ajouter caméra</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="43"/>
         <source>Use the arrow keys to move the camera.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="47"/>
         <source>Reset Camera</source>
         <oldsource>Reset</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="49"/>
         <source>Show 3D models</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="52"/>
         <source>Show Background</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="58"/>
         <source>Gateways</source>
         <translation type="unfinished">出入り口</translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="59"/>
         <source>Doors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="60"/>
         <source>Arrows</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="61"/>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="378"/>
         <source>Camera range</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="62"/>
         <source>Miscellaneous</source>
         <translation type="unfinished">各種情報</translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="104"/>
         <source>Add camera</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="130"/>
         <source>Zoom:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="132"/>
         <source>Camera axis:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="136"/>
         <source>Camera position:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="137"/>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="348"/>
         <source>X</source>
         <translation>X</translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="139"/>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="350"/>
         <source>Y</source>
         <translation>Y</translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="141"/>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="352"/>
         <source>Z</source>
         <translation>Z</translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="168"/>
         <source>Add triangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="169"/>
         <source>Remove triangle</source>
         <oldsource>Ajouter triangle</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="187"/>
         <source>Triangle accessible via the line 1-2 :</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="191"/>
         <source>Triangle accessible via the line 2-3 :</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="195"/>
         <source>Triangle accessible via the line 3-1 :</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="229"/>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="278"/>
         <source>Enable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="233"/>
         <source>T</source>
         <translation>T</translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="241"/>
         <source>Show an arrow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="247"/>
         <source>Exit line:</source>
         <translation type="unfinished">退出ライン:</translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="250"/>
         <source>Destination point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="252"/>
         <source>Character orientation:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="254"/>
         <source>Field ID:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="296"/>
         <source>Background parameter ID:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="298"/>
         <source>Background state ID:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="300"/>
         <source>Behavior:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="302"/>
         <source>Sound ID:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="308"/>
         <source>Trigger Line Door:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="344"/>
         <source>Red</source>
         <translation type="unfinished">赤色</translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="345"/>
         <source>Green</source>
         <translation type="unfinished">緑色</translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="359"/>
         <source>Type:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="379"/>
         <source>Layer sizes (for layer animations)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="380"/>
         <source>Layer flags</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8436,62 +6766,50 @@ Are you sure you want to continue?</source>
         <translation type="obsolete">下に</translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="395"/>
         <source>Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="397"/>
         <source>Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="405"/>
         <source>Background layer 3 width</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="409"/>
         <source>Background layer 4 width</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="420"/>
         <source>Layer 1</source>
         <translation type="unfinished">レイヤー 1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="422"/>
         <source>Layer 2</source>
         <translation type="unfinished">レイヤー 2</translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="424"/>
         <source>Layer 3</source>
         <translation type="unfinished">レイヤー 3</translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="426"/>
         <source>Layer 4</source>
         <translation type="unfinished">レイヤー 4</translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="463"/>
         <source>Movements orientation:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="466"/>
         <source>Camera Focus Height on the playable character:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="468"/>
         <source>Unknown:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="470"/>
         <source>Field map scale:</source>
         <oldsource>Field scale:</oldsource>
         <translation type="unfinished">フィールド スケール :</translation>
@@ -8501,93 +6819,65 @@ Are you sure you want to continue?</source>
         <translation type="obsolete">オープン エラー</translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="200"/>
         <source>Point 1 :</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="202"/>
         <source>Point 2 :</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="204"/>
         <source>Point 3 :</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="343"/>
         <source>Invisible</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="358"/>
         <source>Position:</source>
         <oldsource>Position :</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="391"/>
         <source>Top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="393"/>
         <source>Bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="407"/>
         <source>Background layer 3 height</source>
         <oldsource>Largeur couche 3 décor</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="411"/>
         <source>Background layer 4 height</source>
         <oldsource>Largeur couche 4 décor</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="529"/>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="862"/>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="864"/>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="884"/>
         <source>Triangle %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="513"/>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="715"/>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="717"/>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="737"/>
         <source>Camera %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="544"/>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="558"/>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="574"/>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="1188"/>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="1248"/>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="1372"/>
         <source>Unused</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="556"/>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="1244"/>
         <source>Door %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="572"/>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="1368"/>
         <source>Arrow %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/WalkmeshManager.cpp" line="1049"/>
         <source>?</source>
         <translation>?</translation>
     </message>
@@ -8595,51 +6885,42 @@ Are you sure you want to continue?</source>
 <context>
     <name>Window</name>
     <message>
-        <location filename="../src/Window.cpp" line="96"/>
         <source>&amp;Find...</source>
         <oldsource>&amp;Zones...</oldsource>
         <translatorcomment>&amp;Walkmesh...</translatorcomment>
         <translation type="unfinished">検索(&amp;F)...</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="92"/>
         <source>&amp;Background...</source>
         <translatorcomment>&amp;Background...</translatorcomment>
         <translation>背景(&amp;B)...</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="131"/>
         <source>&amp;Configuration...</source>
         <oldsource>Configuration...</oldsource>
         <translation type="unfinished">構成設定(&amp;C)...</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="61"/>
         <source>&amp;File</source>
         <translation type="unfinished">ファイル(&amp;F)</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="63"/>
         <source>&amp;Open...</source>
         <translation type="unfinished">開く(&amp;O)...</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="64"/>
         <source>Open &amp;Directory...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="65"/>
         <source>&amp;Recent files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="69"/>
         <source>&amp;Save</source>
         <translation>保存(&amp;S)</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="70"/>
         <source>Save &amp;As...</source>
         <translation type="unfinished">名前を付けて保存(&amp;A)...</translation>
     </message>
@@ -8648,40 +6929,31 @@ Are you sure you want to continue?</source>
         <translation type="obsolete">現在のファイルをエクスポート(&amp;E)...</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="72"/>
         <source>&amp;Mass Export...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="75"/>
-        <location filename="../src/Window.cpp" line="422"/>
-        <location filename="../src/Window.cpp" line="1624"/>
         <source>Archive Mana&amp;ger...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="77"/>
         <source>R&amp;un FF7</source>
         <oldsource>Run FF7</oldsource>
         <translation type="unfinished">FF7 を実行 (&amp;U)</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="82"/>
         <source>C&amp;lose</source>
         <translation type="unfinished">閉じる(&amp;L)</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="83"/>
         <source>E&amp;xit</source>
         <translation type="unfinished">終了(&amp;X)</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="86"/>
         <source>T&amp;ools</source>
         <translation type="unfinished">ツール(&amp;O)</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="87"/>
         <source>&amp;Texts...</source>
         <translation type="unfinished">テキスト(&amp;T)...</translation>
     </message>
@@ -8690,163 +6962,128 @@ Are you sure you want to continue?</source>
         <translation type="obsolete">3Dモデル(&amp;M)...</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="89"/>
         <source>Encounte&amp;rs...</source>
         <translation type="unfinished">エンカウント(&amp;E)...</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="90"/>
         <source>Tutorials/&amp;Sounds...</source>
         <translation type="unfinished">解説/サウンド(&amp;S)...</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="91"/>
         <source>&amp;Walkmesh...</source>
         <translation type="unfinished">ウォーク メッシュ(&amp;W)...</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="93"/>
         <source>M&amp;iscellaneous...</source>
         <translation type="unfinished">各種情報(&amp;I)...</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="95"/>
         <source>Variable Mana&amp;ger...</source>
         <translation type="unfinished">変数マネージャー(&amp;G)...</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="100"/>
         <source>&amp;Settings</source>
         <translation type="unfinished">設定(&amp;S)</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="102"/>
         <source>&amp;Japanese Characters</source>
         <translation type="unfinished">日本語版文字コードを使用 (&amp;J)</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="106"/>
         <source>&amp;Language</source>
         <translation type="unfinished">言語(&amp;L)</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="109"/>
         <source>English (default)</source>
         <translation type="unfinished">English (デフォルト)</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="118"/>
         <source>English</source>
         <translation type="unfinished">Japanese (日本語)</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="140"/>
         <source>Main &amp;toolbar</source>
         <translation type="unfinished">メイン ツールバー(&amp;T)</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="145"/>
-        <location filename="../src/Window.cpp" line="496"/>
         <source>Open a file</source>
         <translation type="unfinished">ファイルを開く</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="147"/>
-        <location filename="../src/Window.cpp" line="405"/>
         <source>Save</source>
         <translation>保存</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="150"/>
         <source>Find</source>
         <translation type="unfinished">検索</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="154"/>
         <source>Text editor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="156"/>
         <source>Model loader editor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="160"/>
         <source>Walkmesh editor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="225"/>
-        <location filename="../src/Window.cpp" line="227"/>
         <source>&amp;?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="298"/>
         <source>&amp;View</source>
         <translation type="unfinished">表示(&amp;V)</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="304"/>
         <source>Background Preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="370"/>
         <source>Settings changed</source>
         <translation type="unfinished">設定の変更</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="371"/>
         <source>Restart the program for the settings to take effect.</source>
         <translation>プログラムを再起動して設定の変更を適用してください。</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="403"/>
         <source>
 
 Edited files:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="405"/>
         <source>Would you like to save changes of %1?%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="488"/>
         <source>Compatible Files (*.lgp *.DAT *.bin *.iso *.img)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="489"/>
         <source>Lgp Files (*.lgp)</source>
         <translation type="unfinished">Lgp ファイル (*.lgp)</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="490"/>
-        <location filename="../src/Window.cpp" line="1063"/>
         <source>DAT File (*.DAT)</source>
         <translation type="unfinished">DAT ファイル (*.DAT)</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="492"/>
         <source>Disc Image (*.bin *.iso *.img)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="546"/>
         <source>Select a folder containing the Final Fantasy VII field files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="554"/>
         <source>File Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="555"/>
         <source>What type of file to look for?
  - Playstation field files (&quot;EXAMPLE.DAT&quot;)
  - PC Field File (&quot;example&quot;)
@@ -8854,221 +7091,168 @@ Edited files:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="559"/>
         <source>PS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="560"/>
         <source>PC</source>
         <translation type="unfinished">PC</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="600"/>
         <source>Cancel</source>
         <translatorcomment>アンドゥ</translatorcomment>
         <translation type="unfinished">キャンセル</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="600"/>
         <source>Stop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="629"/>
         <source>Opening...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="648"/>
         <source>Nothing found!</source>
         <translation type="unfinished">見つかりませんでした！</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="652"/>
         <source>The file already exists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="655"/>
-        <location filename="../src/Window.cpp" line="1096"/>
         <source>The file is inaccessible</source>
         <translation type="unfinished">ファイルにアクセスできません</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="658"/>
-        <location filename="../src/Window.cpp" line="1099"/>
         <source>Can not create temporary file</source>
         <translation type="unfinished">一時ファイルが作成できません</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="670"/>
         <source>Invalid file</source>
         <translation type="unfinished">無効なファイル</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="673"/>
         <source>This error should not appear, thank you for reporting it</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="1355"/>
         <source>PS Field Map (*.DAT)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="584"/>
-        <location filename="../src/Window.cpp" line="677"/>
-        <location filename="../src/Window.cpp" line="1118"/>
-        <location filename="../src/Window.cpp" line="1255"/>
-        <location filename="../src/Window.cpp" line="1300"/>
-        <location filename="../src/Window.cpp" line="1328"/>
-        <location filename="../src/Window.cpp" line="1387"/>
-        <location filename="../src/Window.cpp" line="1422"/>
         <source>Error</source>
         <translation type="unfinished">エラー</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="71"/>
         <source>&amp;Export the current map...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="73"/>
         <source>&amp;Import to current map...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="88"/>
         <source>Map &amp;Models...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="97"/>
         <source>B&amp;atch processing...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="301"/>
         <source>Map List</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="491"/>
         <source>PC field File (*)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="664"/>
         <source>Failed to rename the file, check write permissions.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="667"/>
         <source>Failed to copy the file, check write permissions.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="941"/>
-        <location filename="../src/Window.cpp" line="1612"/>
         <source>Author: %1</source>
         <translation type="unfinished">作者: %1</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="1039"/>
         <source>Compilation Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="1039"/>
         <source>Error Compiling Scripts:
 scene %1 (%2), group %3 (%4), script %5, line %6: %7</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="1054"/>
         <source>Save Directory As</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="1061"/>
         <source>Lgp File (*.lgp)</source>
         <translation type="unfinished">Lgp ファイル (*.lgp)</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="1065"/>
         <source>Iso File (*.iso *.bin *.img)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="1069"/>
         <source>Save As</source>
         <translation type="unfinished">名前を付けて保存</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="1076"/>
         <source>Saving...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="1201"/>
-        <location filename="../src/Window.cpp" line="1354"/>
         <source>PC Field Map (*)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="1202"/>
         <source>Data DAT File (*.DAT)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="1203"/>
         <source>Textures MIM File (*.MIM)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="1242"/>
         <source>Archive is inaccessible</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="661"/>
-        <location filename="../src/Window.cpp" line="1102"/>
         <source>Unable to remove the file, check write permissions.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="1093"/>
         <source>No maps found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="1105"/>
         <source>Unable to rename the file, check write permissions.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="1108"/>
         <source>Unable to copy the file, check write permissions.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="1111"/>
         <source>Invalid archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="1114"/>
         <source>This feature is not complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="1204"/>
         <source>Uncompressed PC Field Map (*.dec)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="1216"/>
         <source>Export the current file</source>
         <translation type="unfinished">現在のファイルをエクスポート</translation>
     </message>
@@ -9078,75 +7262,60 @@ scene %1 (%2), group %3 (%4), script %5, line %6: %7</source>
         <translation type="obsolete">Lgp アーカイブにアクセスできません</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="1245"/>
         <source>Error reopening file</source>
         <translation type="unfinished">ファイルの再読み込みに失敗</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="1248"/>
         <source>Unable to create the new file</source>
         <translation type="unfinished">新規ファイルを作成できません</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="1251"/>
         <source>Not yet implemented!</source>
         <translation type="unfinished">まだ実装されていません！</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="1270"/>
         <source>Export...</source>
         <translation type="unfinished">エクスポート...</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="1300"/>
         <source>An error occured when exporting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="1319"/>
         <source>Import...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="1328"/>
         <source>An error occurred when importing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="1365"/>
         <source>Import a file</source>
         <translation type="unfinished">ファイルのインポート</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="1422"/>
         <source>Final Fantasy VII couldn&apos;t be launched
 %1</source>
         <translation>Final Fantasy VII を起動できません。
 %1</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="1538"/>
-        <location filename="../src/Window.cpp" line="1616"/>
         <source>Opening error</source>
         <translation type="unfinished">オープン エラー</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="1538"/>
         <source>Can not open encounters!</source>
         <translation type="unfinished">エンカウントが開けません！</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="1616"/>
         <source>Can not open miscellaneous informations!</source>
         <translation type="unfinished">各種情報が開けません！</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="1627"/>
         <source>Go back to field map editor...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="1647"/>
         <source>Applying...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9158,12 +7327,10 @@ scene %1 (%2), group %3 (%4), script %5, line %6: %7</source>
 <context>
     <name>main</name>
     <message>
-        <location filename="../src/main.cpp" line="110"/>
         <source>Error</source>
         <translation type="unfinished">エラー</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="111"/>
         <source>The file &apos;var.cfg&apos; could not be loaded.
 Make sure it is valid or delete it.</source>
         <translation type="unfinished">ファイル &apos;var.cfg&apos; が読み込めません。

--- a/src/3d/FieldModel.cpp
+++ b/src/3d/FieldModel.cpp
@@ -19,11 +19,11 @@
 #include "core/field/FieldModelFilePS.h"
 
 FieldModel::FieldModel(QWidget *parent) :
-    QOpenGLWidget(parent), blockAll(false), distance(-0.25/*-35*/),
+	QOpenGLWidget(parent), blockAll(false), distance(-0.25/*-35*/),
     animationID(0), currentFrame(0), animated(true), data(nullptr),
 	xRot(270*16), yRot(90*16), zRot(0), gpuRenderer(nullptr)
 {
-	connect(&timer, SIGNAL(timeout()), SLOT(animate()));
+	connect(&timer, &QTimer::timeout, this, &FieldModel::animate);
 }
 
 FieldModel::~FieldModel()

--- a/src/3d/Renderer.cpp
+++ b/src/3d/Renderer.cpp
@@ -38,7 +38,7 @@ Renderer::Renderer(QOpenGLWidget *_widget) :
 	mGL.initializeOpenGLFunctions();
 
 #ifdef QT_DEBUG
-	connect(&mLogger, SIGNAL(messageLogged(QOpenGLDebugMessage)), this, SLOT(messageLogged(QOpenGLDebugMessage)));
+	connect(&mLogger, &QOpenGLDebugLogger::messageLogged, this, &Renderer::messageLogged);
 
 	if (mLogger.initialize()) {
 		mLogger.startLogging();

--- a/src/3d/WalkmeshWidget.cpp
+++ b/src/3d/WalkmeshWidget.cpp
@@ -84,9 +84,8 @@ void WalkmeshWidget::openModels()
 	//	if (field->isPC()) {
 	//		thread = new FieldModelThread(this);
 	//		thread->setField(field);
-	//		connect(thread,
-	// SIGNAL(modelLoaded(Field*,FieldModelFile*,int,int,bool)),
-	// SLOT(addModel(Field*,FieldModelFile*,int)));
+	//		connect(thread, &FieldModelThread::modelLoaded,
+	//				this, &WalkmeshWidget::addModel);
 	// thread->setModels(modelIds); 		thread->start(); 	} else {
 	for (int modelId : modelIds) {
 		addModel(field, field->fieldModel(modelId), modelId);

--- a/src/3d/WalkmeshWidget.cpp
+++ b/src/3d/WalkmeshWidget.cpp
@@ -213,7 +213,8 @@ void WalkmeshWidget::paintGL()
 
 		if (infFile && infFile->isOpen()) {
 			int gateID = 0;
-			for (const Exit &gate : infFile->exitLines()) {
+			const auto exitLines = infFile->exitLines();
+			for (const Exit &gate : exitLines) {
 				if (gate.fieldID != 0x7FFF) {
 					// Vertex info
 					QVector3D positionA(gate.exit_line[0].x / 4096.0f, gate.exit_line[0].y / 4096.0f, gate.exit_line[0].z / 4096.0f),
@@ -226,8 +227,8 @@ void WalkmeshWidget::paintGL()
 				}
 				++gateID;
 			}
-
-			for (const Trigger &trigger : infFile->triggers()) {
+			const auto triggers = infFile->triggers();
+			for (const Trigger &trigger : triggers) {
 				if (trigger.background_parameter != 0xFF) {
 					// Vertex info
 					QVector3D positionA(trigger.trigger_line[0].x / 4096.0f, trigger.trigger_line[0].y / 4096.0f, trigger.trigger_line[0].z / 4096.0f),

--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -60,46 +60,46 @@ Window::Window() :
 	/* "File" Menu */
 	QMenu *fileMenu = menuBar->addMenu(tr("&File"));
 
-	actionOpen = fileMenu->addAction(QApplication::style()->standardIcon(QStyle::SP_DialogOpenButton), tr("&Open..."), this, SLOT(openFile()), QKeySequence("Ctrl+O"));
-	fileMenu->addAction(tr("Open &Directory..."), this, SLOT(openDir()), QKeySequence("Shift+Ctrl+O"));
+	actionOpen = fileMenu->addAction(QApplication::style()->standardIcon(QStyle::SP_DialogOpenButton), tr("&Open..."), this, [&] { openFile(QString());}, QKeySequence("Ctrl+O"));
+	fileMenu->addAction(tr("Open &Directory..."), this, &Window::openDir, QKeySequence("Shift+Ctrl+O"));
 	_recentMenu = new QMenu(tr("&Recent files"), this);
 	fillRecentMenu();
-	connect(_recentMenu, SIGNAL(triggered(QAction*)), SLOT(openRecentFile(QAction*)));
+	connect(_recentMenu, &QMenu::triggered, this, &Window::openRecentFile);
 	fileMenu->addMenu(_recentMenu);
-	actionSave = fileMenu->addAction(QApplication::style()->standardIcon(QStyle::SP_DialogSaveButton), tr("&Save"), this, SLOT(save()), QKeySequence("Ctrl+S"));
-	actionSaveAs = fileMenu->addAction(tr("Save &As..."), this, SLOT(saveAs()), QKeySequence("Shift+Ctrl+S"));
-	actionExport = fileMenu->addAction(tr("&Export the current map..."), this, SLOT(exportCurrentMap()), QKeySequence("Ctrl+E"));
-	actionMassExport = fileMenu->addAction(tr("&Mass Export..."), this, SLOT(massExport()), QKeySequence("Shift+Ctrl+E"));
-	actionImport = fileMenu->addAction(tr("&Import to current map..."), this, SLOT(importToCurrentMap()), QKeySequence("Ctrl+I"));
-//	actionMassImport = fileMenu->addAction(tr("Mass &import..."), this, SLOT(massImport()), QKeySequence("Shift+Ctrl+I"));
-	actionArchive = fileMenu->addAction(tr("Archive Mana&ger..."), this, SLOT(archiveManager()), QKeySequence("Ctrl+K"));
+	actionSave = fileMenu->addAction(QApplication::style()->standardIcon(QStyle::SP_DialogSaveButton), tr("&Save"), this, &Window::save, QKeySequence("Ctrl+S"));
+	actionSaveAs = fileMenu->addAction(tr("Save &As..."), this, &Window::saveAs, QKeySequence("Shift+Ctrl+S"));
+	actionExport = fileMenu->addAction(tr("&Export the current map..."), this, &Window::exportCurrentMap, QKeySequence("Ctrl+E"));
+	actionMassExport = fileMenu->addAction(tr("&Mass Export..."), this, &Window::massExport, QKeySequence("Shift+Ctrl+E"));
+	actionImport = fileMenu->addAction(tr("&Import to current map..."), this, &Window::importToCurrentMap, QKeySequence("Ctrl+I"));
+//	actionMassImport = fileMenu->addAction(tr("Mass &import..."), this, &Window::massImport, QKeySequence("Shift+Ctrl+I"));
+	actionArchive = fileMenu->addAction(tr("Archive Mana&ger..."), this, &Window::archiveManager, QKeySequence("Ctrl+K"));
 	fileMenu->addSeparator();
-	actionRun = fileMenu->addAction(QIcon(":/images/ff7.png"), tr("R&un FF7"), this, SLOT(runFF7()));
+	actionRun = fileMenu->addAction(QIcon(":/images/ff7.png"), tr("R&un FF7"), this, &Window::runFF7);
 	actionRun->setShortcut(Qt::Key_F8);
 	actionRun->setShortcutContext(Qt::ApplicationShortcut);
 	actionRun->setEnabled(!Data::ff7AppPath().isEmpty());
 	fileMenu->addSeparator();
-	actionClose = fileMenu->addAction(QApplication::style()->standardIcon(QStyle::SP_DialogCloseButton), tr("C&lose"), this, SLOT(closeFile()));
-	fileMenu->addAction(tr("E&xit"), this, SLOT(close()), QKeySequence::Quit)->setMenuRole(QAction::QuitRole);
+	actionClose = fileMenu->addAction(QApplication::style()->standardIcon(QStyle::SP_DialogCloseButton), tr("C&lose"), this, &Window::closeFile);
+	fileMenu->addAction(tr("E&xit"), this, &Window::close, QKeySequence::Quit)->setMenuRole(QAction::QuitRole);
 
 	/* "Tools" Menu */
 	menu = menuBar->addMenu(tr("T&ools"));
-	QAction *actionText = menu->addAction(QIcon(":/images/text-editor.png"), tr("&Texts..."), this, SLOT(textManager()), QKeySequence("Ctrl+T"));
-	actionModels = menu->addAction(QIcon(":/images/model.png"), tr("Map &Models..."), this, SLOT(modelManager()), QKeySequence("Ctrl+M"));
-	actionEncounter = menu->addAction(tr("Encounte&rs..."), this, SLOT(encounterManager()), QKeySequence("Ctrl+N"));
-	menu->addAction(tr("Tutorials/&Sounds..."), this, SLOT(tutManager()), QKeySequence("Ctrl+K"));
-	QAction *actionWalkmesh = menu->addAction(QIcon(":/images/location.png"), tr("&Walkmesh..."), this, SLOT(walkmeshManager()), QKeySequence("Ctrl+W"));
-	menu->addAction(QIcon(":/images/background.png"), tr("&Background..."), this, SLOT(backgroundManager()), QKeySequence("Ctrl+B"));
-	actionMisc = menu->addAction(tr("M&iscellaneous..."), this, SLOT(miscManager()));
+	QAction *actionText = menu->addAction(QIcon(":/images/text-editor.png"), tr("&Texts..."), this, [&] {textManager(-1, 0, 0, true);}, QKeySequence("Ctrl+T"));
+	actionModels = menu->addAction(QIcon(":/images/model.png"), tr("Map &Models..."), this, &Window::modelManager, QKeySequence("Ctrl+M"));
+	actionEncounter = menu->addAction(tr("Encounte&rs..."), this, &Window::encounterManager, QKeySequence("Ctrl+N"));
+	menu->addAction(tr("Tutorials/&Sounds..."), this, &Window::tutManager, QKeySequence("Ctrl+K"));
+	QAction *actionWalkmesh = menu->addAction(QIcon(":/images/location.png"), tr("&Walkmesh..."), this, &Window::walkmeshManager, QKeySequence("Ctrl+W"));
+	menu->addAction(QIcon(":/images/background.png"), tr("&Background..."), this, &Window::backgroundManager, QKeySequence("Ctrl+B"));
+	actionMisc = menu->addAction(tr("M&iscellaneous..."), this, &Window::miscManager);
 	menu->addSeparator();
-	menu->addAction(tr("Variable Mana&ger..."), this, SLOT(varManager()), QKeySequence("Ctrl+G"));
-	actionFind = menu->addAction(QIcon(":/images/find.png"), tr("&Find..."), this, SLOT(searchManager()), QKeySequence::Find);
-	actionMiscOperations = menu->addAction(tr("B&atch processing..."), this, SLOT(miscOperations()));
+	menu->addAction(tr("Variable Mana&ger..."), this, &Window::varManager, QKeySequence("Ctrl+G"));
+	actionFind = menu->addAction(QIcon(":/images/find.png"), tr("&Find..."), this, &Window::searchManager, QKeySequence::Find);
+	actionMiscOperations = menu->addAction(tr("B&atch processing..."), this, &Window::miscOperations);
 
 	/* "Settings" Menu */
 	menu = menuBar->addMenu(tr("&Settings"));
 
-	actionJp_txt = menu->addAction(tr("&Japanese Characters"), this, SLOT(jpText(bool)));
+	actionJp_txt = menu->addAction(tr("&Japanese Characters"), this, &Window::jpText);
 	actionJp_txt->setCheckable(true);
 	actionJp_txt->setChecked(Config::value("jp_txt", false).toBool());
 
@@ -126,9 +126,9 @@ Window::Window() :
 			action->setChecked(Config::value("lang").toString() == lang);
 		}
 	}
-	connect(menuLang, SIGNAL(triggered(QAction*)), this, SLOT(changeLanguage(QAction*)));
+	connect(menuLang, &QMenu::triggered, this, &Window::changeLanguage);
 
-	menu->addAction(tr("&Configuration..."), this, SLOT(config()))->setMenuRole(QAction::PreferencesRole);
+	menu->addAction(tr("&Configuration..."), this, &Window::config)->setMenuRole(QAction::PreferencesRole);
 	
 #if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
 	qreal scale = qApp->desktop()->physicalDpiX() / qApp->desktop()->logicalDpiX();
@@ -167,7 +167,7 @@ Window::Window() :
 		fieldModel = new FieldModel();
 //		modelThread = new FieldModelThread(this);
 
-//		connect(modelThread, SIGNAL(modelLoaded(Field*,FieldModelFile*,int,int,bool)), SLOT(showModel(Field*,FieldModelFile*)));
+//		connect(modelThread, &FieldModelThread::modelLoaded, this, &Window::showModel);
 	} else {
 		fieldModel = nullptr;
 	}
@@ -222,27 +222,27 @@ Window::Window() :
 	searchDialog = new Search(this);
 	menuBar->addMenu(createPopupMenu());
 #ifndef Q_OS_MAC
-	menuBar->addAction(tr("&?"), this, SLOT(about()))->setMenuRole(QAction::AboutRole);
+	menuBar->addAction(tr("&?"), this, &Window::about)->setMenuRole(QAction::AboutRole);
 #else
-	fileMenu->addAction(tr("&?"), this, SLOT(about()))->setMenuRole(QAction::AboutRole);
+	fileMenu->addAction(tr("&?"), this, &Window::about)->setMenuRole(QAction::AboutRole);
 #endif
 
 	setMenuBar(menuBar);
 
-	connect(_fieldList, SIGNAL(itemSelectionChanged()), SLOT(openField()));
-	connect(_fieldList, SIGNAL(changed()), SLOT(setModified()));
-	connect(_fieldList, SIGNAL(fieldDeleted()), SLOT(setFieldDeleted()));
-	connect(zoneImage, SIGNAL(clicked()), SLOT(backgroundManager()));
-	connect(searchDialog, SIGNAL(found(int,int,int,int)), SLOT(gotoOpcode(int,int,int,int)));
-	connect(searchDialog, SIGNAL(foundText(int,int,qsizetype,qsizetype)), SLOT(gotoText(int,int,qsizetype,qsizetype)));
-	connect(_scriptManager, SIGNAL(groupScriptCurrentChanged(int)), SLOT(showModel(int)));
-	connect(_scriptManager, SIGNAL(editText(int)), SLOT(textManager(int)));
-	connect(_scriptManager, SIGNAL(changed()), SLOT(setModified()));
-	connect(_scriptManager, SIGNAL(searchOpcode(int)), SLOT(searchOpcode(int)));
-	connect(emptyFieldWidget, SIGNAL(createMapClicked()), SLOT(createCurrentMap()));
-	connect(emptyFieldWidget, SIGNAL(importMapClicked()), SLOT(importToCurrentMap()));
+	connect(_fieldList, &FieldList::itemSelectionChanged, this, [&] {openField(false);});
+	connect(_fieldList, &FieldList::changed, this, [&] {setModified(true);});
+	connect(_fieldList, &FieldList::fieldDeleted, this, &Window::setFieldDeleted);
+	connect(zoneImage, &ApercuBG::clicked, this, &Window::backgroundManager);
+	connect(searchDialog, &Search::found, this, &Window::gotoOpcode);
+	connect(searchDialog, &Search::foundText, this, &Window::gotoText);
+	connect(_scriptManager, &ScriptManager::groupScriptCurrentChanged, this, qOverload<int>(&Window::showModel));
+	connect(_scriptManager, &ScriptManager::editText, this, [&](int id) {textManager(id, 0, 0, true);});
+	connect(_scriptManager, &ScriptManager::changed, this, [&] {setModified(true);});
+	connect(_scriptManager, &ScriptManager::searchOpcode, this, &Window::searchOpcode);
+	connect(emptyFieldWidget, &EmptyFieldWidget::createMapClicked, this, &Window::createCurrentMap);
+	connect(emptyFieldWidget, &EmptyFieldWidget::importMapClicked, this, &Window::importToCurrentMap);
 
-	connect(&timer, SIGNAL(timeout()), SLOT(processEvents()));
+	connect(&timer, &QTimer::timeout, this, &Window::processEvents);
 
 	_fieldList->sortItems(Config::value("fieldListSortColumn", 1).toInt(),
 	                     Qt::SortOrder(Config::value("fieldListSortOrder").toBool()));
@@ -298,10 +298,10 @@ QMenu *Window::createPopupMenu()
 	QMenu *menu = new QMenu(tr("&View"), this);
 	menu->addAction(toolBar->toggleViewAction());
 	QAction *action;
-	action = menu->addAction(tr("Map List"), this, SLOT(toggleFieldList()));
+	action = menu->addAction(tr("Map List"), this, &Window::toggleFieldList);
 	action->setCheckable(true);
 	action->setChecked(!verticalSplitter->isCollapsed(0));
-	action = menu->addAction(tr("Background Preview"), this, SLOT(toggleBackgroundPreview()));
+	action = menu->addAction(tr("Background Preview"), this, &Window::toggleBackgroundPreview);
 	action->setCheckable(true);
 	action->setChecked(!horizontalSplitter->isCollapsed(1));
 	menu->addSeparator();
@@ -1388,7 +1388,7 @@ void Window::importToCurrentMap()
 		return;
 	}
 
-	setModified();
+    setModified(true);
 	index = path.lastIndexOf('/');
 	Config::setValue("importPath", index == -1 ? path : path.left(index));
 	openField(true);
@@ -1466,9 +1466,9 @@ void Window::textManager(int textID, int from, int size, bool activate)
 {
 	if (!_textDialog) {
 		_textDialog = new TextManager(this);
-		connect(_textDialog, SIGNAL(modified()), SLOT(setModified()));
-		connect(_textDialog, SIGNAL(opcodeModified(int,int,int)), _scriptManager, SLOT(refreshOpcode(int,int,int)));
-		connect(_scriptManager, SIGNAL(changed()), _textDialog, SLOT(updateFromScripts()));
+		connect(_textDialog, &TextManager::modified, this, [&] {setModified(true);});
+		connect(_textDialog, &TextManager::opcodeModified, _scriptManager, &ScriptManager::refreshOpcode);
+		connect(_scriptManager, &ScriptManager::changed, _textDialog, &TextManager::updateFromScripts);
 	}
 
 	if (field && field->scriptsAndTexts()->isOpen()) {
@@ -1498,7 +1498,7 @@ void Window::modelManager()
 		} else {
 			_modelManager = new ModelManagerPS(this);
 		}
-		connect(_modelManager, SIGNAL(modified()), SLOT(setModified()));
+		connect(_modelManager, &ModelManager::modified, this, [&] {setModified(true);});
 	}
 
 	if (field) {
@@ -1532,7 +1532,7 @@ void Window::encounterManager()
 			if (dialog.exec()==QDialog::Accepted)
 			{
 				if (encounter->isModified())
-					setModified();
+				setModified(true);
 			}
 		} else {
 			QMessageBox::warning(this, tr("Opening error"), tr("Can not open encounters!"));
@@ -1544,7 +1544,7 @@ void Window::tutManager()
 {
 	if (!_tutManager) {
 		_tutManager = new TutWidget(this);
-		connect(_tutManager, SIGNAL(modified()), SLOT(setModified()));
+		connect(_tutManager, &TutWidget::modified, this, [&] {setModified(true);});
 	}
 
 	if (field && field->tutosAndSounds()->isOpen()) {
@@ -1566,7 +1566,7 @@ void Window::walkmeshManager()
 {
 	if (!_walkmeshManager) {
 		_walkmeshManager = new WalkmeshManager(this);
-		connect(_walkmeshManager, SIGNAL(modified()), SLOT(setModified()));
+		connect(_walkmeshManager, &WalkmeshManager::modified, this, [&] {setModified(true);});
 	}
 
 	if (field) {
@@ -1584,8 +1584,8 @@ void Window::backgroundManager()
 {
 	if (!_backgroundManager) {
 		_backgroundManager = new BGDialog(this);
-		connect(_backgroundManager, SIGNAL(modified()), SLOT(setModified()));
-		connect(_backgroundManager, SIGNAL(modified()), zoneImage, SLOT(drawBackground()));
+		connect(_backgroundManager, &BGDialog::modified, this, [&] {setModified(true);});
+		connect(_backgroundManager, &BGDialog::modified, zoneImage, &ApercuBG::drawBackground);
 	}
 
 	if (field) {
@@ -1608,7 +1608,7 @@ void Window::miscManager()
 			if (dialog.exec()==QDialog::Accepted)
 			{
 				if (inf->isModified() || field->isModified()) {
-					setModified();
+					setModified(true);
 					authorLbl->setText(tr("Author: %1").arg(field->scriptsAndTexts()->author()));
 				}
 			}
@@ -1627,7 +1627,7 @@ void Window::archiveManager()
 		actionArchive->setText(tr("Go back to field map editor..."));
 		if (_lgpWidget == nullptr) {
 			_lgpWidget = new LgpWidget(static_cast<Lgp *>(fieldArchive->io()->device()), this);
-			connect(_lgpWidget, SIGNAL(modified()), SLOT(setModified()));
+			connect(_lgpWidget, &LgpWidget::modified, this, [&] {setModified(true);});
 			_mainStackedWidget->addWidget(_lgpWidget);
 		}
 		_mainStackedWidget->setCurrentWidget(_lgpWidget);
@@ -1675,7 +1675,7 @@ void Window::miscOperations()
 		hideProgression();
 
 		if (fieldArchive->isModified()) {
-			setModified();
+		setModified(true);
 		}
 	}
 }

--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -1675,7 +1675,7 @@ void Window::miscOperations()
 		hideProgression();
 
 		if (fieldArchive->isModified()) {
-		setModified(true);
+			setModified(true);
 		}
 	}
 }

--- a/src/core/field/BackgroundTilesIO.cpp
+++ b/src/core/field/BackgroundTilesIO.cpp
@@ -760,7 +760,9 @@ bool BackgroundTilesIOPS::writeData(const BackgroundTiles &tiles) const
 			}
 
 			// Separation between Y (only when several lines)
-			if (tilesByDstY.keys().size() > 1) {
+			auto tileKeys = tilesByDstY.keys();
+			qsizetype tileSize = tileKeys.size();
+			if (tileSize > 1) {
 				quint16 flag = 0x7FFE;
 				device()->write((char *)&flag, 2);
 				device()->write((char *)&line, 2);

--- a/src/core/field/FieldArchive.cpp
+++ b/src/core/field/FieldArchive.cpp
@@ -108,8 +108,8 @@ FieldArchive::FieldArchive(FieldArchiveIO *io) :
 	_io(io), _observer(nullptr)
 {
 	//	fileWatcher.addPath(path);
-	//	connect(&fileWatcher, SIGNAL(fileChanged(QString)), this, SIGNAL(fileChanged(QString)));
-	//	connect(&fileWatcher, SIGNAL(directoryChanged(QString)), this, SIGNAL(directoryChanged(QString)));
+	//	connect(&fileWatcher, &QFileSystemWatcher::fileChanged, this, &FieldArchive::fileChanged);
+	//	connect(&fileWatcher, &QFileSystemWatcher::directoryChanged, this, &FieldArchive::directoryChanged);
 }
 
 FieldArchive::~FieldArchive()

--- a/src/core/field/Opcode.cpp
+++ b/src/core/field/Opcode.cpp
@@ -263,7 +263,7 @@ bool Opcode::searchVar(quint8 bank, quint16 address, Operation operation, int va
 			}
 		} else {
 			// Every write vars
-			for (const FF7Var &var : vars) {
+			for (const FF7Var &var : qAsConst(vars)) {
 				if (var.bank == bank && (noAddress || var.address == address)
 				        && var.flags.testFlag(FF7Var::Writable) && var.size != FF7Var::Bit) {
 					return true;
@@ -298,7 +298,7 @@ bool Opcode::searchVar(quint8 bank, quint16 address, Operation operation, int va
 		}
 	} return false;
 	default:
-		for (const FF7Var &var : vars) {
+		for (const FF7Var &var : qAsConst(vars)) {
 			if (var.bank == bank && (noAddress || var.address == address)) {
 				return true;
 			}

--- a/src/core/field/Script.cpp
+++ b/src/core/field/Script.cpp
@@ -58,7 +58,8 @@ bool Script::openScript(const char *script, qsizetype scriptSize)
 	quint16 labelNumber = 1;
 	for (qsizetype jump: labelPositionsKeys) {
 		qsizetype index = positions.indexOf(jump);
-		for (qsizetype opcodeID : labelPositions.values(jump)) {
+		const auto IDS = labelPositions.values(jump);
+		for (qsizetype opcodeID : IDS) {
 			_opcodes[opcodeID].setLabel(labelNumber);
 			_opcodes[opcodeID].setBadJump(
 			            index < 0
@@ -92,7 +93,7 @@ Script Script::splitScriptAtReturn()
 	int gotoLabel = -1;
 	int opcodeID = 0;
 
-	for (const Opcode &opcode : _opcodes) {
+	for (const Opcode &opcode : qAsConst(_opcodes)) {
 		if (opcode.id() == OpcodeKey::LABEL) {
 			if (gotoLabel != -1 && opcode.op().opcodeLABEL._label == quint32(gotoLabel)) {
 				gotoLabel = -1;
@@ -159,7 +160,7 @@ bool Script::compile(int &opcodeID, QString &errorStr)
 
 	// Search labels
 	opcodeID = 0;
-	for (const Opcode &opcode : _opcodes) {
+	for (const Opcode &opcode : qAsConst(_opcodes)) {
 		if (opcode.id() == OpcodeKey::LABEL) {
 			if (!labelPositions.contains(opcode.op().opcodeLABEL._label)) {
 				labelPositions.insert(opcode.op().opcodeLABEL._label, pos);
@@ -711,7 +712,7 @@ bool Script::removeTexts()
 {
 	bool modified = false;
 	qsizetype i = 0;
-	for (const Opcode &opcode : _opcodes) {
+	for (const Opcode &opcode : qAsConst(_opcodes)) {
 		if (opcode.id() != OpcodeKey::ASK
 				&& opcode.id() != OpcodeKey::MPNAM
 				&& opcode.textID() != -1) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -40,7 +40,7 @@ int main(int argc, char *argv[])
 	Config::set();
 	CLI::exec();
 
-	QTimer::singleShot(0, &app, SLOT(quit()));
+	QTimer::singleShot(0, &app, &QCoreApplication::quit);
 #else
 
 	QApplication app(argc, argv);

--- a/src/widgets/AboutDialog.cpp
+++ b/src/widgets/AboutDialog.cpp
@@ -40,7 +40,7 @@ AboutDialog::AboutDialog(QWidget *parent)
 
 	QDialogButtonBox *buttonBox = new QDialogButtonBox(Qt::Horizontal, this);
 	buttonBox->addButton(QDialogButtonBox::Close);
-	connect(buttonBox, SIGNAL(rejected()), this, SLOT(close()));
+	connect(buttonBox, &QDialogButtonBox::rejected, this, &AboutDialog::close);
 
 	QLabel *desc3 = new QLabel(QString("Qt %1").arg(QT_VERSION_STR), this);
 	QPalette pal = desc3->palette();

--- a/src/widgets/AnimEditorDialog.cpp
+++ b/src/widgets/AnimEditorDialog.cpp
@@ -45,11 +45,11 @@ AnimEditorDialog::AnimEditorDialog(int animID, QWidget *parent) :
 	layout->addWidget(buttonBox, 1, 0, 1, 2);
 
 	if (Data::currentModelID != -1) {
-		connect(aList, SIGNAL(currentRowChanged(int)), SLOT(changeModelAnimation()));
+		connect(aList, &QListWidget::currentRowChanged, this, &AnimEditorDialog::changeModelAnimation);
 	}
 	aList->setCurrentRow(animID);
-	connect(buttonBox, SIGNAL(accepted()), SLOT(accept()));
-	connect(buttonBox, SIGNAL(rejected()), SLOT(reject()));
+	connect(buttonBox, &QDialogButtonBox::accepted, this, &AnimEditorDialog::accept);
+	connect(buttonBox, &QDialogButtonBox::rejected, this, &AnimEditorDialog::reject);
 }
 
 void AnimEditorDialog::changeModelAnimation()

--- a/src/widgets/ArchivePreview.cpp
+++ b/src/widgets/ArchivePreview.cpp
@@ -55,8 +55,8 @@ QWidget *ArchivePreview::imageWidget()
 	layout->addWidget(palSelect, 0, Qt::AlignCenter);
 	layout->addWidget(scrollArea);
 
-	connect(imageSelect, SIGNAL(currentIndexChanged(int)), SIGNAL(currentImageChanged(int)));
-	connect(palSelect, SIGNAL(currentIndexChanged(int)), SIGNAL(currentPaletteChanged(int)));
+	connect(imageSelect, &QComboBox::currentIndexChanged, this, &ArchivePreview::currentImageChanged);
+	connect(palSelect, &QComboBox::currentIndexChanged, this, &ArchivePreview::currentPaletteChanged);
 
 	return ret;
 }
@@ -93,7 +93,7 @@ void ArchivePreview::imagePreview(const QPixmap &image, const QString &name,
 
 	this->_name = name;
 
-	connect(_lbl, SIGNAL(saveRequested()), SLOT(saveImage()));
+	connect(_lbl, &ApercuBGLabel::saveRequested, this, &ArchivePreview::saveImage);
 
 	imageSelect->blockSignals(true);
 	imageSelect->clear();

--- a/src/widgets/BGDialog.cpp
+++ b/src/widgets/BGDialog.cpp
@@ -83,7 +83,7 @@ BGDialog::BGDialog(QWidget *parent) :
 	connect(layersWidget, &QListWidget::itemChanged, this, &BGDialog::enableLayer);
 	connect(sectionsWidget, &QListWidget::itemChanged, this, &BGDialog::enableSection);
 	connect(zWidget, &QSpinBox::valueChanged, this, &BGDialog::changeZ);
-	connect(buttonRepair, &QPushButton::released, this, &BGDialog::tryToRepairBG);
+	connect(buttonRepair, &QPushButton::clicked, this, &BGDialog::tryToRepairBG);
 	connect(tabBar, &QTabBar::currentChanged, this, &BGDialog::updateBG);
 	connect(tabBar, &QTabBar::currentChanged, this, &BGDialog::showLayersPage);
 }

--- a/src/widgets/BGDialog.cpp
+++ b/src/widgets/BGDialog.cpp
@@ -75,17 +75,17 @@ BGDialog::BGDialog(QWidget *parent) :
 	layout->setColumnStretch(0, 2);
 	layout->setColumnStretch(1, 1);
 
-	connect(image, SIGNAL(saveRequested()), SLOT(saveImage()));
-	connect(parametersWidget, SIGNAL(currentIndexChanged(int)), SLOT(parameterChanged(int)));
-	connect(layersWidget, SIGNAL(itemSelectionChanged()), SLOT(layerChanged()));
-	connect(sectionsWidget, SIGNAL(itemSelectionChanged()), SLOT(sectionChanged()));
-	connect(statesWidget, SIGNAL(itemChanged(QListWidgetItem*)), SLOT(enableState(QListWidgetItem*)));
-	connect(layersWidget, SIGNAL(itemChanged(QListWidgetItem*)), SLOT(enableLayer(QListWidgetItem*)));
-	connect(sectionsWidget, SIGNAL(itemChanged(QListWidgetItem*)), SLOT(enableSection(QListWidgetItem*)));
-	connect(zWidget, SIGNAL(valueChanged(int)), SLOT(changeZ(int)));
-	connect(buttonRepair, SIGNAL(released()), SLOT(tryToRepairBG()));
-	connect(tabBar, SIGNAL(currentChanged(int)), SLOT(updateBG()));
-	connect(tabBar, SIGNAL(currentChanged(int)), SLOT(showLayersPage(int)));
+	connect(image, &ApercuBGLabel::saveRequested, this, &BGDialog::saveImage);
+	connect(parametersWidget, &QComboBox::currentIndexChanged, this, &BGDialog::parameterChanged);
+	connect(layersWidget, &QListWidget::itemSelectionChanged, this, &BGDialog::layerChanged);
+	connect(sectionsWidget, &QListWidget::itemSelectionChanged, this, &BGDialog::sectionChanged);
+	connect(statesWidget, &QListWidget::itemChanged, this, &BGDialog::enableState);
+	connect(layersWidget, &QListWidget::itemChanged, this, &BGDialog::enableLayer);
+	connect(sectionsWidget, &QListWidget::itemChanged, this, &BGDialog::enableSection);
+	connect(zWidget, &QSpinBox::valueChanged, this, &BGDialog::changeZ);
+	connect(buttonRepair, &QPushButton::released, this, &BGDialog::tryToRepairBG);
+	connect(tabBar, &QTabBar::currentChanged, this, &BGDialog::updateBG);
+	connect(tabBar, &QTabBar::currentChanged, this, &BGDialog::showLayersPage);
 }
 
 void BGDialog::fill(Field *field, bool reload)

--- a/src/widgets/ConfigWindow.cpp
+++ b/src/widgets/ConfigWindow.cpp
@@ -159,14 +159,14 @@ ConfigWindow::ConfigWindow(QWidget *parent)
 	layout->addWidget(buttonBox, 4, 0, 1, 2);
 
 	connect(listFF7, &QTreeWidget::itemSelectionChanged, this, &ConfigWindow::changeFF7ListButtonsState);
-	connect(ff7ButtonMod, &QPushButton::released, this, &ConfigWindow::modifyCustomFF7Path);
-	connect(ff7ButtonRem, &QPushButton::released, this, &ConfigWindow::removeCustomFF7Path);
+	connect(ff7ButtonMod, &QPushButton::clicked, this, &ConfigWindow::modifyCustomFF7Path);
+	connect(ff7ButtonRem, &QPushButton::clicked, this, &ConfigWindow::removeCustomFF7Path);
 	connect(kernelAuto, &QCheckBox::toggled, this, &ConfigWindow::kernelAutoChange);
 	connect(windowAuto, &QCheckBox::toggled, this, &ConfigWindow::windowAutoChange);
 	connect(charAuto, &QCheckBox::toggled, this, &ConfigWindow::charAutoChange);
-	connect(kernelButton, &QPushButton::released, this, &ConfigWindow::changeKernelPath);
-	connect(windowButton, &QPushButton::released, this, &ConfigWindow::changeWindowPath);
-	connect(charButton, &QPushButton::released, this, &ConfigWindow::changeCharPath);
+	connect(kernelButton, &QPushButton::clicked, this, &ConfigWindow::changeKernelPath);
+	connect(windowButton, &QPushButton::clicked, this, &ConfigWindow::changeWindowPath);
+	connect(charButton, &QPushButton::clicked, this, &ConfigWindow::changeCharPath);
 	connect(windowPreview, &DialogPreview::LL_ColorChanged, this, [&] (const QColor &color){
 		windowColorBottomLeft = color.rgb();
 	});
@@ -179,10 +179,10 @@ ConfigWindow::ConfigWindow(QWidget *parent)
 	connect(windowPreview, &DialogPreview::UR_ColorChanged, this, [&] (const QColor &color){
 		windowColorTopRight = color.rgb();
 	});
-	connect(windowColorReset, &QPushButton::released, this, &ConfigWindow::resetColor);
+	connect(windowColorReset, &QPushButton::clicked, this, &ConfigWindow::resetColor);
 	connect(listCharNames, &QComboBox::currentIndexChanged, this, &ConfigWindow::fillCharNameEdit);
 	connect(charNameEdit, &QLineEdit::textEdited, this, &ConfigWindow::setCharName);
-	connect(encodingEdit, &QPushButton::released, this, &ConfigWindow::editEncoding);
+	connect(encodingEdit, &QPushButton::clicked, this, &ConfigWindow::editEncoding);
 	connect(buttonBox, &QDialogButtonBox::accepted, this, &ConfigWindow::accept);
 	connect(buttonBox, &QDialogButtonBox::rejected, this, &ConfigWindow::reject);
 

--- a/src/widgets/ConfigWindow.cpp
+++ b/src/widgets/ConfigWindow.cpp
@@ -158,15 +158,15 @@ ConfigWindow::ConfigWindow(QWidget *parent)
 	layout->addWidget(scriptEditor, 3, 0, 1, 2);
 	layout->addWidget(buttonBox, 4, 0, 1, 2);
 
-	connect(listFF7, SIGNAL(itemSelectionChanged()), SLOT(changeFF7ListButtonsState()));
-	connect(ff7ButtonMod, SIGNAL(released()), SLOT(modifyCustomFF7Path()));
-	connect(ff7ButtonRem, SIGNAL(released()), SLOT(removeCustomFF7Path()));
-	connect(kernelAuto, SIGNAL(toggled(bool)), SLOT(kernelAutoChange(bool)));
-	connect(windowAuto, SIGNAL(toggled(bool)), SLOT(windowAutoChange(bool)));
-	connect(charAuto, SIGNAL(toggled(bool)), SLOT(charAutoChange(bool)));
-	connect(kernelButton, SIGNAL(released()), SLOT(changeKernelPath()));
-	connect(windowButton, SIGNAL(released()), SLOT(changeWindowPath()));
-	connect(charButton, SIGNAL(released()), SLOT(changeCharPath()));
+	connect(listFF7, &QTreeWidget::itemSelectionChanged, this, &ConfigWindow::changeFF7ListButtonsState);
+	connect(ff7ButtonMod, &QPushButton::released, this, &ConfigWindow::modifyCustomFF7Path);
+	connect(ff7ButtonRem, &QPushButton::released, this, &ConfigWindow::removeCustomFF7Path);
+	connect(kernelAuto, &QCheckBox::toggled, this, &ConfigWindow::kernelAutoChange);
+	connect(windowAuto, &QCheckBox::toggled, this, &ConfigWindow::windowAutoChange);
+	connect(charAuto, &QCheckBox::toggled, this, &ConfigWindow::charAutoChange);
+	connect(kernelButton, &QPushButton::released, this, &ConfigWindow::changeKernelPath);
+	connect(windowButton, &QPushButton::released, this, &ConfigWindow::changeWindowPath);
+	connect(charButton, &QPushButton::released, this, &ConfigWindow::changeCharPath);
 	connect(windowPreview, &DialogPreview::LL_ColorChanged, this, [&] (const QColor &color){
 		windowColorBottomLeft = color.rgb();
 	});
@@ -179,12 +179,12 @@ ConfigWindow::ConfigWindow(QWidget *parent)
 	connect(windowPreview, &DialogPreview::UR_ColorChanged, this, [&] (const QColor &color){
 		windowColorTopRight = color.rgb();
 	});
-	connect(windowColorReset, SIGNAL(released()), SLOT(resetColor()));
-	connect(listCharNames, SIGNAL(currentIndexChanged(int)), SLOT(fillCharNameEdit()));
-	connect(charNameEdit, SIGNAL(textEdited(QString)), SLOT(setCharName(QString)));
-	connect(encodingEdit, SIGNAL(released()), SLOT(editEncoding()));
-	connect(buttonBox, SIGNAL(accepted()), SLOT(accept()));
-	connect(buttonBox, SIGNAL(rejected()), SLOT(reject()));
+	connect(windowColorReset, &QPushButton::released, this, &ConfigWindow::resetColor);
+	connect(listCharNames, &QComboBox::currentIndexChanged, this, &ConfigWindow::fillCharNameEdit);
+	connect(charNameEdit, &QLineEdit::textEdited, this, &ConfigWindow::setCharName);
+	connect(encodingEdit, &QPushButton::released, this, &ConfigWindow::editEncoding);
+	connect(buttonBox, &QDialogButtonBox::accepted, this, &ConfigWindow::accept);
+	connect(buttonBox, &QDialogButtonBox::rejected, this, &ConfigWindow::reject);
 
 	fillConfig();
 	changeFF7ListButtonsState();
@@ -272,7 +272,7 @@ void ConfigWindow::fillConfig()
 	choiceWidthEdit->setValue(Config::value("choiceWidth", 10).toInt());
 	tabWidthEdit->setValue(Config::value("tabWidth", 4).toInt());
 
-	QTimer::singleShot(0, this, SLOT(showIcons()));
+	QTimer::singleShot(0, this, &ConfigWindow::showIcons);
 }
 
 void ConfigWindow::showIcons()

--- a/src/widgets/EmptyFieldWidget.cpp
+++ b/src/widgets/EmptyFieldWidget.cpp
@@ -28,6 +28,6 @@ EmptyFieldWidget::EmptyFieldWidget(QWidget *parent) : QWidget(parent)
 	layout->addWidget(importMapButton);
 	layout->addStretch(1);
 
-	connect(createNewMapButton, &QPushButton::released, this, &EmptyFieldWidget::createMapClicked);
-	connect(importMapButton, &QPushButton::released, this, &EmptyFieldWidget::importMapClicked);
+	connect(createNewMapButton, &QPushButton::clicked, this, &EmptyFieldWidget::createMapClicked);
+	connect(importMapButton, &QPushButton::clicked, this, &EmptyFieldWidget::importMapClicked);
 }

--- a/src/widgets/EmptyFieldWidget.cpp
+++ b/src/widgets/EmptyFieldWidget.cpp
@@ -28,6 +28,6 @@ EmptyFieldWidget::EmptyFieldWidget(QWidget *parent) : QWidget(parent)
 	layout->addWidget(importMapButton);
 	layout->addStretch(1);
 
-	connect(createNewMapButton, SIGNAL(released()), SIGNAL(createMapClicked()));
-	connect(importMapButton, SIGNAL(released()), SIGNAL(importMapClicked()));
+	connect(createNewMapButton, &QPushButton::released, this, &EmptyFieldWidget::createMapClicked);
+	connect(importMapButton, &QPushButton::released, this, &EmptyFieldWidget::importMapClicked);
 }

--- a/src/widgets/EncounterTableWidget.cpp
+++ b/src/widgets/EncounterTableWidget.cpp
@@ -67,9 +67,9 @@ EncounterTableWidget::EncounterTableWidget(const QString &title, QWidget *parent
 		}
 	}
 
-	connect(mainRate, SIGNAL(valueChanged(int)), SLOT(changePercent()));
+	connect(mainRate, &QSlider::valueChanged, this, &EncounterTableWidget::changePercent);
 	for (QSpinBox *battleProba : qAsConst(battleProbas)) {
-		connect(battleProba, SIGNAL(valueChanged(int)), SLOT(changeProbaCount()));
+		connect(battleProba, &QSpinBox::valueChanged, this, &EncounterTableWidget::changeProbaCount);
 	}
 
 	changePercent();

--- a/src/widgets/EncounterWidget.cpp
+++ b/src/widgets/EncounterWidget.cpp
@@ -46,8 +46,8 @@ EncounterWidget::EncounterWidget(EncounterFile *data, QWidget *parent) :
 	fillGroup(group1, data->encounterTable(EncounterFile::Table1));
 	fillGroup(group2, data->encounterTable(EncounterFile::Table2));
 
-	connect(buttonBox, SIGNAL(accepted()), SLOT(accept()));
-	connect(buttonBox, SIGNAL(rejected()), SLOT(reject()));
+	connect(buttonBox, &QDialogButtonBox::accepted, this, &EncounterWidget::accept);
+	connect(buttonBox, &QDialogButtonBox::rejected, this, &EncounterWidget::reject);
 }
 
 void EncounterWidget::fillGroup(EncounterTableWidget *group, const EncounterTable &encounterTable)

--- a/src/widgets/FieldList.cpp
+++ b/src/widgets/FieldList.cpp
@@ -40,8 +40,8 @@ FieldList::FieldList(QWidget *parent) :
 	_lineSearch->setStatusTip(tr("Quick search"));
 	_lineSearch->setPlaceholderText(tr("Search..."));
 
-	connect(_lineSearch, SIGNAL(textEdited(QString)), SLOT(filterMap(QString)));
-	connect(_lineSearch, SIGNAL(returnPressed()), SLOT(filterMap()));
+	connect(_lineSearch, &QLineEdit::textEdited, this, &FieldList::filterMap);
+	connect(_lineSearch, &QLineEdit::returnPressed, this, [&] { filterMap(_lineSearch->text()); });
 
 	QAction *rename_A = new QAction(tr("Rename field"), this);
 	rename_A->setShortcut(QKeySequence("F2"));
@@ -53,12 +53,12 @@ FieldList::FieldList(QWidget *parent) :
 	del_A->setShortcut(QKeySequence(Qt::Key_Delete));
 	del_A->setShortcutContext(Qt::WidgetWithChildrenShortcut);
 
-	connect(this, SIGNAL(itemDoubleClicked(QTreeWidgetItem *, int)), SLOT(rename(QTreeWidgetItem *, int)));
-	connect(this, SIGNAL(currentItemChanged(QTreeWidgetItem*,QTreeWidgetItem*)), SLOT(evidence(QTreeWidgetItem*,QTreeWidgetItem*)));
+	connect(this, &FieldList::itemDoubleClicked, this, qOverload<QTreeWidgetItem*,int>(&FieldList::rename));
+	connect(this, &QTreeWidget::currentItemChanged, this, &FieldList::evidence);
 
-	connect(rename_A, SIGNAL(triggered()), SLOT(rename()));
-	connect(add_A, SIGNAL(triggered()), SLOT(add()));
-	connect(del_A, SIGNAL(triggered()), SLOT(del()));
+	connect(rename_A, &QAction::triggered, this, qOverload<>(&FieldList::rename));
+	connect(add_A, &QAction::triggered, this, &FieldList::add);
+	connect(del_A, &QAction::triggered, this, &FieldList::del);
 
 	this->addAction(rename_A);
 	this->addAction(add_A);
@@ -195,7 +195,7 @@ void FieldList::rename(QTreeWidgetItem *item, int column)
 	item->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEnabled | Qt::ItemIsEditable);
 	editItem(item, 0);
 	item->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEnabled);
-	connect(this, SIGNAL(itemChanged(QTreeWidgetItem *, int)), SLOT(renameOK(QTreeWidgetItem *, int)));
+	connect(this, &FieldList::itemChanged, this, &FieldList::renameOK);
 }
 
 void FieldList::renameOK(QTreeWidgetItem *item, int column)
@@ -204,7 +204,7 @@ void FieldList::renameOK(QTreeWidgetItem *item, int column)
 		return;
 	}
 
-	disconnect(this, SIGNAL(itemChanged(QTreeWidgetItem *, int)), this, SLOT(renameOK(QTreeWidgetItem *, int)));
+	disconnect(this, &FieldList::itemChanged, this, &FieldList::renameOK);
 	QString newName = item->text(1).left(8);
 
 	if (newName.isEmpty()) {

--- a/src/widgets/FontManager.cpp
+++ b/src/widgets/FontManager.cpp
@@ -41,7 +41,7 @@ FontManager::FontManager(QWidget *parent) :
 	//fillList1();
 	//setFont(list1->currentRow());
 
-	//connect(list1, SIGNAL(currentRowChanged(int)), SLOT(setFont(int)));
+	//connect(list1, &QListWidget::currentRowChanged, this &FontManager::setFont);
 }
 
 void FontManager::fillList1()
@@ -119,7 +119,7 @@ bool FontManager::newNameDialog(QString &name, QString &nameId)
 	layout->addLayout(formLayout, 1);
 	layout->addWidget(ok, 0, Qt::AlignCenter);
 
-	connect(ok, SIGNAL(clicked()), &dialog, SLOT(accept()));
+	connect(ok, &QPushButton::clicked, &dialog, &QDialog::accept);
 
 	if (dialog.exec() == QDialog::Accepted) {
 		QString name1 = nameEdit->text();

--- a/src/widgets/FontWidget.cpp
+++ b/src/widgets/FontWidget.cpp
@@ -74,20 +74,20 @@ FontWidget::FontWidget(QWidget *parent) :
 	layout->setRowStretch(5, 1);
 	layout->setContentsMargins(QMargins());
 
-	connect(selectPal, SIGNAL(currentIndexChanged(int)), SLOT(setColor(int)));
-	connect(selectTable, SIGNAL(currentIndexChanged(int)), SLOT(setTable(int)));
-	connect(fontGrid, SIGNAL(letterClicked(int)), SLOT(setLetter(int)));
-	connect(fontLetter, SIGNAL(imageChanged(QRect)), fontGrid, SLOT(updateLetter(QRect)));
-	connect(fontLetter, SIGNAL(imageChanged(QRect)), SLOT(setModified()));
-//	connect(resetButton1, SIGNAL(clicked()), SLOT(reset()));
-	connect(exportButton, SIGNAL(clicked()), SLOT(exportFont()));
-	connect(importButton, SIGNAL(clicked()), SLOT(importFont()));
-	connect(resetButton2, SIGNAL(clicked()), SLOT(resetLetter()));
-	connect(fontPalette, SIGNAL(colorChanged(int)), fontLetter, SLOT(setPixelIndex(int)));
-	connect(textLetter, SIGNAL(textEdited(QString)), SLOT(editLetter(QString)));
-	connect(widthLetter, SIGNAL(valueChanged(int)), SLOT(editWidth(int)));
-	connect(fontLetter, SIGNAL(widthEdited(int)), widthLetter, SLOT(setValue(int)));
-	connect(leftPaddingLetter, SIGNAL(valueChanged(int)), SLOT(editLeftPadding(int)));
+	connect(selectPal, &QComboBox::currentIndexChanged, this, &FontWidget::setColor);
+	connect(selectTable, &QComboBox::currentIndexChanged, this, &FontWidget::setTable);
+	connect(fontGrid, &FontGrid::letterClicked, this, &FontWidget::setLetter);
+	connect(fontLetter, &FontLetter::imageChanged, fontGrid, &FontGrid::updateLetter);
+	connect(fontLetter, &FontLetter::imageChanged, this, &FontWidget::setModified);
+//	connect(resetButton1, &QPushButton::clicked, this, &FontWidget::reset);
+	connect(exportButton, &QPushButton::clicked, this, &FontWidget::exportFont);
+	connect(importButton, &QPushButton::clicked, this, &FontWidget::importFont);
+	connect(resetButton2, &QPushButton::clicked, this, &FontWidget::resetLetter);
+	connect(fontPalette, &FontPalette::colorChanged, fontLetter, &FontLetter::setPixelIndex);
+	connect(textLetter, &QLineEdit::textEdited, this, &FontWidget::editLetter);
+	connect(widthLetter, &QSpinBox::valueChanged, this, &FontWidget::editWidth);
+	connect(fontLetter, &FontLetter::widthEdited, widthLetter, &QSpinBox::setValue);
+	connect(leftPaddingLetter, &QSpinBox::valueChanged, this, &FontWidget::editLeftPadding);
 }
 
 void FontWidget::clear()

--- a/src/widgets/GrpScriptList.cpp
+++ b/src/widgets/GrpScriptList.cpp
@@ -65,18 +65,18 @@ GrpScriptList::GrpScriptList(QWidget *parent) :
 	down_A->setShortcutContext(Qt::WidgetWithChildrenShortcut);
 	down_A->setEnabled(false);
 
-	connect(this, SIGNAL(itemDoubleClicked(QTreeWidgetItem*,int)), SLOT(rename(QTreeWidgetItem*,int)));
-	connect(this, SIGNAL(currentItemChanged(QTreeWidgetItem*,QTreeWidgetItem*)), SLOT(evidence(QTreeWidgetItem*,QTreeWidgetItem*)));
-	connect(this, SIGNAL(itemSelectionChanged()), SLOT(upDownEnabled()));
+	connect(this, &GrpScriptList::itemDoubleClicked, this, qOverload<QTreeWidgetItem *, int>(&GrpScriptList::rename));
+	connect(this, &GrpScriptList::currentItemChanged, this, &GrpScriptList::evidence);
+	connect(this, &GrpScriptList::itemSelectionChanged, this, &GrpScriptList::upDownEnabled);
 
-	connect(rename_A, SIGNAL(triggered()), SLOT(rename()));
-	connect(add_A, SIGNAL(triggered()), SLOT(add()));
-	connect(del_A, SIGNAL(triggered()), SLOT(del()));
-	connect(cut_A, SIGNAL(triggered()), SLOT(cut()));
-	connect(copy_A, SIGNAL(triggered()), SLOT(copy()));
-	connect(paste_A, SIGNAL(triggered()), SLOT(paste()));
-	connect(up_A, SIGNAL(triggered()), SLOT(up()));
-	connect(down_A, SIGNAL(triggered()), SLOT(down()));
+	connect(rename_A, &QAction::triggered, this, qOverload<>(&GrpScriptList::rename));
+	connect(add_A, &QAction::triggered, this, &GrpScriptList::add);
+	connect(del_A, &QAction::triggered, this, &GrpScriptList::del);
+	connect(cut_A, &QAction::triggered, this, &GrpScriptList::cut);
+	connect(copy_A, &QAction::triggered, this, &GrpScriptList::copy);
+	connect(paste_A, &QAction::triggered, this, &GrpScriptList::paste);
+	connect(up_A, &QAction::triggered, this, &GrpScriptList::up);
+	connect(down_A, &QAction::triggered, this, &GrpScriptList::down);
 
 	this->addAction(rename_A);
 	this->addAction(add_A);
@@ -273,7 +273,7 @@ void GrpScriptList::rename(QTreeWidgetItem *item, int column)
 	item->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEnabled | Qt::ItemIsEditable);
 	editItem(item, 1);
 	item->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEnabled);
-	connect(this, SIGNAL(itemChanged(QTreeWidgetItem*,int)), SLOT(renameOK(QTreeWidgetItem*,int)));
+	connect(this, &GrpScriptList::itemChanged, this, &GrpScriptList::renameOK);
 }
 
 void GrpScriptList::renameOK(QTreeWidgetItem *item, int column)
@@ -281,7 +281,7 @@ void GrpScriptList::renameOK(QTreeWidgetItem *item, int column)
 	if (column != 1) {
 		return;
 	}
-	disconnect(this, SIGNAL(itemChanged(QTreeWidgetItem *, int)), this, SLOT(renameOK(QTreeWidgetItem *, int)));
+	disconnect(this, &GrpScriptList::itemChanged, this, &GrpScriptList::renameOK);
 	QString newName = item->text(1).left(8);
 	item->setText(1, newName);
 	scripts->grpScript(selectedID()).setName(newName);

--- a/src/widgets/GrpScriptList.cpp
+++ b/src/widgets/GrpScriptList.cpp
@@ -376,7 +376,7 @@ void GrpScriptList::paste()
 		grpScriptID = topLevelItemCount(); // Last position
 	}
 	int i = grpScriptID;
-	for (const GrpScript &GScopied : grpScriptCopied) {
+	for (const GrpScript &GScopied : qAsConst(grpScriptCopied)) {
 		scripts->insertGrpScript(i++, GScopied);
 	}
 

--- a/src/widgets/GrpScriptWizard.cpp
+++ b/src/widgets/GrpScriptWizard.cpp
@@ -78,8 +78,8 @@ GrpScriptWizardPageType::GrpScriptWizardPageType(QWidget *parent) :
 	layout->addWidget(_type, 0, 0);
 	layout->addWidget(_subType, 0, 1);
 
-	connect(_type, SIGNAL(currentRowChanged(int)), SLOT(fillSubTypeList(int)));
-	connect(_subType, SIGNAL(currentRowChanged(int)), SLOT(updateButtons()));
+	connect(_type, &QListWidget::currentRowChanged, this, &GrpScriptWizardPageType::fillSubTypeList);
+	connect(_subType, &QListWidget::currentRowChanged, this, &GrpScriptWizardPageType::updateButtons);
 
 	registerField(FIELD_TYPE"*", _type);
 	registerField(FIELD_SUB_TYPE"*", _subType);

--- a/src/widgets/HexLineEdit.cpp
+++ b/src/widgets/HexLineEdit.cpp
@@ -20,7 +20,7 @@
 HexLineEdit::HexLineEdit(QWidget *parent) :
 	QLineEdit(parent), _noEmit(false)
 {
-	connect(this, SIGNAL(textEdited(QString)), SLOT(emitDataEdited()));
+	connect(this, &HexLineEdit::textEdited, this, &HexLineEdit::emitDataEdited);
 }
 
 HexLineEdit::HexLineEdit(const QByteArray &contents, QWidget *parent) :

--- a/src/widgets/ImportDialog.cpp
+++ b/src/widgets/ImportDialog.cpp
@@ -111,12 +111,12 @@ ImportDialog::ImportDialog(bool sourceSameTypeAsTarget, bool isDat, const QStrin
 	layout->addWidget(buttonBox);
 	layout->addStretch();
 
-	connect(buttonBox, SIGNAL(accepted()), SLOT(accept()));
-	connect(buttonBox, SIGNAL(rejected()), SLOT(reject()));
-	connect(changePathButtonMim, SIGNAL(clicked()), SLOT(setMimPathByUser()));
-	connect(changePathButtonBsx, SIGNAL(clicked()), SLOT(setBsxPathByUser()));
-	connect(mim, SIGNAL(toggled(bool)), pathWidgetMim, SLOT(setEnabled(bool)));
-	connect(model, SIGNAL(toggled(bool)), pathWidgetBsx, SLOT(setEnabled(bool)));
+	connect(buttonBox, &QDialogButtonBox::accepted, this, &ImportDialog::accept);
+	connect(buttonBox, &QDialogButtonBox::rejected, this, &ImportDialog::reject);
+	connect(changePathButtonMim, &QPushButton::clicked, this, &ImportDialog::setMimPathByUser);
+	connect(changePathButtonBsx, &QPushButton::clicked, this, &ImportDialog::setBsxPathByUser);
+	connect(mim, &QCheckBox::toggled, pathWidgetMim, &QWidget::setEnabled);
+	connect(model, &QCheckBox::toggled, pathWidgetBsx, &QWidget::setEnabled);
 }
 
 Field::FieldSections ImportDialog::parts() const

--- a/src/widgets/KeyEditorDialog.cpp
+++ b/src/widgets/KeyEditorDialog.cpp
@@ -32,8 +32,8 @@ KeyEditorDialog::KeyEditorDialog(quint16 value, QWidget *parent)
 	}
 	layout->addWidget(buttonBox);
 	
-	connect(buttonBox, SIGNAL(accepted()), SLOT(accept()));
-	connect(buttonBox, SIGNAL(rejected()), SLOT(reject()));
+	connect(buttonBox, &QDialogButtonBox::accepted, this, &KeyEditorDialog::accept);
+	connect(buttonBox, &QDialogButtonBox::rejected, this, &KeyEditorDialog::reject);
 }
 
 int KeyEditorDialog::keys() const

--- a/src/widgets/LgpWidget.cpp
+++ b/src/widgets/LgpWidget.cpp
@@ -716,12 +716,12 @@ LgpWidget::LgpWidget(Lgp *lgp, QWidget *parent) :
 	layout->addWidget(treeView, 1, 0);
 	layout->addWidget(preview, 1, 1);
 
-	connect(renameButton, &QPushButton::released, this, &LgpWidget::renameCurrent);
-	connect(replaceButton, &QPushButton::released, this, &LgpWidget::replaceCurrent);
-	connect(extractButton, &QPushButton::released, this, &LgpWidget::extractCurrent);
-	connect(extractAllButton, &QPushButton::released, this, &LgpWidget::extractAll);
-	connect(addButton, &QPushButton::released, this, &LgpWidget::add);
-	connect(removeButton, &QPushButton::released, this, &LgpWidget::removeCurrent);
+	connect(renameButton, &QPushButton::clicked, this, &LgpWidget::renameCurrent);
+	connect(replaceButton, &QPushButton::clicked, this, &LgpWidget::replaceCurrent);
+	connect(extractButton, &QPushButton::clicked, this, &LgpWidget::extractCurrent);
+	connect(extractAllButton, &QPushButton::clicked, this, &LgpWidget::extractAll);
+	connect(addButton, &QPushButton::clicked, this, &LgpWidget::add);
+	connect(removeButton, &QPushButton::clicked, this, &LgpWidget::removeCurrent);
 	connect(treeView->selectionModel(), &QItemSelectionModel::selectionChanged, this, &LgpWidget::setButtonsState);
 	connect(treeView->selectionModel(), &QItemSelectionModel::selectionChanged, this, &LgpWidget::changePreview);
 	connect(preview, &ArchivePreview::currentImageChanged, this, &LgpWidget::changeImageInPreview);

--- a/src/widgets/LgpWidget.cpp
+++ b/src/widgets/LgpWidget.cpp
@@ -394,7 +394,7 @@ LgpItemModel::LgpItemModel(Lgp *lgp, QObject *parent) :
 	}
 //	root->debug();
 
-//	connect(&iconThread, SIGNAL(iconLoaded(QString,QIcon)), SLOT(setIcon(QString,QIcon)));
+//	connect(&iconThread, &IconThread::iconLoaded, this, &LgpItemModel::setIcon);
 
 	QFileIconProvider iconProvider;
 	fileIcon = iconProvider.icon(QFileIconProvider::File);
@@ -716,16 +716,16 @@ LgpWidget::LgpWidget(Lgp *lgp, QWidget *parent) :
 	layout->addWidget(treeView, 1, 0);
 	layout->addWidget(preview, 1, 1);
 
-	connect(renameButton, SIGNAL(released()), SLOT(renameCurrent()));
-	connect(replaceButton, SIGNAL(released()), SLOT(replaceCurrent()));
-	connect(extractButton, SIGNAL(released()), SLOT(extractCurrent()));
-	connect(extractAllButton, SIGNAL(released()), SLOT(extractAll()));
-	connect(addButton, SIGNAL(released()), SLOT(add()));
-	connect(removeButton, SIGNAL(released()), SLOT(removeCurrent()));
-	connect(treeView->selectionModel(), SIGNAL(selectionChanged(QItemSelection,QItemSelection)), SLOT(setButtonsState()));
-	connect(treeView->selectionModel(), SIGNAL(selectionChanged(QItemSelection,QItemSelection)), SLOT(changePreview()));
-	connect(preview, SIGNAL(currentImageChanged(int)), SLOT(changeImageInPreview(int)));
-	connect(preview, SIGNAL(currentPaletteChanged(int)), SLOT(changeImagePaletteInPreview(int)));
+	connect(renameButton, &QPushButton::released, this, &LgpWidget::renameCurrent);
+	connect(replaceButton, &QPushButton::released, this, &LgpWidget::replaceCurrent);
+	connect(extractButton, &QPushButton::released, this, &LgpWidget::extractCurrent);
+	connect(extractAllButton, &QPushButton::released, this, &LgpWidget::extractAll);
+	connect(addButton, &QPushButton::released, this, &LgpWidget::add);
+	connect(removeButton, &QPushButton::released, this, &LgpWidget::removeCurrent);
+	connect(treeView->selectionModel(), &QItemSelectionModel::selectionChanged, this, &LgpWidget::setButtonsState);
+	connect(treeView->selectionModel(), &QItemSelectionModel::selectionChanged, this, &LgpWidget::changePreview);
+	connect(preview, &ArchivePreview::currentImageChanged, this, &LgpWidget::changeImageInPreview);
+	connect(preview, &ArchivePreview::currentPaletteChanged, this, &LgpWidget::changeImagePaletteInPreview);
 
 	setButtonsState();
 }

--- a/src/widgets/LgpWidget.cpp
+++ b/src/widgets/LgpWidget.cpp
@@ -387,8 +387,9 @@ void LgpDirectoryItem::debug() const
 LgpItemModel::LgpItemModel(Lgp *lgp, QObject *parent) :
 	QAbstractItemModel(parent), _lgp(lgp)/*, iconThread(this)*/
 {
-	root = new LgpDirectoryItem("");
-	for (const QString &path : lgp->fileList()) {
+	root = new LgpDirectoryItem(QString());
+	auto const fileList = lgp->fileList();
+	for (const QString &path : fileList) {
 		root->addChild(path, lgp);
 //		iconThread.addFile(path);
 	}
@@ -965,7 +966,8 @@ void LgpWidget::extractAll()
 	setObserverMaximum(static_cast<unsigned int>(lgp->fileCount()));
 	int i = 0;
 
-	for (const QString &fileName : lgp->fileList()) {
+	const auto fileList = lgp->fileList();
+	for (const QString &fileName : fileList) {
 		if (observerWasCanceled()) {
 			break;
 		}

--- a/src/widgets/MassExportDialog.cpp
+++ b/src/widgets/MassExportDialog.cpp
@@ -29,9 +29,9 @@ MassExportDialog::MassExportDialog(QWidget *parent) :
 	fieldList->setSelectionMode(QAbstractItemView::MultiSelection);
 
 	QToolBar *toolBar = new QToolBar(this);
-	toolBar->addAction(tr("Current"), this, SLOT(selectCurrentField()));
-	toolBar->addAction(tr("+"), fieldList, SLOT(selectAll()));
-	toolBar->addAction(tr("-"), fieldList, SLOT(clearSelection()));
+	toolBar->addAction(tr("Current"), this, &MassExportDialog::selectCurrentField);
+	toolBar->addAction(tr("+"), fieldList, &QListWidget::selectAll);
+	toolBar->addAction(tr("-"), fieldList, &QListWidget::clearSelection);
 
 	QVBoxLayout *listLayout = new QVBoxLayout;
 	listLayout->addWidget(toolBar);
@@ -87,9 +87,9 @@ MassExportDialog::MassExportDialog(QWidget *parent) :
 	layout->addWidget(buttonBox, row + 4, 0, 1, 3);
 	layout->setRowStretch(row + 3, 1);
 
-	connect(changeDir, SIGNAL(clicked()),  SLOT(chooseExportDirectory()));
-	connect(buttonBox, SIGNAL(accepted()), SLOT(accept()));
-	connect(buttonBox, SIGNAL(rejected()), SLOT(reject()));
+	connect(changeDir, &QPushButton::clicked, this, &MassExportDialog::chooseExportDirectory);
+	connect(buttonBox, &QDialogButtonBox::accepted, this, &MassExportDialog::accept);
+	connect(buttonBox, &QDialogButtonBox::rejected, this, &MassExportDialog::reject);
 
 	fieldList->setFocus();
 }

--- a/src/widgets/MassImportDialog.cpp
+++ b/src/widgets/MassImportDialog.cpp
@@ -46,9 +46,9 @@ MassImportDialog::MassImportDialog(QWidget *parent) :
 	fieldList->setSelectionMode(QAbstractItemView::MultiSelection);
 
 	QToolBar *toolBar = new QToolBar(this);
-	toolBar->addAction(tr("Current"), this, SLOT(selectCurrentField()));
-	toolBar->addAction(tr("+"), fieldList, SLOT(selectAll()));
-	toolBar->addAction(tr("-"), fieldList, SLOT(clearSelection()));
+	toolBar->addAction(tr("Current"), this, &MassImportDialog::selectCurrentField);
+	toolBar->addAction(tr("+"), fieldList, &QListWidget::selectAll);
+	toolBar->addAction(tr("-"), fieldList, &QListWidget::clearSelection);
 
 	QVBoxLayout *listLayout = new QVBoxLayout;
 	listLayout->addWidget(toolBar);
@@ -70,9 +70,9 @@ MassImportDialog::MassImportDialog(QWidget *parent) :
 	layout->addWidget(buttonBox, row + 3, 0, 1, 3);
 	layout->setRowStretch(row + 2, 1);
 
-	connect(changeDir, SIGNAL(clicked()),  SLOT(chooseImportDirectory()));
-	connect(buttonBox, SIGNAL(accepted()), SLOT(accept()));
-	connect(buttonBox, SIGNAL(rejected()), SLOT(reject()));
+	connect(changeDir, &QPushButton::clicked, this, &MassImportDialog::chooseImportDirectory);
+	connect(buttonBox, &QDialogButtonBox::accepted, this, &MassImportDialog::accept);
+	connect(buttonBox, &QDialogButtonBox::rejected, this, &MassImportDialog::reject);
 
 	fieldList->setFocus();
 }

--- a/src/widgets/MiscWidget.cpp
+++ b/src/widgets/MiscWidget.cpp
@@ -37,8 +37,8 @@ MiscWidget::MiscWidget(InfFile *data, Field *field, QWidget *parent) :
 	layout->addWidget(mapAuthor, 1, 1);
 	layout->addWidget(buttonBox, 3, 0, 1, 2);
 
-	connect(buttonBox, SIGNAL(accepted()), SLOT(accept()));
-	connect(buttonBox, SIGNAL(rejected()), SLOT(reject()));
+	connect(buttonBox, &QDialogButtonBox::accepted, this, &MiscWidget::accept);
+	connect(buttonBox, &QDialogButtonBox::rejected, this, &MiscWidget::reject);
 
 	fill();
 }

--- a/src/widgets/ModelColorsLayout.cpp
+++ b/src/widgets/ModelColorsLayout.cpp
@@ -26,14 +26,14 @@ ModelColorWidget::ModelColorWidget(QWidget *parent) :
 	for (quint8 i = 0; i < 3; ++i) {
 		_dirWidget[i] = new QSpinBox(parent);
 		_dirWidget[i]->setRange(-32768, 32767);
-		connect(_dirWidget[i], SIGNAL(editingFinished()), SLOT(relayEdition()));
+		connect(_dirWidget[i], &QSpinBox::editingFinished, this, &ModelColorWidget::relayEdition);
 	}
 
 	_dirWidget[0]->adjustSize();
 	_colorWidget->setMinimumWidth(_dirWidget[0]->height());
 	_colorWidget->setMinimumHeight(_dirWidget[0]->height());
 
-	connect(_colorWidget, SIGNAL(colorEdited(int,QRgb)), SLOT(relayEdition()));
+	connect(_colorWidget, &ColorDisplay::colorEdited, this, &ModelColorWidget::relayEdition);
 }
 
 void ModelColorWidget::relayEdition()
@@ -77,12 +77,9 @@ ModelColorsLayout::ModelColorsLayout(QWidget *parent) :
 		addWidget(modelColorWidget[i]->dirWidget(2), i + 1, 3);
 	}
 
-	connect(modelColorWidget[0], SIGNAL(colorDirEdited(FieldModelColorDir)),
-	        SLOT(relayColorDirEdited0(FieldModelColorDir)));
-	connect(modelColorWidget[1], SIGNAL(colorDirEdited(FieldModelColorDir)),
-	        SLOT(relayColorDirEdited1(FieldModelColorDir)));
-	connect(modelColorWidget[2], SIGNAL(colorDirEdited(FieldModelColorDir)),
-	        SLOT(relayColorDirEdited2(FieldModelColorDir)));
+	connect(modelColorWidget[0], &ModelColorWidget::colorDirEdited, this, &ModelColorsLayout::relayColorDirEdited0);
+	connect(modelColorWidget[1], &ModelColorWidget::colorDirEdited, this, &ModelColorsLayout::relayColorDirEdited1);
+	connect(modelColorWidget[2], &ModelColorWidget::colorDirEdited, this, &ModelColorsLayout::relayColorDirEdited2);
 }
 
 void ModelColorsLayout::setModelColorDirs(const QList<FieldModelColorDir> &dirs)

--- a/src/widgets/ModelManager.cpp
+++ b/src/widgets/ModelManager.cpp
@@ -63,12 +63,12 @@ ModelManager::ModelManager(QWidget *parent) :
 		modelWidget = new QWidget(this);
 	}
 
-	connect(models, SIGNAL(currentItemChanged(QTreeWidgetItem*,QTreeWidgetItem*)), SLOT(showModelInfos(QTreeWidgetItem*,QTreeWidgetItem*)));
-	connect(modelAnims, SIGNAL(currentItemChanged(QTreeWidgetItem*,QTreeWidgetItem*)), SLOT(showModel(QTreeWidgetItem*)));
-	connect(modelUnknown, SIGNAL(valueChanged(int)), SLOT(setModelUnknown(int)));
-	connect(modelScaleWidget, SIGNAL(valueChanged(int)), SLOT(setModelScale(int)));
-	connect(modelGlobalColorWidget, SIGNAL(colorEdited(int,QRgb)), SLOT(setModelGlobalColor(int,QRgb)));
-	connect(modelColorsLayout, SIGNAL(colorDirEdited(int,FieldModelColorDir)), SLOT(setModelColor(int,FieldModelColorDir)));
+	connect(models, &QTreeWidget::currentItemChanged, this, qOverload<QTreeWidgetItem *, QTreeWidgetItem *>(&ModelManager::showModelInfos));
+	connect(modelAnims, &QTreeWidget::currentItemChanged, this, &ModelManager::showModel);
+	connect(modelUnknown, &QSpinBox::valueChanged, this, &ModelManager::setModelUnknown);
+	connect(modelScaleWidget, &QSpinBox::valueChanged, this, qOverload<int>(&ModelManager::setModelScale));
+	connect(modelGlobalColorWidget, &ColorDisplay::colorEdited, this, &ModelManager::setModelGlobalColor);
+	connect(modelColorsLayout, &ModelColorsLayout::colorDirEdited, this, &ModelManager::setModelColor);
 }
 
 void ModelManager::clear()

--- a/src/widgets/ModelManagerPC.cpp
+++ b/src/widgets/ModelManagerPC.cpp
@@ -161,7 +161,7 @@ void ModelManagerPC::addModel()
 		layout.addWidget(&OKButton);
 
 		connect(&list, &QComboBox::currentTextChanged, this, &ModelManagerPC::modifyHRC);
-		connect(&OKButton, &QPushButton::released, &dialog, &QDialog::accept);
+		connect(&OKButton, &QPushButton::clicked, &dialog, &QDialog::accept);
 
 		if (dialog.exec() == QDialog::Accepted) {
 			hrc = list.currentText().left(8).toUpper();
@@ -389,7 +389,7 @@ void ModelManagerPC::addAnim()
 		layout.addWidget(&OKButton);
 
 		connect(&list, &QComboBox::currentTextChanged, this, &ModelManagerPC::modifyAnimation);
-		connect(&OKButton, &QPushButton::released, &dialog, &QDialog::accept);
+		connect(&OKButton, &QPushButton::clicked, &dialog, &QDialog::accept);
 		toolBar2->setEnabled(true);
 
 		if (dialog.exec() == QDialog::Accepted) {

--- a/src/widgets/ModelManagerPC.cpp
+++ b/src/widgets/ModelManagerPC.cpp
@@ -30,10 +30,10 @@ ModelManagerPC::ModelManagerPC(QWidget *parent) :
 	
 	QToolBar *toolBar1 = new QToolBar();
 	toolBar1->setIconSize(QSize(int(scale * 14), int(scale * 14)));
-	toolBar1->addAction(QIcon(":/images/plus.png"), QString(), this, SLOT(addModel()));
-	toolBar1->addAction(QIcon(":/images/minus.png"), QString(), this, SLOT(delModel()));
-	toolBar1->addAction(QIcon(":/images/up.png"), QString(), this, SLOT(upModel()));
-	toolBar1->addAction(QIcon(":/images/down.png"), QString(), this, SLOT(downModel()));
+	toolBar1->addAction(QIcon(":/images/plus.png"), QString(), this, &ModelManagerPC::addModel);
+	toolBar1->addAction(QIcon(":/images/minus.png"), QString(), this, &ModelManagerPC::delModel);
+	toolBar1->addAction(QIcon(":/images/up.png"), QString(), this, &ModelManagerPC::upModel);
+	toolBar1->addAction(QIcon(":/images/down.png"), QString(), this, &ModelManagerPC::downModel);
 
 	models->setContextMenuPolicy(Qt::ActionsContextMenu);
 	models->setSelectionMode(QAbstractItemView::ExtendedSelection);
@@ -52,10 +52,10 @@ ModelManagerPC::ModelManagerPC(QWidget *parent) :
 
 	toolBar2 = new QToolBar();
 	toolBar2->setIconSize(QSize(int(scale * 14), int(scale * 14)));
-	toolBar2->addAction(QIcon(":/images/plus.png"), QString(), this, SLOT(addAnim()));
-	toolBar2->addAction(QIcon(":/images/minus.png"), QString(), this, SLOT(delAnim()));
-	toolBar2->addAction(QIcon(":/images/up.png"), QString(), this, SLOT(upAnim()));
-	toolBar2->addAction(QIcon(":/images/down.png"), QString(), this, SLOT(downAnim()));
+	toolBar2->addAction(QIcon(":/images/plus.png"), QString(), this, &ModelManagerPC::addAnim);
+	toolBar2->addAction(QIcon(":/images/minus.png"), QString(), this, &ModelManagerPC::delAnim);
+	toolBar2->addAction(QIcon(":/images/up.png"), QString(), this, &ModelManagerPC::upAnim);
+	toolBar2->addAction(QIcon(":/images/down.png"), QString(), this, &ModelManagerPC::downAnim);
 
 	modelAnims->setColumnCount(3);
 	modelAnims->setHeaderLabels(QStringList() << tr("Id") << tr("Animation") << tr("?"));
@@ -84,18 +84,18 @@ ModelManagerPC::ModelManagerPC(QWidget *parent) :
 
 	adjustSize();
 
-	connect(models, SIGNAL(doubleClicked(QModelIndex)), models, SLOT(edit(QModelIndex)));
-	connect(models, SIGNAL(itemChanged(QTreeWidgetItem*,int)), SLOT(renameOKModel(QTreeWidgetItem*)));
+	connect(models, &QTreeWidget::doubleClicked, models, qOverload<const QModelIndex &>(&QTreeWidget::edit));
+	connect(models, &QTreeWidget::itemChanged, this, &ModelManagerPC::renameOKModel);
 
-	connect(modelAnims, SIGNAL(itemDoubleClicked(QTreeWidgetItem*,int)), SLOT(editAnim(QTreeWidgetItem*,int)));
-	connect(modelAnims, SIGNAL(itemChanged(QTreeWidgetItem*,int)), SLOT(renameOKAnim(QTreeWidgetItem*,int)));
+	connect(modelAnims, &QTreeWidget::itemDoubleClicked, this, &ModelManagerPC::editAnim);
+	connect(modelAnims, &QTreeWidget::itemChanged, this, &ModelManagerPC::renameOKAnim);
 
-	connect(modelName, SIGNAL(textEdited(QString)), SLOT(setModelName(QString)));
+	connect(modelName, &QLineEdit::textEdited, this, &ModelManagerPC::setModelName);
 
-	connect(cutModelAction, SIGNAL(triggered()), SLOT(cutCurrentModel()));
-	connect(copyModelAction, SIGNAL(triggered()), SLOT(copyCurrentModel()));
-	connect(pasteModelAction, SIGNAL(triggered()), SLOT(pasteOnCurrentModel()));
-	connect(modelAnims, SIGNAL(currentItemChanged(QTreeWidgetItem*,QTreeWidgetItem*)), SLOT(updateActionsState()));
+	connect(cutModelAction, &QAction::triggered, this, &ModelManagerPC::cutCurrentModel);
+	connect(copyModelAction, &QAction::triggered, this, &ModelManagerPC::copyCurrentModel);
+	connect(pasteModelAction, &QAction::triggered, this, &ModelManagerPC::pasteOnCurrentModel);
+	connect(modelAnims, &QTreeWidget::currentItemChanged, this, &ModelManagerPC::updateActionsState);
 }
 
 QList<QStringList> ModelManagerPC::modelNames() const
@@ -160,8 +160,8 @@ void ModelManagerPC::addModel()
 		layout.addWidget(&list);
 		layout.addWidget(&OKButton);
 
-		connect(&list, SIGNAL(currentIndexChanged(QString)), SLOT(modifyHRC(QString)));
-		connect(&OKButton, SIGNAL(released()), &dialog, SLOT(accept()));
+		connect(&list, &QComboBox::currentTextChanged, this, &ModelManagerPC::modifyHRC);
+		connect(&OKButton, &QPushButton::released, &dialog, &QDialog::accept);
 
 		if (dialog.exec() == QDialog::Accepted) {
 			hrc = list.currentText().left(8).toUpper();
@@ -358,7 +358,7 @@ void ModelManagerPC::addAnim()
 		list.setSizeAdjustPolicy(QComboBox::AdjustToMinimumContentsLengthWithIcon);
 
 		QTimer t(this);
-		connect(&t, SIGNAL(timeout()), SLOT(processEvents()));
+		connect(&t, &QTimer::timeout, this, &ModelManagerPC::processEvents);
 		t.start(700);
 
 		int boneCount = modelPreview ? modelPreview->boneCount() : 0;
@@ -388,8 +388,8 @@ void ModelManagerPC::addAnim()
 		layout.addWidget(&list);
 		layout.addWidget(&OKButton);
 
-		connect(&list, SIGNAL(currentIndexChanged(QString)), SLOT(modifyAnimation(QString)));
-		connect(&OKButton, SIGNAL(released()), &dialog, SLOT(accept()));
+		connect(&list, &QComboBox::currentTextChanged, this, &ModelManagerPC::modifyAnimation);
+		connect(&OKButton, &QPushButton::released, &dialog, &QDialog::accept);
 		toolBar2->setEnabled(true);
 
 		if (dialog.exec() == QDialog::Accepted) {

--- a/src/widgets/OpcodeList.cpp
+++ b/src/widgets/OpcodeList.cpp
@@ -92,22 +92,22 @@ OpcodeList::OpcodeList(QWidget *parent) :
 	disableTree_A = new QAction(tr("Disable tree"), this);
 	search_A = new QAction(tr("Search opcode..."), this);
 
-	connect(edit_A, SIGNAL(triggered()), SLOT(scriptEditor()));
-	connect(add_A, SIGNAL(triggered()), SLOT(add()));
-	connect(del_A, SIGNAL(triggered()), SLOT(del()));
-	connect(cut_A, SIGNAL(triggered()), SLOT(cut()));
-	connect(copy_A, SIGNAL(triggered()), SLOT(copy()));
-	connect(copyText_A, SIGNAL(triggered()), SLOT(copyText()));
-	connect(paste_A, SIGNAL(triggered()), SLOT(paste()));
-	connect(up_A, SIGNAL(triggered()), SLOT(up()));
-	connect(down_A, SIGNAL(triggered()), SLOT(down()));
-	connect(expand_A, SIGNAL(triggered()), SLOT(expandAll()));
-	connect(text_A, SIGNAL(triggered()), SLOT(editText()));
-	connect(undo_A, SIGNAL(triggered()), SLOT(undo()));
-	connect(redo_A, SIGNAL(triggered()), SLOT(redo()));
-	connect(goto_A, SIGNAL(triggered()), SLOT(gotoLabel()));
-	connect(disableTree_A, SIGNAL(triggered()), SLOT(toggleTree()));
-	connect(search_A, SIGNAL(triggered()), SLOT(searchOpcode()));
+	connect(edit_A, &QAction::triggered, this, &OpcodeList::scriptEditor);
+	connect(add_A, &QAction::triggered, this, &OpcodeList::add);
+	connect(del_A, &QAction::triggered, this, &OpcodeList::del);
+	connect(cut_A, &QAction::triggered, this, &OpcodeList::cut);
+	connect(copy_A, &QAction::triggered, this, &OpcodeList::copy);
+	connect(copyText_A, &QAction::triggered, this, &OpcodeList::copyText);
+	connect(paste_A, &QAction::triggered, this, &OpcodeList::paste);
+	connect(up_A, &QAction::triggered, this, &OpcodeList::up);
+	connect(down_A, &QAction::triggered, this, &OpcodeList::down);
+	connect(expand_A, &QAction::triggered, this, &OpcodeList::expandAll);
+	connect(text_A, &QAction::triggered, this, qOverload<>(&OpcodeList::editText));
+	connect(undo_A, &QAction::triggered, this, &OpcodeList::undo);
+	connect(redo_A, &QAction::triggered, this, &OpcodeList::redo);
+	connect(goto_A, &QAction::triggered, this, [&] {gotoLabel(nullptr);} );
+	connect(disableTree_A, &QAction::triggered, this, &OpcodeList::toggleTree);
+	connect(search_A, &QAction::triggered, this, qOverload<>(&OpcodeList::searchOpcode));
 
 	addAction(edit_A);
 	addAction(add_A);
@@ -173,10 +173,10 @@ OpcodeList::OpcodeList(QWidget *parent) :
 	setMinimumWidth(_toolBar->sizeHint().width());
 	setMinimumHeight(_toolBar->sizeHint().width());
 
-	connect(this, SIGNAL(itemDoubleClicked(QTreeWidgetItem*,int)), SLOT(scriptEditor()));
-	connect(this, SIGNAL(itemSelectionChanged()), SLOT(itemSelected()));
-	connect(this, SIGNAL(currentItemChanged(QTreeWidgetItem*,QTreeWidgetItem*)), SLOT(evidence(QTreeWidgetItem*,QTreeWidgetItem*)));
-	connect(QApplication::clipboard(), SIGNAL(changed(QClipboard::Mode)), SLOT(adjustPasteAction()));
+	connect(this, &OpcodeList::itemDoubleClicked, this, &OpcodeList::scriptEditor);
+	connect(this, &OpcodeList::itemSelectionChanged, this, &OpcodeList::itemSelected);
+	connect(this, &OpcodeList::currentItemChanged, this, &OpcodeList::evidence);
+	connect(QApplication::clipboard(), &QClipboard::changed, this, &OpcodeList::adjustPasteAction);
 }
 
 void OpcodeList::adjustPasteAction()

--- a/src/widgets/OperationsManager.cpp
+++ b/src/widgets/OperationsManager.cpp
@@ -44,11 +44,11 @@ OperationsManager::OperationsManager(bool isPC, QWidget *parent) :
 	layout->addWidget(buttonBox);
 
 	for (QCheckBox *checkBox : qAsConst(_operations)) {
-		connect(checkBox, SIGNAL(toggled(bool)), SLOT(updateApplyButton()));
+		connect(checkBox, &QCheckBox::toggled, this, &OperationsManager::updateApplyButton);
 	}
 
-	connect(buttonBox, SIGNAL(accepted()), SLOT(accept()));
-	connect(buttonBox, SIGNAL(rejected()), SLOT(reject()));
+	connect(buttonBox, &QDialogButtonBox::accepted, this, &OperationsManager::accept);
+	connect(buttonBox, &QDialogButtonBox::rejected, this, &OperationsManager::reject);
 
 	updateApplyButton();
 }

--- a/src/widgets/ScriptEditor.cpp
+++ b/src/widgets/ScriptEditor.cpp
@@ -110,8 +110,8 @@ ScriptEditor::ScriptEditor(Field *field, const Section1File *scriptsAndTexts, co
 		changeCurrentOpcode(0);
 	}
 
-	connect(ok, &QPushButton::released, this, &ScriptEditor::accept);
-	connect(cancel, &QPushButton::released, this, &ScriptEditor::close);
+	connect(ok, &QPushButton::clicked, this, &ScriptEditor::accept);
+	connect(cancel, &QPushButton::clicked, this, &ScriptEditor::close);
 	connect(comboBox0, &QComboBox::currentIndexChanged, this, &ScriptEditor::buildList);
 	connect(comboBox, &QComboBox::currentIndexChanged, this, &ScriptEditor::changeCurrentOpcode);
 }

--- a/src/widgets/ScriptEditor.cpp
+++ b/src/widgets/ScriptEditor.cpp
@@ -110,10 +110,10 @@ ScriptEditor::ScriptEditor(Field *field, const Section1File *scriptsAndTexts, co
 		changeCurrentOpcode(0);
 	}
 
-	connect(ok, SIGNAL(released()), SLOT(accept()));
-	connect(cancel, SIGNAL(released()), SLOT(close()));
-	connect(comboBox0, SIGNAL(currentIndexChanged(int)), SLOT(buildList(int)));
-	connect(comboBox, SIGNAL(currentIndexChanged(int)), SLOT(changeCurrentOpcode(int)));
+	connect(ok, &QPushButton::released, this, &ScriptEditor::accept);
+	connect(cancel, &QPushButton::released, this, &ScriptEditor::close);
+	connect(comboBox0, &QComboBox::currentIndexChanged, this, &ScriptEditor::buildList);
+	connect(comboBox, &QComboBox::currentIndexChanged, this, &ScriptEditor::changeCurrentOpcode);
 }
 
 ScriptEditorView *ScriptEditor::buildEditorPage(PageType id)
@@ -352,7 +352,7 @@ void ScriptEditor::fillEditor()
 	
 	if (!_typeToIndex.contains(_currentPageType)) {
 		_currentPageWidget = buildEditorPage(_currentPageType);
-		connect(_currentPageWidget, SIGNAL(opcodeChanged()), SLOT(refreshTextEdit()));
+		connect(_currentPageWidget, &ScriptEditorView::opcodeChanged, this, &ScriptEditor::refreshTextEdit);
 		_typeToIndex.insert(_currentPageType, editorLayout->addWidget(_currentPageWidget));
 	} else {
 		_currentPageWidget = static_cast<ScriptEditorView *>(editorLayout->widget(_typeToIndex.value(_currentPageType)));

--- a/src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp
+++ b/src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp
@@ -58,9 +58,9 @@ void ScriptEditorGenericList::build()
 	layout->addLayout(buttonLayout);
 	layout->setContentsMargins(QMargins());
 
-	connect(model, SIGNAL(itemChanged(QStandardItem*)), SIGNAL(opcodeChanged()));
-	connect(addButton, SIGNAL(released()), SLOT(addParam()));
-	connect(delButton, SIGNAL(released()), SLOT(delLastRow()));
+	connect(model, &QStandardItemModel::itemChanged, this, &ScriptEditorGenericList::opcodeChanged);
+	connect(addButton, &QPushButton::released, this, &ScriptEditorGenericList::addParam);
+	connect(delButton, &QPushButton::released, this, &ScriptEditorGenericList::delLastRow);
 }
 
 Opcode ScriptEditorGenericList::buildOpcode()
@@ -700,7 +700,7 @@ void ScriptEditorBooleanPage::build()
 	layout->setRowStretch(1, 1);
 	layout->setContentsMargins(QMargins());
 
-	connect(_boolean, SIGNAL(currentIndexChanged(int)), SIGNAL(opcodeChanged()));
+	connect(_boolean, &QComboBox::currentIndexChanged, this, &ScriptEditorBooleanPage::opcodeChanged);
 }
 
 Opcode ScriptEditorBooleanPage::buildOpcode()

--- a/src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp
+++ b/src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp
@@ -59,8 +59,8 @@ void ScriptEditorGenericList::build()
 	layout->setContentsMargins(QMargins());
 
 	connect(model, &QStandardItemModel::itemChanged, this, &ScriptEditorGenericList::opcodeChanged);
-	connect(addButton, &QPushButton::released, this, &ScriptEditorGenericList::addParam);
-	connect(delButton, &QPushButton::released, this, &ScriptEditorGenericList::delLastRow);
+	connect(addButton, &QPushButton::clicked, this, &ScriptEditorGenericList::addParam);
+	connect(delButton, &QPushButton::clicked, this, &ScriptEditorGenericList::delLastRow);
 }
 
 Opcode ScriptEditorGenericList::buildOpcode()

--- a/src/widgets/ScriptEditorWidgets/ScriptEditorMathPage.cpp
+++ b/src/widgets/ScriptEditorWidgets/ScriptEditorMathPage.cpp
@@ -68,10 +68,10 @@ void ScriptEditorBinaryOpPage::build()
 	layout->setColumnStretch(1, 1);
 	layout->setContentsMargins(QMargins());
 
-	connect(var, SIGNAL(changed()), SIGNAL(opcodeChanged()));
-	connect(varOrValue, SIGNAL(changed()), SIGNAL(opcodeChanged()));
-	connect(type1, SIGNAL(toggled(bool)), SLOT(updateValueRange()));
-	connect(operationList, SIGNAL(currentIndexChanged(int)), SLOT(changeCurrentOpcode(int)));
+	connect(var, &VarOrValueWidget::changed, this, &ScriptEditorBinaryOpPage::opcodeChanged);
+	connect(varOrValue, &VarOrValueWidget::changed, this, &ScriptEditorBinaryOpPage::opcodeChanged);
+	connect(type1, &QRadioButton::toggled, this, &ScriptEditorBinaryOpPage::updateValueRange);
+	connect(operationList, &QComboBox::currentIndexChanged, this, &ScriptEditorBinaryOpPage::changeCurrentOpcode);
 }
 
 Opcode ScriptEditorBinaryOpPage::buildOpcode()
@@ -411,9 +411,9 @@ void ScriptEditorUnaryOpPage::build()
 	layout->setColumnStretch(1, 1);
 	layout->setContentsMargins(QMargins());
 
-	connect(var, SIGNAL(changed()), SIGNAL(opcodeChanged()));
-	connect(type1, SIGNAL(toggled(bool)), SLOT(updateValueRange()));
-	connect(operationList, SIGNAL(currentIndexChanged(int)), SLOT(changeCurrentOpcode(int)));
+	connect(var, &VarOrValueWidget::changed, this, &ScriptEditorUnaryOpPage::opcodeChanged);
+	connect(type1, &QRadioButton::toggled, this, &ScriptEditorUnaryOpPage::updateValueRange);
+	connect(operationList, &QComboBox::currentIndexChanged, this, &ScriptEditorUnaryOpPage::changeCurrentOpcode);
 }
 
 Opcode ScriptEditorUnaryOpPage::buildOpcode()
@@ -616,9 +616,10 @@ void ScriptEditorBitOpPage::build()
 	layout->setRowStretch(3, 1);
 	layout->setContentsMargins(QMargins());
 
-	connect(var, SIGNAL(changed()), SIGNAL(opcodeChanged()));
-	connect(position, SIGNAL(changed()), SIGNAL(opcodeChanged()));
-	connect(operationList, SIGNAL(currentIndexChanged(int)), SLOT(changeCurrentOpcode(int)));
+
+	connect(var, &VarOrValueWidget::changed, this, &ScriptEditorBitOpPage::opcodeChanged);
+	connect(position, &VarOrValueWidget::changed, this, &ScriptEditorBitOpPage::opcodeChanged);
+	connect(operationList, &QComboBox::currentIndexChanged, this, &ScriptEditorBitOpPage::changeCurrentOpcode);
 }
 
 Opcode ScriptEditorBitOpPage::buildOpcode()
@@ -724,7 +725,7 @@ void ScriptEditorVariablePage::build()
 	layout->setColumnStretch(1, 1);
 	layout->setContentsMargins(QMargins());
 
-	connect(varOrValue, SIGNAL(changed()), SIGNAL(opcodeChanged()));
+	connect(varOrValue, &VarOrValueWidget::changed, this, &ScriptEditorVariablePage::opcodeChanged);
 }
 
 Opcode ScriptEditorVariablePage::buildOpcode()
@@ -783,10 +784,9 @@ void ScriptEditor2BytePage::build()
 	layout->setColumnStretch(2, 1);
 	layout->setContentsMargins(QMargins());
 
-	connect(var, SIGNAL(changed()), SIGNAL(opcodeChanged()));
-	connect(varOrValue1, SIGNAL(changed()), SIGNAL(opcodeChanged()));
-	connect(varOrValue2, SIGNAL(changed()), SIGNAL(opcodeChanged()));
-}
+	connect(var, &VarOrValueWidget::changed, this, &ScriptEditor2BytePage::opcodeChanged);
+	connect(varOrValue1, &VarOrValueWidget::changed, this, &ScriptEditor2BytePage::opcodeChanged);
+	connect(varOrValue2, &VarOrValueWidget::changed, this, &ScriptEditor2BytePage::opcodeChanged);}
 
 Opcode ScriptEditor2BytePage::buildOpcode()
 {
@@ -879,11 +879,11 @@ void ScriptEditorSinCosPage::build()
 	layout->setColumnStretch(1, 1);
 	layout->setContentsMargins(QMargins());
 	
-	connect(operationList, SIGNAL(currentIndexChanged(int)), SLOT(changeCurrentOpcode(int)));
-	connect(var, SIGNAL(changed()), SIGNAL(opcodeChanged()));
-	connect(varOrValue1, SIGNAL(changed()), SIGNAL(opcodeChanged()));
-	connect(varOrValue2, SIGNAL(changed()), SIGNAL(opcodeChanged()));
-	connect(varOrValue3, SIGNAL(changed()), SIGNAL(opcodeChanged()));
+	connect(operationList, &QComboBox::currentIndexChanged, this, &ScriptEditorSinCosPage::changeCurrentOpcode);
+	connect(var, &VarOrValueWidget::changed, this, &ScriptEditorSinCosPage::opcodeChanged);
+	connect(varOrValue1, &VarOrValueWidget::changed, this, &ScriptEditorSinCosPage::opcodeChanged);
+	connect(varOrValue2, &VarOrValueWidget::changed, this, &ScriptEditorSinCosPage::opcodeChanged);
+	connect(varOrValue3, &VarOrValueWidget::changed, this, &ScriptEditorSinCosPage::opcodeChanged);
 }
 
 Opcode ScriptEditorSinCosPage::buildOpcode()

--- a/src/widgets/ScriptEditorWidgets/ScriptEditorMoviePage.cpp
+++ b/src/widgets/ScriptEditorWidgets/ScriptEditorMoviePage.cpp
@@ -39,8 +39,8 @@ void ScriptEditorMoviePage::build()
 	layout->setRowStretch(2, 1);
 	layout->setContentsMargins(QMargins());
 
-	connect(discList, SIGNAL(currentIndexChanged(int)), SLOT(setMovieListItemTexts(int)));
-	connect(movieList, SIGNAL(currentIndexChanged(int)), SIGNAL(opcodeChanged()));
+	connect(discList, &QComboBox::currentIndexChanged, this, &ScriptEditorMoviePage::setMovieListItemTexts);
+	connect(movieList, &QComboBox::currentIndexChanged, this, &ScriptEditorMoviePage::opcodeChanged);
 }
 
 void ScriptEditorMoviePage::buildDiscList()

--- a/src/widgets/ScriptEditorWidgets/ScriptEditorSpecialPage.cpp
+++ b/src/widgets/ScriptEditorWidgets/ScriptEditorSpecialPage.cpp
@@ -58,12 +58,12 @@ void ScriptEditorDLPBSavemap::build()
 	layout->setColumnStretch(2, 1);
 	layout->setContentsMargins(QMargins());
 
-	connect(_from, SIGNAL(editingFinished()), SIGNAL(opcodeChanged()));
-	connect(_to, SIGNAL(editingFinished()), SIGNAL(opcodeChanged()));
-	connect(_absValue, SIGNAL(editingFinished()), SIGNAL(opcodeChanged()));
-	connect(_flag, SIGNAL(currentIndexChanged(int)), SIGNAL(opcodeChanged()));
-	connect(_fromIsPointer, SIGNAL(toggled(bool)), SIGNAL(opcodeChanged()));
-	connect(_toIsPointer, SIGNAL(toggled(bool)), SIGNAL(opcodeChanged()));
+	connect(_from, &QSpinBox::editingFinished, this, &ScriptEditorDLPBSavemap::opcodeChanged);
+	connect(_to, &QSpinBox::editingFinished, this, &ScriptEditorDLPBSavemap::opcodeChanged);
+	connect(_absValue, &QDoubleSpinBox::editingFinished, this, &ScriptEditorDLPBSavemap::opcodeChanged);
+	connect(_flag, &QComboBox::currentIndexChanged, this, &ScriptEditorDLPBSavemap::opcodeChanged);
+	connect(_fromIsPointer, &QCheckBox::toggled, this, &ScriptEditorDLPBSavemap::opcodeChanged);
+	connect(_toIsPointer, &QCheckBox::toggled, this, &ScriptEditorDLPBSavemap::opcodeChanged);
 }
 
 Opcode ScriptEditorDLPBSavemap::buildOpcode()
@@ -115,8 +115,8 @@ void ScriptEditorDLPBWriteToMemory::build()
 	layout->setRowStretch(2, 1);
 	layout->setContentsMargins(QMargins());
 
-	connect(_address, SIGNAL(editingFinished()), SIGNAL(opcodeChanged()));
-	connect(_bytes, SIGNAL(editingFinished()), SIGNAL(opcodeChanged()));
+	connect(_address, &QDoubleSpinBox::editingFinished, this, &ScriptEditorDLPBWriteToMemory::opcodeChanged);
+	connect(_bytes, &QLineEdit::editingFinished, this, &ScriptEditorDLPBWriteToMemory::opcodeChanged);
 }
 
 Opcode ScriptEditorDLPBWriteToMemory::buildOpcode()

--- a/src/widgets/ScriptEditorWidgets/ScriptEditorStructPage.cpp
+++ b/src/widgets/ScriptEditorWidgets/ScriptEditorStructPage.cpp
@@ -30,7 +30,7 @@ void ScriptEditorWithPriorityPage::build()
 
 	helpWidget = new HelpWidget(16, tr("Lower priority number is higher priority in the game"));
 
-	connect(priority, SIGNAL(valueChanged(int)), SIGNAL(opcodeChanged()));
+	connect(priority, &QSpinBox::valueChanged, this, &ScriptEditorWithPriorityPage::opcodeChanged);
 }
 
 ScriptEditorReturnToPage::ScriptEditorReturnToPage(const Section1File *scriptsAndTexts, const GrpScript &grpScript, const Script &script, int opcodeID, QWidget *parent) :
@@ -56,7 +56,7 @@ void ScriptEditorReturnToPage::build()
 	layout->setRowStretch(3, 1);
 	layout->setContentsMargins(QMargins());
 
-	connect(scriptList, SIGNAL(currentIndexChanged(int)), SIGNAL(opcodeChanged()));
+	connect(scriptList, &QComboBox::currentIndexChanged, this, &ScriptEditorReturnToPage::opcodeChanged);
 }
 
 Opcode ScriptEditorReturnToPage::buildOpcode()
@@ -121,10 +121,10 @@ void ScriptEditorExecPage::build()
 	layout->setRowStretch(5, 1);
 	layout->setContentsMargins(QMargins());
 
-	connect(groupList, SIGNAL(currentIndexChanged(int)), SIGNAL(opcodeChanged()));
-	connect(scriptList, SIGNAL(currentIndexChanged(int)), SIGNAL(opcodeChanged()));
-	connect(groupList, SIGNAL(currentIndexChanged(int)), SLOT(updateScriptList(int)));
-	connect(execType, SIGNAL(currentIndexChanged(int)), SLOT(changeCurrentOpcode(int)));
+	connect(groupList, &QComboBox::currentIndexChanged, this, &ScriptEditorExecPage::opcodeChanged);
+	connect(scriptList, &QComboBox::currentIndexChanged, this, &ScriptEditorExecPage::opcodeChanged);
+	connect(groupList, &QComboBox::currentIndexChanged, this, &ScriptEditorExecPage::updateScriptList);
+	connect(execType, &QComboBox::currentIndexChanged, this, &ScriptEditorExecPage::changeCurrentOpcode);
 }
 
 Opcode ScriptEditorExecPage::buildOpcode()
@@ -255,9 +255,9 @@ void ScriptEditorExecCharPage::build()
 	layout->setRowStretch(5, 1);
 	layout->setContentsMargins(QMargins());
 
-	connect(partyID, SIGNAL(valueChanged(int)), SIGNAL(opcodeChanged()));
-	connect(scriptList, SIGNAL(currentIndexChanged(int)), SIGNAL(opcodeChanged()));
-	connect(execType, SIGNAL(currentIndexChanged(int)), SLOT(changeCurrentOpcode(int)));
+	connect(partyID, &QSpinBox::valueChanged, this, &ScriptEditorExecCharPage::opcodeChanged);
+	connect(scriptList, &QComboBox::currentIndexChanged, this, &ScriptEditorExecCharPage::opcodeChanged);
+	connect(execType, &QComboBox::currentIndexChanged, this, &ScriptEditorExecCharPage::changeCurrentOpcode);
 }
 
 Opcode ScriptEditorExecCharPage::buildOpcode()
@@ -339,7 +339,7 @@ void ScriptEditorLabelPage::build()
 	layout->setRowStretch(1, 1);
 	layout->setContentsMargins(QMargins());
 
-	connect(label, SIGNAL(valueChanged(double)), SIGNAL(opcodeChanged()));
+	connect(label, &QDoubleSpinBox::valueChanged, this, &ScriptEditorLabelPage::opcodeChanged);
 }
 
 Opcode ScriptEditorLabelPage::buildOpcode()
@@ -421,7 +421,7 @@ void ScriptEditorJumpPage::build()
 	layout->setRowStretch(1, 1);
 	layout->setContentsMargins(QMargins());
 
-	connect(label, SIGNAL(currentIndexChanged(int)), SIGNAL(opcodeChanged()));
+	connect(label, &QComboBox::currentIndexChanged, this, &ScriptEditorJumpPage::opcodeChanged);
 }
 
 void ScriptEditorJumpPage::clear()
@@ -480,7 +480,7 @@ void ScriptEditorJumpNanakiPage::build()
 	layout->setRowStretch(1, 1);
 	layout->setContentsMargins(QMargins());
 
-	connect(label, SIGNAL(currentIndexChanged(int)), SIGNAL(opcodeChanged()));
+	connect(label, &QComboBox::currentIndexChanged, this, &ScriptEditorJumpNanakiPage::opcodeChanged);
 }
 
 Opcode ScriptEditorJumpNanakiPage::buildOpcode()
@@ -544,11 +544,11 @@ void ScriptEditorIfPage::build()
 	layout->setRowStretch(3, 1);
 	layout->setContentsMargins(QMargins());
 
-	connect(varOrValue1, SIGNAL(changed()), SIGNAL(opcodeChanged()));
-	connect(varOrValue2, SIGNAL(changed()), SIGNAL(opcodeChanged()));
-	connect(operatorList, SIGNAL(currentIndexChanged(int)), SIGNAL(opcodeChanged()));
-	connect(label, SIGNAL(currentIndexChanged(int)), SIGNAL(opcodeChanged()));
-	connect(rangeTest, SIGNAL(currentIndexChanged(int)), SLOT(updateOpcode()));
+	connect(varOrValue1, &VarOrValueWidget::changed, this, &ScriptEditorIfPage::opcodeChanged);
+	connect(varOrValue2, &VarOrValueWidget::changed, this, &ScriptEditorIfPage::opcodeChanged);
+	connect(operatorList, &QComboBox::currentIndexChanged, this, &ScriptEditorIfPage::opcodeChanged);
+	connect(label, &QComboBox::currentIndexChanged, this, &ScriptEditorIfPage::opcodeChanged);
+	connect(rangeTest, &QComboBox::currentIndexChanged, this, &ScriptEditorIfPage::updateOpcode);
 }
 
 Opcode ScriptEditorIfPage::buildOpcode()
@@ -669,7 +669,7 @@ void ScriptEditorIfKeyPage::build()
 	for (const QString &keyName : qAsConst(Data::key_names)) {
 		QCheckBox *key = new QCheckBox(keyName, this);
 		keys.append(key);
-		connect(key, SIGNAL(toggled(bool)), SIGNAL(opcodeChanged()));
+		connect(key, &QCheckBox::toggled, this, &ScriptEditorIfKeyPage::opcodeChanged);
 		layout->addWidget(key, row, column);
 
 		if (column == 3) {
@@ -698,8 +698,8 @@ void ScriptEditorIfKeyPage::build()
 	layout->setRowStretch(row+2, 1);
 	layout->setContentsMargins(QMargins());
 
-	connect(label, SIGNAL(currentIndexChanged(int)), SIGNAL(opcodeChanged()));
-	connect(typeList, SIGNAL(currentIndexChanged(int)), SIGNAL(opcodeChanged()));
+	connect(label, &QComboBox::currentIndexChanged, this, &ScriptEditorIfKeyPage::opcodeChanged);
+	connect(typeList, &QComboBox::currentIndexChanged, this, &ScriptEditorIfKeyPage::opcodeChanged);
 }
 
 Opcode ScriptEditorIfKeyPage::buildOpcode()
@@ -793,8 +793,8 @@ void ScriptEditorIfQPage::build()
 	layout->setRowStretch(2, 1);
 	layout->setContentsMargins(QMargins());
 
-	connect(charList, SIGNAL(currentIndexChanged(int)), SIGNAL(opcodeChanged()));
-	connect(label, SIGNAL(currentIndexChanged(int)), SIGNAL(opcodeChanged()));
+	connect(charList, &QComboBox::currentIndexChanged, this, &ScriptEditorIfQPage::opcodeChanged);
+	connect(label, &QComboBox::currentIndexChanged, this, &ScriptEditorIfQPage::opcodeChanged);
 }
 
 Opcode ScriptEditorIfQPage::buildOpcode()
@@ -843,7 +843,7 @@ void ScriptEditorWaitPage::build()
 	layout->setRowStretch(1, 1);
 	layout->setContentsMargins(QMargins());
 
-	connect(frames, SIGNAL(valueChanged(int)), SIGNAL(opcodeChanged()));
+	connect(frames, &QSpinBox::valueChanged, this, &ScriptEditorWaitPage::opcodeChanged);
 }
 
 Opcode ScriptEditorWaitPage::buildOpcode()

--- a/src/widgets/ScriptEditorWidgets/ScriptEditorWalkmeshPage.cpp
+++ b/src/widgets/ScriptEditorWidgets/ScriptEditorWalkmeshPage.cpp
@@ -38,8 +38,8 @@ void ScriptEditorWalkmeshPage::build()
 	layout->setRowStretch(2, 1);
 	layout->setContentsMargins(QMargins());
 
-	connect(_point1, SIGNAL(valuesChanged(Vertex_s)), SLOT(updatePreview()));
-	connect(_point2, SIGNAL(valuesChanged(Vertex_s)), SLOT(updatePreview()));
+	connect(_point1, &VertexWidget::valuesChanged, this, &ScriptEditorWalkmeshPage::updatePreview);
+	connect(_point2, &VertexWidget::valuesChanged, this, &ScriptEditorWalkmeshPage::updatePreview);
 }
 
 Opcode ScriptEditorWalkmeshPage::buildOpcode()

--- a/src/widgets/ScriptEditorWidgets/ScriptEditorWindowPage.cpp
+++ b/src/widgets/ScriptEditorWidgets/ScriptEditorWindowPage.cpp
@@ -73,16 +73,16 @@ void ScriptEditorWindowPage::build()
 	layout->setColumnStretch(3, 1);
 	layout->setContentsMargins(QMargins());
 
-	connect(winID, SIGNAL(valueChanged(int)), SIGNAL(opcodeChanged()));
-	connect(x, SIGNAL(valueChanged(int)), SLOT(updatePreview()));
-	connect(y, SIGNAL(valueChanged(int)), SLOT(updatePreview()));
-	connect(w, SIGNAL(valueChanged(int)), SLOT(updatePreview()));
-	connect(h, SIGNAL(valueChanged(int)), SLOT(updatePreview()));
-	connect(textPreview, SIGNAL(positionChanged(QPoint)), SLOT(setPositionWindow(QPoint)));
-	connect(previewText, SIGNAL(currentIndexChanged(int)), SLOT(updateText(int)));
-	connect(hAlign, SIGNAL(clicked()), SLOT(alignHorizontally()));
-	connect(vAlign, SIGNAL(clicked()), SLOT(alignVertically()));
-	connect(autoSize, SIGNAL(clicked()), SLOT(resizeWindow()));
+	connect(winID, &QSpinBox::valueChanged, this, &ScriptEditorWindowPage::opcodeChanged);
+	connect(x, &QSpinBox::valueChanged, this, &ScriptEditorWindowPage::updatePreview);
+	connect(y, &QSpinBox::valueChanged, this, &ScriptEditorWindowPage::updatePreview);
+	connect(w, &QSpinBox::valueChanged, this, &ScriptEditorWindowPage::updatePreview);
+	connect(h, &QSpinBox::valueChanged, this, &ScriptEditorWindowPage::updatePreview);
+	connect(textPreview, &TextPreview::positionChanged, this, &ScriptEditorWindowPage::setPositionWindow);
+	connect(previewText, &QComboBox::currentIndexChanged, this, &ScriptEditorWindowPage::updateText);
+	connect(hAlign, &QPushButton::clicked, this, &ScriptEditorWindowPage::alignHorizontally);
+	connect(vAlign, &QPushButton::clicked, this, &ScriptEditorWindowPage::alignVertically);
+	connect(autoSize, &QPushButton::clicked, this, &ScriptEditorWindowPage::resizeWindow);
 }
 
 Opcode ScriptEditorWindowPage::buildOpcode()
@@ -288,9 +288,9 @@ void ScriptEditorWindowModePage::build()
 	layout->setColumnStretch(2, 1);
 	layout->setContentsMargins(QMargins());
 
-	connect(winID, SIGNAL(valueChanged(int)), SIGNAL(opcodeChanged()));
-	connect(winType, SIGNAL(currentIndexChanged(int)), SLOT(updatePreview()));
-	connect(winClose, SIGNAL(currentIndexChanged(int)), SIGNAL(opcodeChanged()));
+	connect(winID, &QSpinBox::valueChanged, this, &ScriptEditorWindowModePage::opcodeChanged);
+	connect(winType, &QComboBox::currentIndexChanged, this, &ScriptEditorWindowModePage::updatePreview);
+	connect(winClose, &QComboBox::currentIndexChanged, this, &ScriptEditorWindowModePage::opcodeChanged);
 }
 
 Opcode ScriptEditorWindowModePage::buildOpcode()
@@ -361,9 +361,9 @@ void ScriptEditorWindowMovePage::build()
 	layout->setColumnStretch(2, 1);
 	layout->setContentsMargins(QMargins());
 
-	connect(winID, SIGNAL(valueChanged(int)), SIGNAL(opcodeChanged()));
-	connect(x, SIGNAL(valueChanged(int)), SIGNAL(opcodeChanged()));
-	connect(y, SIGNAL(valueChanged(int)), SIGNAL(opcodeChanged()));
+	connect(winID, &QSpinBox::valueChanged, this, &ScriptEditorWindowMovePage::opcodeChanged);
+	connect(x, &QSpinBox::valueChanged, this, &ScriptEditorWindowMovePage::opcodeChanged);
+	connect(y, &QSpinBox::valueChanged, this, &ScriptEditorWindowMovePage::opcodeChanged);
 }
 
 Opcode ScriptEditorWindowMovePage::buildOpcode()
@@ -421,9 +421,9 @@ void ScriptEditorWindowVariablePage::build()
 	layout->setColumnStretch(2, 1);
 	layout->setContentsMargins(QMargins());
 
-	connect(winID, SIGNAL(valueChanged(int)), SIGNAL(opcodeChanged()));
-	connect(winVar, SIGNAL(valueChanged(int)), SIGNAL(opcodeChanged()));
-	connect(varOrValue, SIGNAL(changed()), SIGNAL(opcodeChanged()));
+	connect(winID, &QSpinBox::valueChanged, this, &ScriptEditorWindowVariablePage::opcodeChanged);
+	connect(winVar, &QSpinBox::valueChanged, this, &ScriptEditorWindowVariablePage::opcodeChanged);
+	connect(varOrValue, &VarOrValueWidget::changed, this, &ScriptEditorWindowVariablePage::opcodeChanged);
 }
 
 Opcode ScriptEditorWindowVariablePage::buildOpcode()

--- a/src/widgets/ScriptList.cpp
+++ b/src/widgets/ScriptList.cpp
@@ -23,8 +23,7 @@ ScriptList::ScriptList(QWidget *parent) :
 {
 	setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
 	setContextMenuPolicy(Qt::ActionsContextMenu);
-	connect(this, SIGNAL(currentItemChanged(QListWidgetItem*,QListWidgetItem*)),
-	        SLOT(evidence(QListWidgetItem*,QListWidgetItem*)));
+	connect(this, &ScriptList::currentItemChanged, this, &ScriptList::evidence);
 }
 
 void ScriptList::evidence(QListWidgetItem *current, QListWidgetItem *previous)

--- a/src/widgets/ScriptManager.cpp
+++ b/src/widgets/ScriptManager.cpp
@@ -70,18 +70,18 @@ ScriptManager::ScriptManager(QWidget *parent) :
 	contentLayout->setColumnStretch(1, 1);
 	contentLayout->setColumnStretch(2, 9);
 
-	connect(_groupScriptList, SIGNAL(changed()), SIGNAL(changed()));
-	connect(_groupScriptList, SIGNAL(itemSelectionChanged()), SLOT(fillScripts()));
+	connect(_groupScriptList, &GrpScriptList::changed, this, &ScriptManager::changed);
+	connect(_groupScriptList, &GrpScriptList::itemSelectionChanged, this, &ScriptManager::fillScripts);
 
-	connect(_scriptList, SIGNAL(itemSelectionChanged()), SLOT(fillOpcodes()));
+	connect(_scriptList, &ScriptList::itemSelectionChanged, this, &ScriptManager::fillOpcodes);
 
-	connect(_opcodeList, SIGNAL(changed()), SIGNAL(changed()));
-	connect(_opcodeList, SIGNAL(changed()), SLOT(refresh()));
-	connect(_opcodeList, SIGNAL(editText(int)), SIGNAL(editText(int)));
-	connect(_opcodeList, SIGNAL(changed()), SLOT(compile()));
-	connect(_opcodeList, SIGNAL(gotoScript(int,int)), SLOT(gotoScript(int,int)));
-	connect(_opcodeList, SIGNAL(gotoField(int)), SIGNAL(gotoField(int)));
-	connect(_opcodeList, SIGNAL(searchOpcode(int)), SIGNAL(searchOpcode(int)));
+	connect(_opcodeList, &OpcodeList::changed, this, &ScriptManager::changed);
+	connect(_opcodeList, &OpcodeList::changed, this, &ScriptManager::refresh);
+	connect(_opcodeList, qOverload<int>(&OpcodeList::editText), this, &ScriptManager::editText);
+	connect(_opcodeList, &OpcodeList::changed, this, &ScriptManager::compile);
+	connect(_opcodeList, &OpcodeList::gotoScript, this, &ScriptManager::gotoScript);
+	connect(_opcodeList, &OpcodeList::gotoField, this, &ScriptManager::gotoField);
+	connect(_opcodeList, qOverload<int>(&OpcodeList::searchOpcode), this, &ScriptManager::searchOpcode);
 
 	_groupScriptList->toolBar()->setVisible(Config::value("grpToolbarVisible", true).toBool());
 	_opcodeList->toolBar()->setVisible(Config::value("scriptToolbarVisible", true).toBool());

--- a/src/widgets/Search.cpp
+++ b/src/widgets/Search.cpp
@@ -386,7 +386,8 @@ void Search::setFieldArchive(FieldArchive *fieldArchive)
 	setActionsEnabled(fieldArchive != nullptr);
 	if (mapJump->count() <= 0) {
 		int mapID=0;
-		for (const QString &fieldName : Data::maplist()) {
+		const auto mapList = Data::maplist();
+		for (const QString &fieldName : mapList) {
 			mapJump->addItem(QString("%1 - %2").arg(mapID++, 3, 10, QChar('0')).arg(fieldName));
 		}
 		// set config values

--- a/src/widgets/Search.cpp
+++ b/src/widgets/Search.cpp
@@ -81,9 +81,9 @@ Search::Search(Window *mainWindow) :
 
 	searchAllDialog = new SearchAll(mainWindow);
 
-	connect(buttonNext, &QPushButton::released, this, &Search::findNext);
-	connect(buttonPrev, &QPushButton::released, this, &Search::findPrev);
-	connect(buttonAll, &QPushButton::released, this, &Search::findAll);
+	connect(buttonNext, &QPushButton::clicked, this, &Search::findNext);
+	connect(buttonPrev, &QPushButton::clicked, this, &Search::findPrev);
+	connect(buttonAll, &QPushButton::clicked, this, &Search::findAll);
 
 	connect(champ->lineEdit(), &QLineEdit::textEdited, champ2->lineEdit(), &QLineEdit::setText);
 	connect(caseSens, &QCheckBox::clicked, this, &Search::updateCaseSensitivity);

--- a/src/widgets/Search.cpp
+++ b/src/widgets/Search.cpp
@@ -46,10 +46,16 @@ Search::Search(Window *mainWindow) :
 	}
 
 	buttonNext->setDefault(true);
-
 	// Button Shortcuts
-	new QShortcut(QKeySequence::FindNext, this, SLOT(findNext()), nullptr, Qt::ApplicationShortcut);
-	new QShortcut(QKeySequence::FindPrevious, this, SLOT(findPrev()), nullptr, Qt::ApplicationShortcut);
+	findNextShortcut = new QShortcut(this);
+	findNextShortcut->setKey(QKeySequence::FindNext);
+	findNextShortcut->setContext(Qt::ApplicationShortcut);
+	connect(findNextShortcut, &QShortcut::activated, this, [&]{emit buttonNext->clicked();});
+
+	findPreviousShortcut = new QShortcut(this);
+	findPreviousShortcut->setKey(QKeySequence::FindPrevious);
+	findPreviousShortcut->setContext(Qt::ApplicationShortcut);
+	connect(findPreviousShortcut, &QShortcut::activated, this, [&]{emit buttonPrev->clicked();});
 
 	// buttonNext.width == buttonPrev.width
 	QPushButton *largerButton = buttonWidths.last();
@@ -75,19 +81,19 @@ Search::Search(Window *mainWindow) :
 
 	searchAllDialog = new SearchAll(mainWindow);
 
-	connect(buttonNext, SIGNAL(released()), SLOT(findNext()));
-	connect(buttonPrev, SIGNAL(released()), SLOT(findPrev()));
-	connect(buttonAll, SIGNAL(released()), SLOT(findAll()));
+	connect(buttonNext, &QPushButton::released, this, &Search::findNext);
+	connect(buttonPrev, &QPushButton::released, this, &Search::findPrev);
+	connect(buttonAll, &QPushButton::released, this, &Search::findAll);
 
-	connect(champ->lineEdit(), SIGNAL(textEdited(QString)), champ2->lineEdit(), SLOT(setText(QString)));
-	connect(caseSens, SIGNAL(clicked(bool)), SLOT(updateCaseSensitivity(bool)));
-	connect(useRegexp, SIGNAL(clicked(bool)), useRegexp2, SLOT(setChecked(bool)));
+	connect(champ->lineEdit(), &QLineEdit::textEdited, champ2->lineEdit(), &QLineEdit::setText);
+	connect(caseSens, &QCheckBox::clicked, this, &Search::updateCaseSensitivity);
+	connect(useRegexp, &QCheckBox::clicked, useRegexp2, &QCheckBox::setChecked);
 
-	connect(champ2->lineEdit(), SIGNAL(textEdited(QString)), champ->lineEdit(), SLOT(setText(QString)));
-	connect(caseSens2, SIGNAL(clicked(bool)), SLOT(updateCaseSensitivity(bool)));
-	connect(useRegexp2, SIGNAL(clicked(bool)), useRegexp, SLOT(setChecked(bool)));
+	connect(champ2->lineEdit(), &QLineEdit::textEdited, champ->lineEdit(), &QLineEdit::setText);
+	connect(caseSens2, &QCheckBox::clicked, this, &Search::updateCaseSensitivity);
+	connect(useRegexp2, &QCheckBox::clicked, useRegexp, &QCheckBox::setChecked);
 
-	connect(tabWidget, SIGNAL(currentChanged(int)), SLOT(saveCurrentTab(int)));
+	connect(tabWidget, &QTabWidget::currentChanged, this, &Search::saveCurrentTab);
 
 	setActionsEnabled(false);
 	updateCaseSensitivity(Config::value("findWithCaseSensitive").toBool());
@@ -267,13 +273,13 @@ QWidget *Search::scriptPageWidget()
 	topLayout->addWidget(contextGroupBox, 2, 0, 1, 2, Qt::AlignBottom);
 	topLayout->setRowStretch(1, 1);
 
-	connect(liste, SIGNAL(currentIndexChanged(int)), stack, SLOT(setCurrentIndex(int)));
-	connect(liste, SIGNAL(currentIndexChanged(int)), SLOT(saveCurrentScriptTab(int)));
-	connect(champBank, SIGNAL(valueChanged(int)), SLOT(updateComboVarName()));
-	connect(champAddress, SIGNAL(valueChanged(int)), comboVarName, SLOT(setCurrentIndex(int)));
-	connect(comboVarName, SIGNAL(currentIndexChanged(int)), SLOT(updateChampAdress()));
-	connect(champOp, SIGNAL(currentIndexChanged(int)), SLOT(updateSearchVarPlaceholder(int)));
-	connect(opcode, SIGNAL(currentIndexChanged(int)), SLOT(updateOpcode2(int)));
+	connect(liste, &QComboBox::currentIndexChanged, stack, &QStackedWidget::setCurrentIndex);
+	connect(liste, &QComboBox::currentIndexChanged, this, &Search::saveCurrentScriptTab);
+	connect(champBank, &QSpinBox::valueChanged, this, &Search::updateComboVarName);
+	connect(champAddress, &QSpinBox::valueChanged, comboVarName, &QComboBox::setCurrentIndex);
+	connect(comboVarName, &QComboBox::currentIndexChanged, this, &Search::updateChampAdress);
+	connect(champOp, &QComboBox::currentIndexChanged, this, &Search::updateSearchVarPlaceholder);
+	connect(opcode, &QComboBox::currentIndexChanged, this, &Search::updateOpcode2);
 
 	liste->setCurrentIndex(Config::value("searchDialogScriptCurrentModule").toInt());
 
@@ -336,8 +342,8 @@ QWidget *Search::textPageWidget()
 	textLayout->addWidget(contextGroupBox, 4, 0, 1, 6);
 	textLayout->setRowStretch(3, 1);
 
-	connect(replaceCurrentButton, SIGNAL(clicked()), SLOT(replaceCurrent()));
-	connect(replaceAllButton, SIGNAL(clicked()), SLOT(replaceAll()));
+	connect(replaceCurrentButton, &QPushButton::clicked, this, &Search::replaceCurrent);
+	connect(replaceAllButton, &QPushButton::clicked, this, &Search::replaceAll);
 
 	return ret;
 }
@@ -540,7 +546,7 @@ void Search::findNext()
 	returnToBegin->hide();
 
 	QTimer timer(this);
-	connect(&timer, SIGNAL(timeout()), SLOT(processEvents()));
+	connect(&timer, &QTimer::timeout, this, &Search::processEvents);
 	timer.start(700);
 
 	setSearchValues();
@@ -693,7 +699,7 @@ void Search::findPrev()
 	bool f = false;
 
 	QTimer timer(this);
-	connect(&timer, SIGNAL(timeout()), SLOT(processEvents()));
+	connect(&timer, &QTimer::timeout, this, &Search::processEvents);
 	timer.start(700);
 
 	if (tabWidget->currentIndex() == 0) { // scripts page
@@ -958,7 +964,7 @@ void Search::replaceAll()
 	}
 
 	QTimer timer(this);
-	connect(&timer, SIGNAL(timeout()), SLOT(processEvents()));
+	connect(&timer, &QTimer::timeout, this, &Search::processEvents);
 	timer.start(700);
 
 	int replacedCount = 0;

--- a/src/widgets/Search.h
+++ b/src/widgets/Search.h
@@ -109,6 +109,8 @@ private:
 	quint8 bank;
 	bool cancel;
 	bool atTheEnd, atTheBeginning;
+	QShortcut *findNextShortcut = nullptr;
+	QShortcut *findPreviousShortcut = nullptr;
 
 signals:
 	void found(int fieldID, int grpScriptID, int scriptID, int opcodeID);

--- a/src/widgets/SearchAll.cpp
+++ b/src/widgets/SearchAll.cpp
@@ -40,12 +40,12 @@ SearchAll::SearchAll(Window *parent) :
 	layout->addWidget(_resultList, 0, 0);
 	layout->setContentsMargins(QMargins());
 
-	connect(_resultList, SIGNAL(itemActivated(QTreeWidgetItem*,int)), SLOT(gotoResult(QTreeWidgetItem*)));
+	connect(_resultList, &QTreeWidget::itemActivated, this, &SearchAll::gotoResult);
 
 	QAction *copy = new QAction(QIcon(":/images/copy.png"), tr("Copy"), this);
 	copy->setShortcut(QKeySequence("Ctrl+C"));
 	copy->setShortcutContext(Qt::WidgetWithChildrenShortcut);
-	connect(copy, SIGNAL(triggered()), SLOT(copySelected()));
+	connect(copy, &QAction::triggered, this, &SearchAll::copySelected);
 
 	_resultList->addAction(copy);
 

--- a/src/widgets/TextManager.cpp
+++ b/src/widgets/TextManager.cpp
@@ -256,28 +256,28 @@ TextManager::TextManager(QWidget *parent) :
 	setLayout(layout);
 	adjustSize();
 
-	connect(liste1, SIGNAL(currentItemChanged(QListWidgetItem*,QListWidgetItem*)), SLOT(selectText(QListWidgetItem*,QListWidgetItem*)));
-	connect(dispUnusedText, SIGNAL(toggled(bool)), SLOT(showList()));
-	connect(toolBar, SIGNAL(actionTriggered(QAction*)), SLOT(insertTag(QAction*)));
-	connect(toolBar2, SIGNAL(actionTriggered(QAction*)), SLOT(insertTag(QAction*)));
-	connect(menu1, SIGNAL(triggered(QAction*)), SLOT(insertTag(QAction*)));
-	connect(menu2, SIGNAL(triggered(QAction*)), SLOT(insertTag(QAction*)));
-	connect(menuVars, SIGNAL(triggered(QAction*)), SLOT(insertTag(QAction*)));
-	connect(menuKeys, SIGNAL(triggered(QAction*)), SLOT(insertTag(QAction*)));
-	connect(textEdit, SIGNAL(textChanged()), SLOT(setTextChanged()));
-	connect(prevPage, SIGNAL(released()), SLOT(prevTextPreviewPage()));
-	connect(nextPage, SIGNAL(released()), SLOT(nextTextPreviewPage()));
-	connect(prevWin, SIGNAL(released()), SLOT(prevTextPreviewWin()));
-	connect(nextWin, SIGNAL(released()), SLOT(nextTextPreviewWin()));
-	connect(textPreview, SIGNAL(positionChanged(const QPoint&)), SLOT(changePosition(const QPoint&)));
-	connect(textPreview, SIGNAL(pageChanged(int)), SLOT(changeTextPreviewPage()));
-	connect(xCoord, SIGNAL(valueChanged(int)), SLOT(changeXCoord(int)));
-	connect(yCoord, SIGNAL(valueChanged(int)), SLOT(changeYCoord(int)));
-	connect(wSize, SIGNAL(valueChanged(int)), SLOT(changeWSize(int)));
-	connect(hSize, SIGNAL(valueChanged(int)), SLOT(changeHSize(int)));
-	connect(hAlign, SIGNAL(clicked()), SLOT(alignHorizontally()));
-	connect(vAlign, SIGNAL(clicked()), SLOT(alignVertically()));
-	connect(autoSize, SIGNAL(clicked()), SLOT(resizeWindow()));
+	connect(liste1, &QListWidget::currentItemChanged, this, &TextManager::selectText);
+	connect(dispUnusedText, &QCheckBox::toggled, this, &TextManager::showList);
+	connect(toolBar, &QToolBar::actionTriggered, this, &TextManager::insertTag);
+	connect(toolBar2, &QToolBar::actionTriggered, this, &TextManager::insertTag);
+	connect(menu1, &QMenu::triggered, this, &TextManager::insertTag);
+	connect(menu2, &QMenu::triggered, this, &TextManager::insertTag);
+	connect(menuVars, &QMenu::triggered, this, &TextManager::insertTag);
+	connect(menuKeys, &QMenu::triggered, this, &TextManager::insertTag);
+	connect(textEdit, &QPlainTextEdit::textChanged, this, &TextManager::setTextChanged);
+	connect(prevPage, &QPushButton::released, this, &TextManager::prevTextPreviewPage);
+	connect(nextPage, &QPushButton::released, this, &TextManager::nextTextPreviewPage);
+	connect(prevWin, &QPushButton::released, this, &TextManager::prevTextPreviewWin);
+	connect(nextWin, &QPushButton::released, this, &TextManager::nextTextPreviewWin);
+	connect(textPreview, &TextPreview::positionChanged, this, &TextManager::changePosition);
+	connect(textPreview, &TextPreview::pageChanged, this, &TextManager::changeTextPreviewPage);
+	connect(xCoord, &QSpinBox::valueChanged, this, &TextManager::changeXCoord);
+	connect(yCoord, &QSpinBox::valueChanged, this, &TextManager::changeYCoord);
+	connect(wSize, &QSpinBox::valueChanged, this, &TextManager::changeWSize);
+	connect(hSize, &QSpinBox::valueChanged, this, &TextManager::changeHSize);
+	connect(hAlign, &QPushButton::clicked, this, &TextManager::alignHorizontally);
+	connect(vAlign, &QPushButton::clicked, this, &TextManager::alignVertically);
+	connect(autoSize, &QPushButton::clicked, this, &TextManager::resizeWindow);
 }
 
 void TextManager::focusInEvent(QFocusEvent *)

--- a/src/widgets/TextManager.cpp
+++ b/src/widgets/TextManager.cpp
@@ -265,10 +265,10 @@ TextManager::TextManager(QWidget *parent) :
 	connect(menuVars, &QMenu::triggered, this, &TextManager::insertTag);
 	connect(menuKeys, &QMenu::triggered, this, &TextManager::insertTag);
 	connect(textEdit, &QPlainTextEdit::textChanged, this, &TextManager::setTextChanged);
-	connect(prevPage, &QPushButton::released, this, &TextManager::prevTextPreviewPage);
-	connect(nextPage, &QPushButton::released, this, &TextManager::nextTextPreviewPage);
-	connect(prevWin, &QPushButton::released, this, &TextManager::prevTextPreviewWin);
-	connect(nextWin, &QPushButton::released, this, &TextManager::nextTextPreviewWin);
+	connect(prevPage, &QPushButton::clicked, this, &TextManager::prevTextPreviewPage);
+	connect(nextPage, &QPushButton::clicked, this, &TextManager::nextTextPreviewPage);
+	connect(prevWin, &QPushButton::clicked, this, &TextManager::prevTextPreviewWin);
+	connect(nextWin, &QPushButton::clicked, this, &TextManager::nextTextPreviewWin);
 	connect(textPreview, &TextPreview::positionChanged, this, &TextManager::changePosition);
 	connect(textPreview, &TextPreview::pageChanged, this, &TextManager::changeTextPreviewPage);
 	connect(xCoord, &QSpinBox::valueChanged, this, &TextManager::changeXCoord);

--- a/src/widgets/TextPreview.cpp
+++ b/src/widgets/TextPreview.cpp
@@ -34,7 +34,7 @@ TextPreview::TextPreview(QWidget *parent) :
 {
 	pagesPos.append(0);
 
-	connect(&timer, SIGNAL(timeout()), SLOT(animate()));
+	connect(&timer, &QTimer::timeout, this, &TextPreview::animate);
 
 	setFixedSize(320, 224);
 	clear();

--- a/src/widgets/TutWidget.cpp
+++ b/src/widgets/TutWidget.cpp
@@ -70,8 +70,8 @@ TutWidget::TutWidget(QWidget *parent) :
 
 	connect(list, &QListWidget::currentItemChanged, this, &TutWidget::showText);
 
-	connect(exportButton, &QPushButton::released, this, &TutWidget::exportation);
-	connect(importButton, &QPushButton::released, this, &TutWidget::importation);
+	connect(exportButton, &QPushButton::clicked, this, &TutWidget::exportation);
+	connect(importButton, &QPushButton::clicked, this, &TutWidget::importation);
 }
 
 void TutWidget::fill(Field *field, TutFilePC *tutPC, bool reload)
@@ -167,9 +167,9 @@ QWidget *TutWidget::buildBrokenPage()
 	layout->addStretch();
 	layout->setContentsMargins(QMargins());
 
-	connect(repairButton, &QPushButton::released, this, &TutWidget::repairBroken);
-	connect(createNewAkaoButton, &QPushButton::released, this, &TutWidget::replaceByEmptyAkao);
-	connect(createNewTutoButton, &QPushButton::released, this, &TutWidget::replaceByEmptyTuto);
+	connect(repairButton, &QPushButton::clicked, this, &TutWidget::repairBroken);
+	connect(createNewAkaoButton, &QPushButton::clicked, this, &TutWidget::replaceByEmptyAkao);
+	connect(createNewTutoButton, &QPushButton::clicked, this, &TutWidget::replaceByEmptyTuto);
 
 	return ret;
 }

--- a/src/widgets/TutWidget.cpp
+++ b/src/widgets/TutWidget.cpp
@@ -57,7 +57,7 @@ TutWidget::TutWidget(QWidget *parent) :
 	exportLayout->addWidget(versionPS);
 	exportLayout->addWidget(versionPC);
 
-	connect(versionPS, SIGNAL(toggled(bool)), SLOT(changeVersion(bool)));
+	connect(versionPS, &QRadioButton::toggled, this, &TutWidget::changeVersion);
 
 	exportLayout->addStretch();
 	exportLayout->addWidget(exportButton);
@@ -68,10 +68,10 @@ TutWidget::TutWidget(QWidget *parent) :
 	layout->addWidget(_list, 1, 0);
 	layout->addWidget(stackedWidget, 1, 1);
 
-	connect(list, SIGNAL(currentItemChanged(QListWidgetItem*,QListWidgetItem*)), SLOT(showText(QListWidgetItem*,QListWidgetItem*)));
+	connect(list, &QListWidget::currentItemChanged, this, &TutWidget::showText);
 
-	connect(exportButton, SIGNAL(released()), SLOT(exportation()));
-	connect(importButton, SIGNAL(released()), SLOT(importation()));
+	connect(exportButton, &QPushButton::released, this, &TutWidget::exportation);
+	connect(importButton, &QPushButton::released, this, &TutWidget::importation);
 }
 
 void TutWidget::fill(Field *field, TutFilePC *tutPC, bool reload)
@@ -116,7 +116,7 @@ QWidget *TutWidget::buildTutPage()
 	textEdit->setLineWrapMode(QPlainTextEdit::NoWrap);
 	new TextHighlighter(textEdit->document(), true);
 
-	connect(textEdit, SIGNAL(textChanged()), SLOT(setTextChanged()));
+	connect(textEdit, &QPlainTextEdit::textChanged, this, &TutWidget::setTextChanged);
 
 	return textEdit;
 }
@@ -167,9 +167,9 @@ QWidget *TutWidget::buildBrokenPage()
 	layout->addStretch();
 	layout->setContentsMargins(QMargins());
 
-	connect(repairButton, SIGNAL(released()), SLOT(repairBroken()));
-	connect(createNewAkaoButton, SIGNAL(released()), SLOT(replaceByEmptyAkao()));
-	connect(createNewTutoButton, SIGNAL(released()), SLOT(replaceByEmptyTuto()));
+	connect(repairButton, &QPushButton::released, this, &TutWidget::repairBroken);
+	connect(createNewAkaoButton, &QPushButton::released, this, &TutWidget::replaceByEmptyAkao);
+	connect(createNewTutoButton, &QPushButton::released, this, &TutWidget::replaceByEmptyTuto);
 
 	return ret;
 }
@@ -338,8 +338,8 @@ void TutWidget::add()
 		chooseLayout->addWidget(tutType, 0, 0);
 		chooseLayout->addWidget(akaoType, 0, 1);
 		chooseLayout->addWidget(buttonBox, 1, 0, 1, 2);
-		connect(buttonBox, SIGNAL(accepted()), &chooseType, SLOT(accept()));
-		connect(buttonBox, SIGNAL(rejected()), &chooseType, SLOT(reject()));
+		connect(buttonBox, &QDialogButtonBox::accepted, &chooseType, &QDialog::accept);
+		connect(buttonBox, &QDialogButtonBox::rejected, &chooseType, &QDialog::reject);
 		if (chooseType.exec() != QDialog::Accepted) {
 			return;
 		}

--- a/src/widgets/VarManager.cpp
+++ b/src/widgets/VarManager.cpp
@@ -101,9 +101,9 @@ VarManager::VarManager(FieldArchive *fieldArchive, QWidget *parent)
 	connect(liste1, &QListWidget::currentRowChanged, this, &VarManager::changeBank);
 	connect(liste2, &QTreeWidget::itemSelectionChanged, this, &VarManager::fillForm);
 	connect(name, &QLineEdit::returnPressed, this, &VarManager::renameVar);
-	connect(rename, &QPushButton::released, this, &VarManager::renameVar);
-	connect(ok, &QPushButton::released, this, &VarManager::save);
-	connect(searchButton, &QPushButton::released, this, &VarManager::search);
+	connect(rename, &QPushButton::clicked, this, &VarManager::renameVar);
+	connect(ok, &QPushButton::clicked, this, &VarManager::save);
+	connect(searchButton, &QPushButton::clicked, this, &VarManager::search);
 
 	adjustSize();
 }

--- a/src/widgets/VarManager.cpp
+++ b/src/widgets/VarManager.cpp
@@ -96,14 +96,14 @@ VarManager::VarManager(FieldArchive *fieldArchive, QWidget *parent)
 	changeBank(0);
 	fillForm();
 
-	connect(bank, SIGNAL(valueChanged(int)), SLOT(scrollToList1(int)));
-	connect(address, SIGNAL(valueChanged(int)), SLOT(scrollToList2(int)));
-	connect(liste1, SIGNAL(currentRowChanged(int)), SLOT(changeBank(int)));
-	connect(liste2, SIGNAL(itemSelectionChanged()), SLOT(fillForm()));
-	connect(name, SIGNAL(returnPressed()), SLOT(renameVar()));
-	connect(rename, SIGNAL(released()), SLOT(renameVar()));
-	connect(ok, SIGNAL(released()), SLOT(save()));
-	connect(searchButton, SIGNAL(released()), SLOT(search()));
+	connect(bank, &QSpinBox::valueChanged, this, &VarManager::scrollToList1);
+	connect(address, &QSpinBox::valueChanged, this, &VarManager::scrollToList2);
+	connect(liste1, &QListWidget::currentRowChanged, this, &VarManager::changeBank);
+	connect(liste2, &QTreeWidget::itemSelectionChanged, this, &VarManager::fillForm);
+	connect(name, &QLineEdit::returnPressed, this, &VarManager::renameVar);
+	connect(rename, &QPushButton::released, this, &VarManager::renameVar);
+	connect(ok, &QPushButton::released, this, &VarManager::save);
+	connect(searchButton, &QPushButton::released, this, &VarManager::search);
 
 	adjustSize();
 }
@@ -275,7 +275,7 @@ void VarManager::search()
 	mess.setStandardButtons(QMessageBox::NoButton);
 	mess.show();
 	QTimer t(this);
-	connect(&t, SIGNAL(timeout()), SLOT(processEvents()));
+	connect(&t, &QTimer::timeout, this, &VarManager::processEvents);
 	t.start(700);
 	allVars = fieldArchive->searchAllVars(_fieldNames);
 	quint8 b = quint8(bank->value());

--- a/src/widgets/VarOrValueWidget.cpp
+++ b/src/widgets/VarOrValueWidget.cpp
@@ -57,12 +57,12 @@ VarOrValueWidget::VarOrValueWidget(QWidget *parent) :
 	_typeSelect->setCurrentIndex(0);
 	_varOrValuelayout->setCurrentIndex(0);
 
-	connect(_typeSelect, SIGNAL(currentIndexChanged(int)), SLOT(updateVarOrValueLayout()));
-	connect(_typeSelect, SIGNAL(currentIndexChanged(int)), SLOT(updateBankList()));
-	connect(_typeSelect, SIGNAL(currentIndexChanged(int)), SIGNAL(changed()));
-	connect(_bank, SIGNAL(currentIndexChanged(int)), SIGNAL(changed()));
-	connect(_value, SIGNAL(valueChanged(int)), SIGNAL(changed()));
-	connect(_adress, SIGNAL(valueChanged(int)), SIGNAL(changed()));
+	connect(_typeSelect, &QComboBox::currentIndexChanged, this, &VarOrValueWidget::updateVarOrValueLayout);
+	connect(_typeSelect, &QComboBox::currentIndexChanged, this, &VarOrValueWidget::updateBankList);
+	connect(_typeSelect, &QComboBox::currentIndexChanged, this, &VarOrValueWidget::changed);
+	connect(_bank, &QComboBox::currentIndexChanged, this, &VarOrValueWidget::changed);
+	connect(_value, &QSpinBox::valueChanged, this, &VarOrValueWidget::changed);
+	connect(_adress, &QSpinBox::valueChanged, this, &VarOrValueWidget::changed);
 }
 
 int VarOrValueWidget::value() const

--- a/src/widgets/VertexWidget.cpp
+++ b/src/widgets/VertexWidget.cpp
@@ -47,9 +47,9 @@ void VertexWidget::build(const QString &xLabel, const QString &yLabel, const QSt
 	layout->addWidget(new QLabel(zLabel.isEmpty() ? tr("Z") : zLabel));
 	layout->addWidget(z, 1);
 
-	connect(x, SIGNAL(valueChanged(int)), SLOT(emitValuesChanged()));
-	connect(y, SIGNAL(valueChanged(int)), SLOT(emitValuesChanged()));
-	connect(z, SIGNAL(valueChanged(int)), SLOT(emitValuesChanged()));
+	connect(x, &QSpinBox::valueChanged, this, &VertexWidget::emitValuesChanged);
+	connect(y, &QSpinBox::valueChanged, this, &VertexWidget::emitValuesChanged);
+	connect(z, &QSpinBox::valueChanged, this, &VertexWidget::emitValuesChanged);
 }
 
 Vertex_s VertexWidget::values() const

--- a/src/widgets/WalkmeshManager.cpp
+++ b/src/widgets/WalkmeshManager.cpp
@@ -73,12 +73,12 @@ WalkmeshManager::WalkmeshManager(QWidget *parent) :
 	layout->addWidget(tabWidget, 5, 0, 1, 4);
 
 	if (walkmesh) {
-		connect(slider1, SIGNAL(valueChanged(int)), walkmesh, SLOT(setXRotation(int)));
-		connect(slider2, SIGNAL(valueChanged(int)), walkmesh, SLOT(setYRotation(int)));
-		connect(slider3, SIGNAL(valueChanged(int)), walkmesh, SLOT(setZRotation(int)));
-		connect(resetCamera, SIGNAL(clicked()), SLOT(resetCamera()));
-		connect(showModels, SIGNAL(toggled(bool)), walkmesh, SLOT(setModelsVisible(bool)));
-		connect(showBackground, SIGNAL(toggled(bool)), walkmesh, SLOT(setBackgroundVisible(bool)));
+		connect(slider1, &QSlider::valueChanged, walkmesh, &WalkmeshWidget::setXRotation);
+		connect(slider2, &QSlider::valueChanged, walkmesh, &WalkmeshWidget::setYRotation);
+		connect(slider3, &QSlider::valueChanged, walkmesh, &WalkmeshWidget::setZRotation);
+		connect(resetCamera, &QPushButton::clicked, this, &WalkmeshManager::resetCamera);
+		connect(showModels, &QCheckBox::toggled, walkmesh, &WalkmeshWidget::setModelsVisible);
+		connect(showBackground, &QCheckBox::toggled, walkmesh, &WalkmeshWidget::setBackgroundVisible);
 	}
 }
 
@@ -101,8 +101,8 @@ QWidget *WalkmeshManager::buildCameraPage()
 	QWidget *ret = new QWidget(this);
 
 	ListWidget *listWidget = new ListWidget(ret);
-	listWidget->addAction(ListWidget::Add, tr("Add camera"), this, SLOT(addCamera()));
-	listWidget->addAction(ListWidget::Rem, tr("Remove camera"), this, SLOT(removeCamera()));
+	listWidget->addAction(ListWidget::Add, tr("Add camera"), this, SLOT(addCamera));
+	listWidget->addAction(ListWidget::Rem, tr("Remove camera"), this, SLOT(removeCamera));
 
 	caToolbar = listWidget->toolBar();
 	camList = listWidget->listWidget();
@@ -145,17 +145,18 @@ QWidget *WalkmeshManager::buildCameraPage()
 	caLayout->setColumnStretch(4, 1);
 	caLayout->setColumnStretch(6, 1);
 
-	connect(camList, SIGNAL(currentRowChanged(int)), SLOT(setCurrentCamera(int)));
+	connect(camList, &QListWidget::currentRowChanged, this, &WalkmeshManager::setCurrentCamera);
 
-	connect(caVectorXEdit, SIGNAL(valuesChanged(Vertex_s)), SLOT(editCaVector(Vertex_s)));
-	connect(caVectorYEdit, SIGNAL(valuesChanged(Vertex_s)), SLOT(editCaVector(Vertex_s)));
-	connect(caVectorZEdit, SIGNAL(valuesChanged(Vertex_s)), SLOT(editCaVector(Vertex_s)));
+	//qOverload is not aware of the Vertex_s type for conversion
+	connect(caVectorXEdit, &VertexWidget::valuesChanged, this, [&] (const Vertex_s &vertex) { editCaVector(vertex);} );
+	connect(caVectorYEdit, &VertexWidget::valuesChanged, this, [&] (const Vertex_s &vertex) { editCaVector(vertex);} );
+	connect(caVectorZEdit, &VertexWidget::valuesChanged, this, [&] (const Vertex_s &vertex) { editCaVector(vertex);} );
 
-	connect(caSpaceXEdit, SIGNAL(valueChanged(double)), SLOT(editCaPos(double)));
-	connect(caSpaceYEdit, SIGNAL(valueChanged(double)), SLOT(editCaPos(double)));
-	connect(caSpaceZEdit, SIGNAL(valueChanged(double)), SLOT(editCaPos(double)));
+	connect(caSpaceXEdit, &QDoubleSpinBox::valueChanged,this , qOverload<double>(&WalkmeshManager::editCaPos));
+	connect(caSpaceYEdit, &QDoubleSpinBox::valueChanged,this , qOverload<double>(&WalkmeshManager::editCaPos));
+	connect(caSpaceZEdit, &QDoubleSpinBox::valueChanged,this , qOverload<double>(&WalkmeshManager::editCaPos));
 
-	connect(caZoomEdit, SIGNAL(valueChanged(int)), SLOT(editCaZoom(int)));
+	connect(caZoomEdit, &QSpinBox::valueChanged, this, &WalkmeshManager::editCaZoom);
 
 	return ret;
 }
@@ -165,8 +166,8 @@ QWidget *WalkmeshManager::buildWalkmeshPage()
 	QWidget *ret = new QWidget(this);
 
 	ListWidget *listWidget = new ListWidget(ret);
-	listWidget->addAction(ListWidget::Add, tr("Add triangle"), this, SLOT(addTriangle()));
-	listWidget->addAction(ListWidget::Rem, tr("Remove triangle"), this, SLOT(removeTriangle()));
+	listWidget->addAction(ListWidget::Add, tr("Add triangle"), this, SLOT(addTriangle));
+	listWidget->addAction(ListWidget::Rem, tr("Remove triangle"), this, SLOT(removeTriangle));
 
 	idToolbar = listWidget->toolBar();
 	idList = listWidget->listWidget();
@@ -208,13 +209,13 @@ QWidget *WalkmeshManager::buildWalkmeshPage()
 	layout->addLayout(accessLayout2, 5, 1, 1, 2);
 	layout->setRowStretch(6, 1);
 
-	connect(idList, SIGNAL(currentRowChanged(int)), SLOT(setCurrentId(int)));
-	connect(idVertices[0], SIGNAL(valuesChanged(Vertex_s)), SLOT(editIdTriangle(Vertex_s)));
-	connect(idVertices[1], SIGNAL(valuesChanged(Vertex_s)), SLOT(editIdTriangle(Vertex_s)));
-	connect(idVertices[2], SIGNAL(valuesChanged(Vertex_s)), SLOT(editIdTriangle(Vertex_s)));
-	connect(idAccess[0], SIGNAL(valueChanged(int)), SLOT(editIdAccess(int)));
-	connect(idAccess[1], SIGNAL(valueChanged(int)), SLOT(editIdAccess(int)));
-	connect(idAccess[2], SIGNAL(valueChanged(int)), SLOT(editIdAccess(int)));
+	connect(idList, &QListWidget::currentRowChanged, this, &WalkmeshManager::setCurrentId);
+	connect(idVertices[0], &VertexWidget::valuesChanged, this, [&] (const Vertex_s &vertex_s) { editIdTriangle(vertex_s); });
+	connect(idVertices[1], &VertexWidget::valuesChanged, this, [&] (const Vertex_s &vertex_s) { editIdTriangle(vertex_s); });
+	connect(idVertices[2], &VertexWidget::valuesChanged, this, [&] (const Vertex_s &vertex_s) { editIdTriangle(vertex_s); });
+	connect(idAccess[0], &QSpinBox::valueChanged, this, qOverload<int>(&WalkmeshManager::editIdAccess));
+	connect(idAccess[1], &QSpinBox::valueChanged, this, qOverload<int>(&WalkmeshManager::editIdAccess));
+	connect(idAccess[2], &QSpinBox::valueChanged, this, qOverload<int>(&WalkmeshManager::editIdAccess));
 
 	return ret;
 }
@@ -256,14 +257,14 @@ QWidget *WalkmeshManager::buildGatewaysPage()
 	layout->addWidget(arrowDisplay, 6, 1, 1, 2);
 	layout->setRowStretch(7, 1);
 
-	connect(gateList, SIGNAL(currentRowChanged(int)), SLOT(setCurrentGateway(int)));
-	connect(gateEnabled, SIGNAL(toggled(bool)), SLOT(editGateEnabled(bool)));
-	connect(exitPoints[0], SIGNAL(valuesChanged(Vertex_s)), SLOT(editExitPoint(Vertex_s)));
-	connect(exitPoints[1], SIGNAL(valuesChanged(Vertex_s)), SLOT(editExitPoint(Vertex_s)));
-	connect(entryPoint, SIGNAL(valuesChanged(Vertex_s)), SLOT(editEntryPoint(Vertex_s)));
-	connect(fieldId, SIGNAL(valueChanged(int)), SLOT(editFieldId(int)));
-	connect(arrowDisplay, SIGNAL(toggled(bool)), SLOT(editArrowDisplay(bool)));
-	connect(exitDirection, SIGNAL(valueChanged(int)), SLOT(editExitDirection(int)));
+	connect(gateList, &QListWidget::currentRowChanged, this, &WalkmeshManager::setCurrentGateway);
+	connect(gateEnabled, &QCheckBox::toggled, this, &WalkmeshManager::editGateEnabled);
+	connect(exitPoints[0], &VertexWidget::valuesChanged, this, [&] (const Vertex_s &vertex_s){ editExitPoint(vertex_s); });
+	connect(exitPoints[1], &VertexWidget::valuesChanged, this, [&] (const Vertex_s &vertex_s){ editExitPoint(vertex_s); });
+	connect(entryPoint, &VertexWidget::valuesChanged, this, [&] (const Vertex_s &vertex_s){ editEntryPoint(vertex_s);});
+	connect(fieldId, &QSpinBox::valueChanged, this, &WalkmeshManager::editFieldId);
+	connect(arrowDisplay, &QCheckBox::toggled, this, &WalkmeshManager::editArrowDisplay);
+	connect(exitDirection, &QSpinBox::valueChanged, this, &WalkmeshManager::editExitDirection);
 
 	return ret;
 }
@@ -311,14 +312,14 @@ QWidget *WalkmeshManager::buildDoorsPage()
 	layout->addLayout(idsLayout, 3, 1, 1, 2);
 	layout->setRowStretch(4, 1);
 
-	connect(doorList, SIGNAL(currentRowChanged(int)), SLOT(setCurrentDoor(int)));
-	connect(doorEnabled, SIGNAL(toggled(bool)), SLOT(editDoorEnabled(bool)));
-	connect(doorPosition[0], SIGNAL(valuesChanged(Vertex_s)), SLOT(editDoorPoint(Vertex_s)));
-	connect(doorPosition[1], SIGNAL(valuesChanged(Vertex_s)), SLOT(editDoorPoint(Vertex_s)));
-	connect(bgParamId, SIGNAL(valueChanged(int)), SLOT(editParamId(int)));
-	connect(bgStateId, SIGNAL(valueChanged(int)), SLOT(editStateId(int)));
-	connect(doorBehavior, SIGNAL(valueChanged(int)), SLOT(editBehavior(int)));
-	connect(doorSoundId, SIGNAL(valueChanged(int)), SLOT(editSoundId(int)));
+	connect(doorList, &QListWidget::currentRowChanged, this, &WalkmeshManager::setCurrentDoor);
+	connect(doorEnabled, &QCheckBox::toggled, this, &WalkmeshManager::editDoorEnabled);
+	connect(doorPosition[0], &VertexWidget::valuesChanged, this, [&] (const Vertex_s &vertex_s){ editDoorPoint(vertex_s);});
+	connect(doorPosition[1], &VertexWidget::valuesChanged, this, [&] (const Vertex_s &vertex_s){ editDoorPoint(vertex_s);});
+	connect(bgParamId, &QSpinBox::valueChanged, this, &WalkmeshManager::editParamId);
+	connect(bgStateId, &QSpinBox::valueChanged, this, &WalkmeshManager::editStateId);
+	connect(doorBehavior, &QSpinBox::valueChanged, this, &WalkmeshManager::editBehavior);
+	connect(doorSoundId, &QSpinBox::valueChanged, this, &WalkmeshManager::editSoundId);
 
 	return ret;
 }
@@ -362,11 +363,11 @@ QWidget *WalkmeshManager::buildArrowPage()
 	layout->setRowStretch(2, 1);
 	layout->setColumnStretch(2, 1);
 
-	connect(arrowList, SIGNAL(currentRowChanged(int)), SLOT(setCurrentArrow(int)));
-	connect(arrowX, SIGNAL(valueChanged(int)), SLOT(editArrowX(int)));
-	connect(arrowY, SIGNAL(valueChanged(int)), SLOT(editArrowY(int)));
-	connect(arrowZ, SIGNAL(valueChanged(int)), SLOT(editArrowZ(int)));
-	connect(arrowType, SIGNAL(currentIndexChanged(int)), SLOT(editArrowType(int)));
+	connect(arrowList, &QListWidget::currentRowChanged, this, &WalkmeshManager::setCurrentArrow);
+	connect(arrowX, &QSpinBox::valueChanged, this, &WalkmeshManager::editArrowX);
+	connect(arrowY, &QSpinBox::valueChanged, this, &WalkmeshManager::editArrowY);
+	connect(arrowZ, &QSpinBox::valueChanged, this, &WalkmeshManager::editArrowZ);
+	connect(arrowType, &QComboBox::currentIndexChanged, this, &WalkmeshManager::editArrowType);
 
 	return ret;
 }
@@ -434,9 +435,9 @@ QWidget *WalkmeshManager::buildCameraRangePage()
 	//layout->addStretch();
 
 	for (int i=0; i<4; ++i) {
-		connect(rangeEdit[i], SIGNAL(valueChanged(int)), SLOT(editRange(int)));
-		connect(bgSizeEdit[i], SIGNAL(valueChanged(int)), SLOT(editRange(int)));
-		connect(bgFlagEdit[i], SIGNAL(valueChanged(int)), SLOT(editRange(int)));
+		connect(rangeEdit[i], &QSpinBox::valueChanged, this, qOverload<int>(&WalkmeshManager::editRange));
+		connect(bgSizeEdit[i], &QSpinBox::valueChanged, this, qOverload<int>(&WalkmeshManager::editRange));
+		connect(bgFlagEdit[i], &QSpinBox::valueChanged, this, qOverload<int>(&WalkmeshManager::editRange));
 	}
 
 	return ret;
@@ -471,11 +472,11 @@ QWidget *WalkmeshManager::buildMiscPage()
 	layout->addWidget(mapScale, 3, 1, 1, 2);
 	layout->setRowStretch(4, 1);
 
-	connect(navigation, SIGNAL(valueEdited(int)), navigation2, SLOT(setValue(int)));
-	connect(navigation2, SIGNAL(valueChanged(int)), SLOT(editNavigation(int)));
-	connect(cameraFocusHeight, SIGNAL(valueChanged(int)), SLOT(editCameraFocusHeight(int)));
-	connect(unknown, SIGNAL(dataEdited(QByteArray)), SLOT(editUnknown(QByteArray)));
-	connect(mapScale, SIGNAL(valueChanged(int)), SLOT(editMapScale(int)));
+	connect(navigation, &OrientationWidget::valueEdited, navigation2, &QSpinBox::setValue);
+	connect(navigation2, &QSpinBox::valueChanged, this, &WalkmeshManager::editNavigation);
+	connect(cameraFocusHeight, &QSpinBox::valueChanged, this, &WalkmeshManager::editCameraFocusHeight);
+	connect(unknown, &HexLineEdit::dataEdited, this, &WalkmeshManager::editUnknown);
+	connect(mapScale, &QSpinBox::valueChanged, this, &WalkmeshManager::editMapScale);
 
 	return ret;
 }


### PR DESCRIPTION
- Stop tracking the string locations in ts files (reduce unneeded updates on them)
- Use Qt5 connections 
  - *ListWidget::addAction needs updating due to how its creates actions*
- Use QPushButton::clicked in place of QPuchButton::released
- Release both Qt5 and Qt6 assets
- Fix up various Clazy / Clang issues