### PR TITLE
Update qt and fft7k

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,8 @@ jobs:
       makoureactor_appbundle_path: ${{ github.workspace }}/../appbundle-makoureactor
       CMAKE_GENERATOR: Ninja
       CMAKE_BUILD_TYPE: ${{ matrix.build_type }}
-      ff7tk_package: ff7tk-0.81.00-Qt${{matrix.qt_major}}-${{matrix.ff7tk_pack_suffix}}
+      ff7tk_package: ff7tk-continuous-${{matrix.ff7tk_pack_suffix}}
+
 
     steps:
     - uses: actions/checkout@v2
@@ -126,7 +127,7 @@ jobs:
         cmake --build ${{ env.zlib_build_path }} --target install -j3
 
     - name: Get ff7tk redist
-      run: curl -LJO https://github.com/sithlord48/ff7tk/releases/download/v0.81.0/${{ env.ff7tk_package }}
+      run: curl -LJO https://github.com/sithlord48/ff7tk/releases/download/continuous/${{ env.ff7tk_package }}
 
     - name: Install ff7tk
       run: ${{matrix.ff7tk_install_command_extract}} ${{env.ff7tk_package}} ${{matrix.ff7tk_install_command_dest}}${{env.ff7tk_installation_path}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         qt:
-          - 6.2.0
+          - 6.3.0
         os:
           - ubuntu-latest
           - macos-latest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,7 @@ if(APPLE)
     find_package(QT NAMES Qt6 COMPONENTS Svg REQUIRED)
     find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Svg REQUIRED)
 endif()
-find_package(ff7tk 0.81.00 REQUIRED COMPONENTS ff7tkWidgets ff7tkFormats ff7tkUtils)
+find_package(ff7tk 0.82 REQUIRED COMPONENTS ff7tkWidgets ff7tkFormats ff7tkUtils)
 find_package(ZLIB REQUIRED)
 
 if(${QT_VERSION_MAJOR} EQUAL 6)


### PR DESCRIPTION
Sorry for the extra PR here
- Re use Continuous Build Both on Qt6 no need to force a tag
- Use ff7tk 0.82 for version check (ff7tk is same minor compatible).
- Build with Qt 6.3.0