### PR TITLE
List widget cleanup

### DIFF
--- a/lang/Makou_Reactor_fr.ts
+++ b/lang/Makou_Reactor_fr.ts
@@ -1312,6 +1312,37 @@ Certains scripts peuvent y faire référence !</translation>
     </message>
 </context>
 <context>
+    <name>ListWidget</name>
+    <message>
+        <source>Add</source>
+        <translation type="unfinished">Ajouter</translation>
+    </message>
+    <message>
+        <source>Remove</source>
+        <translation type="unfinished">Supprimer</translation>
+    </message>
+    <message>
+        <source>Up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cut</source>
+        <translation type="unfinished">Couper</translation>
+    </message>
+    <message>
+        <source>Copy</source>
+        <translation type="unfinished">Copier</translation>
+    </message>
+    <message>
+        <source>Paste</source>
+        <translation type="unfinished">Coller</translation>
+    </message>
+</context>
+<context>
     <name>MassExportDialog</name>
     <message>
         <source>Mass Export</source>
@@ -6856,11 +6887,11 @@ Le supprimer remplacera les appels à ce texte par des appels au texte qui suit.
     </message>
     <message>
         <source>Add</source>
-        <translation>Ajouter</translation>
+        <translation type="vanished">Ajouter</translation>
     </message>
     <message>
         <source>Remove</source>
-        <translation>Supprimer</translation>
+        <translation type="vanished">Supprimer</translation>
     </message>
     <message>
         <source>Export...</source>

--- a/lang/Makou_Reactor_ja.ts
+++ b/lang/Makou_Reactor_ja.ts
@@ -1200,6 +1200,37 @@ Some scripts can refer to it!</source>
     </message>
 </context>
 <context>
+    <name>ListWidget</name>
+    <message>
+        <source>Add</source>
+        <translation type="unfinished">追加</translation>
+    </message>
+    <message>
+        <source>Remove</source>
+        <translation type="unfinished">削除</translation>
+    </message>
+    <message>
+        <source>Up</source>
+        <translation type="unfinished">上に</translation>
+    </message>
+    <message>
+        <source>Down</source>
+        <translation type="unfinished">下に</translation>
+    </message>
+    <message>
+        <source>Cut</source>
+        <translation type="unfinished">切り取り</translation>
+    </message>
+    <message>
+        <source>Copy</source>
+        <translation type="unfinished">コピー</translation>
+    </message>
+    <message>
+        <source>Paste</source>
+        <translation type="unfinished">貼り付け</translation>
+    </message>
+</context>
+<context>
     <name>MassExportDialog</name>
     <message>
         <source>Mass Export</source>
@@ -6313,11 +6344,11 @@ Are you sure you want to continue?</source>
     </message>
     <message>
         <source>Add</source>
-        <translation type="unfinished">追加</translation>
+        <translation type="obsolete">追加</translation>
     </message>
     <message>
         <source>Remove</source>
-        <translation type="unfinished">削除</translation>
+        <translation type="obsolete">削除</translation>
     </message>
     <message>
         <source>Export...</source>

--- a/src/widgets/FontManager.cpp
+++ b/src/widgets/FontManager.cpp
@@ -26,8 +26,10 @@ FontManager::FontManager(QWidget *parent) :
 	setSizeGripEnabled(true);
 
 	/* ListWidget *listWidget = new ListWidget(this);
-	plusAction = listWidget->addAction(ListWidget::Add, tr("Add"), this, SLOT(addFont()));
-	minusAction = listWidget->addAction(ListWidget::Rem, tr("Remove"), this, SLOT(removeFont()));
+	plusAction = listWidget->addAction(ListWidget::Add);
+	connect(listWidget, &ListWidget::addTriggered, this, &FontManager::addFont);
+	minusAction = listWidget->addAction(ListWidget::Remove);
+	connect(listWidget, &ListWidget::removeTriggered, this, &FontManager::removeFont);
 	toolbar1 = listWidget->toolBar();
 	list1 = listWidget->listWidget(); */
 

--- a/src/widgets/Listwidget.cpp
+++ b/src/widgets/Listwidget.cpp
@@ -51,52 +51,67 @@ void ListWidget::addSeparator(bool invisible)
 	insertAction(nullptr, action);
 }
 
-QAction *ListWidget::addAction(ActionType type, const QString &text,
-							   const QObject *receiver, const char *member, bool invisible)
+QAction *ListWidget::addAction(ActionType type, const QString &overrideText, bool visible)
 {
-	QIcon icon;
-	QKeySequence shortcut;
-	QAction *action;
+	QAction *action = new QAction(this);
+	QString text;
 
 	switch (type) {
 	case Add:
-		icon = QIcon(":images/plus.png");
-		shortcut = QKeySequence("Ctrl++");
+		action->setIcon(QIcon(QStringLiteral(":images/plus.png")));
+		action->setShortcut(QKeySequence("Ctrl++"));
+		text = tr("Add");
+		connect(action, &QAction::triggered, this, &ListWidget::addTriggered);
 		break;
-	case Rem:
-		icon = QIcon(":images/minus.png");
-		shortcut = QKeySequence::Delete;
+	case Remove:
+		action->setIcon(QIcon(QStringLiteral(":images/minus.png")));
+		action->setShortcut(QKeySequence::Delete);
+		text = tr("Remove");
+		connect(action, &QAction::triggered, this, &ListWidget::removeTriggered);
 		break;
 	case Up:
-		icon = QIcon(":images/up.png");
-		shortcut = QKeySequence("Shift+Up");
+		action->setIcon(QIcon(QStringLiteral(":images/up.png")));
+		action->setShortcut(QKeySequence("Shift+Up"));
+		text = tr("Up");
+		connect(action, &QAction::triggered, this, &ListWidget::upTriggered);
 		break;
 	case Down:
-		icon = QIcon(":images/down.png");
-		shortcut = QKeySequence("Shift+Down");
+		action->setIcon(QIcon(QStringLiteral(":images/down.png")));
+		action->setShortcut(QKeySequence("Shift+Down"));
+		text = tr("Down");
+		connect(action, &QAction::triggered, this, &ListWidget::downTriggered);
 		break;
 	case Cut:
-		icon = QIcon(":images/cut.png");
-		shortcut = QKeySequence::Cut;
+		action->setIcon(QIcon(QStringLiteral(":images/cut.png")));
+		action->setShortcut(QKeySequence::Cut);
+		text = tr("Cut");
+		connect(action, &QAction::triggered, this, &ListWidget::cutTriggered);
 		break;
 	case Copy:
-		icon = QIcon(":images/copy.png");
-		shortcut = QKeySequence::Copy;
+		action->setIcon(QIcon(QStringLiteral(":images/copy.png")));
+		action->setShortcut(QKeySequence::Copy);
+		text = tr("Copy");
+		connect(action, &QAction::triggered, this, &ListWidget::copyTriggered);
 		break;
 	case Paste:
-		icon = QIcon(":images/paste.png");
-		shortcut = QKeySequence::Paste;
+		action->setIcon(QIcon(QStringLiteral(":images/paste.png")));
+		action->setShortcut(QKeySequence::Paste);
+		text = tr("Paste");
+		connect(action, &QAction::triggered, this, &ListWidget::pasteTriggered);
 		break;
 	}
 
-	if (invisible) {
-		action = new QAction(icon, text, this);
-		connect(action, SIGNAL(triggered()), receiver, member);
-	} else {
-		action = _toolBar->addAction(icon, text, receiver, member);
+	if(!overrideText.isEmpty()) {
+		text = overrideText;
 	}
-	action->setShortcut(shortcut);
+
+	action->setText(text);
 	action->setStatusTip(text);
+
+	if (visible) {
+		_toolBar->addAction(action);
+	}
+
 	insertAction(nullptr, action);
 
 	return action;

--- a/src/widgets/Listwidget.h
+++ b/src/widgets/Listwidget.h
@@ -21,18 +21,26 @@
 
 class ListWidget : public QWidget
 {
+	Q_OBJECT
 public:
 	enum ActionType {
-		Add, Rem, Up, Down, Cut, Copy, Paste
+		Add, Remove, Up, Down, Cut, Copy, Paste
 	};
 	
 	explicit ListWidget(QWidget *parent = nullptr);
 	void addSeparator(bool invisible = false);
-	QAction *addAction(ActionType type, const QString &text,
-	                   const QObject *receiver, const char *member, bool invisible = false);
+	QAction *addAction(ActionType type, const QString &overrideText = QString(), bool visible = true);
 	
 	QToolBar *toolBar() const;
 	QListWidget *listWidget() const;
+signals:
+	void addTriggered();
+	void removeTriggered();
+	void cutTriggered();
+	void copyTriggered();
+	void pasteTriggered();
+	void upTriggered();
+	void downTriggered();
 private:
 	QToolBar *_toolBar;
 	QListWidget *_listWidget;

--- a/src/widgets/TextManager.cpp
+++ b/src/widgets/TextManager.cpp
@@ -39,8 +39,8 @@ TextManager::TextManager(QWidget *parent) :
 	dispUnusedText->setChecked(Config::value("dispUnusedText", true).toBool());
 
 	ListWidget *listWidget = new ListWidget(this);
-	listWidget->addAction(ListWidget::Add, tr("Add text"), this, SLOT(addText()));
-	listWidget->addAction(ListWidget::Rem, tr("Remove text"), this, SLOT(delText()));
+	listWidget->addAction(ListWidget::Add, tr("Add text"));
+	listWidget->addAction(ListWidget::Remove, tr("Remove text"));
 	liste1 = listWidget->listWidget();
 
 	QAction *action;
@@ -256,6 +256,8 @@ TextManager::TextManager(QWidget *parent) :
 	setLayout(layout);
 	adjustSize();
 
+	connect(listWidget, &ListWidget::addTriggered, this, &TextManager::addText);
+	connect(listWidget, &ListWidget::removeTriggered, this, &TextManager::delText);
 	connect(liste1, &QListWidget::currentItemChanged, this, &TextManager::selectText);
 	connect(dispUnusedText, &QCheckBox::toggled, this, &TextManager::showList);
 	connect(toolBar, &QToolBar::actionTriggered, this, &TextManager::insertTag);

--- a/src/widgets/TutWidget.cpp
+++ b/src/widgets/TutWidget.cpp
@@ -28,12 +28,17 @@ TutWidget::TutWidget(QWidget *parent) :
 	setWindowTitle(tr("Tutorials/Sounds"));
 
 	ListWidget *_list = new ListWidget(this);
-	_list->addAction(ListWidget::Add, tr("Add"), this, SLOT(add()));
-	_list->addAction(ListWidget::Rem, tr("Remove"), this, SLOT(del()));
+	_list->addAction(ListWidget::Add);
+	_list->addAction(ListWidget::Remove);
+	connect(_list, &ListWidget::addTriggered, this, &TutWidget::add);
+	connect(_list, &ListWidget::removeTriggered, this, &TutWidget::del);
 //	_list->addSeparator(true);
-//	_list->addAction(ListWidget::Cut, tr("Cut"), this, SLOT(cutCurrent()), true);
-//	_list->addAction(ListWidget::Copy, tr("Copy"), this, SLOT(copyCurrent()), true);
-//	_list->addAction(ListWidget::Paste, tr("Paste"), this, SLOT(pasteOnCurrent()), true);
+//	_list->addAction(ListWidget::Cut);
+//	connect(_list, &ListWidget::cutTriggered, this, &TutWidget::cutCurrent);
+//	_list->addAction(ListWidget::Copy);
+//	connect(_list, &ListWidget::copyTriggered, this, &TutWidget::copyCurrent);
+//	_list->addAction(ListWidget::Paste);
+//	connect(_list, &ListWidget::pasteTriggered, this, &TutWidget::pasteonCurrent);
 	list = _list->listWidget();
 //	list->setSelectionMode(QAbstractItemView::ExtendedSelection);
 

--- a/src/widgets/WalkmeshManager.cpp
+++ b/src/widgets/WalkmeshManager.cpp
@@ -101,8 +101,10 @@ QWidget *WalkmeshManager::buildCameraPage()
 	QWidget *ret = new QWidget(this);
 
 	ListWidget *listWidget = new ListWidget(ret);
-	listWidget->addAction(ListWidget::Add, tr("Add camera"), this, SLOT(addCamera));
-	listWidget->addAction(ListWidget::Rem, tr("Remove camera"), this, SLOT(removeCamera));
+	listWidget->addAction(ListWidget::Add, tr("Add camera"));
+	connect(listWidget, &ListWidget::addTriggered, this, &WalkmeshManager::addCamera);
+	listWidget->addAction(ListWidget::Remove, tr("Remove camera"));
+	connect(listWidget, &ListWidget::removeTriggered, this, &WalkmeshManager::removeCamera);
 
 	caToolbar = listWidget->toolBar();
 	camList = listWidget->listWidget();
@@ -166,8 +168,10 @@ QWidget *WalkmeshManager::buildWalkmeshPage()
 	QWidget *ret = new QWidget(this);
 
 	ListWidget *listWidget = new ListWidget(ret);
-	listWidget->addAction(ListWidget::Add, tr("Add triangle"), this, SLOT(addTriangle));
-	listWidget->addAction(ListWidget::Rem, tr("Remove triangle"), this, SLOT(removeTriangle));
+	listWidget->addAction(ListWidget::Add, tr("Add triangle"));
+	connect(listWidget, &ListWidget::addTriggered, this, &WalkmeshManager::addTriangle);
+	listWidget->addAction(ListWidget::Remove, tr("Remove triangle"));
+	connect(listWidget, &ListWidget::removeTriggered, this, &WalkmeshManager::removeTriangle);
 
 	idToolbar = listWidget->toolBar();
 	idList = listWidget->listWidget();


### PR DESCRIPTION
Remove the use of SLOT macro in ListWidget

rewrite addAction to do more w/ the known actions if the the text is not overwritten 
 each action is connected to a <actionName>Triggered signal that creator of the ListWidget can connect to when adding the known actions. 
 
Update the items that use ListWidget