### PR TITLE
add light and dark color scheme

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -524,6 +524,7 @@ if(GUI)
         
         target_compile_definitions(${GUI_TARGET}
             PRIVATE TASKBAR_BUTTON=1
+            GUI=1
         )
     endif()
     

--- a/src/Data.cpp
+++ b/src/Data.cpp
@@ -863,7 +863,7 @@ const char *Data::musicList2[100] =
 
 QColor Data::color(Color color)
 {
-	bool darkTheme = Config::value("dark_theme", false).toBool();
+	bool darkTheme = Config::inDarkMode();
 
 	switch (color) {
 	case ColorEvidence:

--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -37,9 +37,11 @@ Window::Window() :
     _textDialog(nullptr), _modelManager(nullptr), _tutManager(nullptr), _walkmeshManager(nullptr),
     _backgroundManager(nullptr), _lgpWidget(nullptr), _progressDialog(nullptr), timer(this)
 {
-	QString colorMode = palette().text().color().value() >= QColor(Qt::lightGray).value() ? QStringLiteral("dark") : QStringLiteral("light");
+	qApp->setPalette(Config::paletteForSetting());
+	const QString &colorMode = Config::iconThemeColor();
+	qDebug() << "MODE" << colorMode;
 	QIcon::setFallbackSearchPaths(QIcon::fallbackSearchPaths() << ":/icons/common");
-	QIcon::setFallbackSearchPaths(QIcon::fallbackSearchPaths() << QStringLiteral(":/icons/%1").arg(colorMode));
+	QIcon::setFallbackSearchPaths(QIcon::fallbackSearchPaths() << QStringLiteral(":/icons/mr-%1").arg(colorMode));
 	if (QIcon::themeName().isEmpty()) {
 		QIcon::setThemeName(QStringLiteral("mr-%1").arg(colorMode));
 	} else {

--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -17,6 +17,12 @@
  ****************************************************************************/
 #include "Config.h"
 
+#include <QPalette>
+
+#ifdef GUI
+	#include <QApplication>
+#endif
+
 QSettings *Config::settings = nullptr;
 
 QString Config::programResourceDir()
@@ -49,6 +55,35 @@ QString Config::programLanguagesDir()
 		}
 	}
 	return translationDir.absolutePath();
+}
+
+QPalette Config::paletteForSetting()
+{
+	int index = Config::value("color-scheme").toInt();
+	QPalette newPalette;
+	if( index != 0) {
+		newPalette.setColor(QPalette::Window, index == 1 ? darkWindow : lightWindow);
+		newPalette.setColor(QPalette::Base, index == 1 ? darkButton : lightButton);
+		newPalette.setColor(QPalette::Text, index == 1 ? darkText : lightText);
+		newPalette.setColor(QPalette::AlternateBase, index == 1 ? darkWindow : lightWindow);
+		newPalette.setColor(QPalette::WindowText, index == 1 ? darkText : lightText);
+		newPalette.setColor(QPalette::Button, index == 1 ? darkButton : lightButton);
+		newPalette.setColor(QPalette::ButtonText,index == 1 ? darkText : lightText);
+		newPalette.setColor(QPalette::PlaceholderText, index == 1 ? darkPlaceholderText : lightPlaceholderText);
+		newPalette.setColor(QPalette::Disabled, QPalette::Button, index == 1 ? darkDisableButton : lightDisableButton);
+		newPalette.setColor(QPalette::Disabled, QPalette::Window, index == 1 ? darkDisableButton : lightDisableButton);
+		newPalette.setColor(QPalette::Disabled, QPalette::WindowText, index == 1 ? darkInactiveText : lightInactiveText);
+		newPalette.setColor(QPalette::Disabled,QPalette::ButtonText, index == 1 ? darkInactiveText : lightInactiveText);
+		newPalette.setColor(QPalette::ToolTipBase, index == 1 ? darkText : lightText);
+		newPalette.setColor(QPalette::ToolTipText, index == 1 ? darkWindow : lightWindow);
+		newPalette.setColor(QPalette::Highlight,index == 1 ? darkHighlight : lightHighlight);
+		newPalette.setColor(QPalette::HighlightedText, index == 1 ? darkWindow : lightWindow);
+		newPalette.setColor(QPalette::Inactive, QPalette::HighlightedText, index == 1 ? darkButton : lightButton);
+		newPalette.setColor(QPalette::Active, QPalette::Text, index == 1 ? darkText : lightText);
+		newPalette.setColor(QPalette::Link, index == 1 ? darkLink : lightLink);
+		newPalette.setColor(QPalette::LinkVisited, index == 1 ? darkInactiveText : lightInactiveText);
+	}
+	return newPalette;
 }
 
 void Config::set() {
@@ -95,4 +130,18 @@ void Config::remove(const QString &key)
 void Config::flush()
 {
 	settings->sync();
+}
+
+bool Config::inDarkMode()
+{
+#ifndef GUI
+	return false;
+#else
+	return qApp->palette().text().color().value() >= QColor(Qt::lightGray).value();
+#endif
+}
+
+QString Config::iconThemeColor()
+{
+	return Config::inDarkMode() ? QStringLiteral("dark") : QStringLiteral("light");
 }

--- a/src/core/Config.h
+++ b/src/core/Config.h
@@ -18,12 +18,14 @@
 #pragma once
 
 #include <QtCore>
+#include <QColor>
 
 class Config
 {
 public:
 	static QString programResourceDir();
 	static QString programLanguagesDir();
+	static QPalette paletteForSetting();
 	static void set();
 	static void remove();
 	static QVariant value(const QString &key, const QVariant &defaultValue = QVariant());
@@ -31,6 +33,27 @@ public:
 	static void append(const QString &key, const QVariant &value);
 	static void remove(const QString &key);
 	static void flush();
+	static bool inDarkMode();
+	static QString iconThemeColor();
 private:
 	static QSettings *settings;
+	//Theme Colors
+	inline static const QColor lightWindow = QColor(252, 252, 252);
+	inline static const QColor lightDisableWindow = QColor(192, 192, 192);
+	inline static const QColor lightText = QColor(35, 38, 39);
+	inline static const QColor lightButton = QColor(239, 240, 241);
+	inline static const QColor lightDisableButton = QColor(180, 181, 182);
+	inline static const QColor lightHighlight = QColor(61,174,233);
+	inline static const QColor lightInactiveText = QColor(127,140,141);
+	inline static const QColor lightLink = QColor(41, 128, 185);
+	inline static const QColor lightPlaceholderText = QColor(96, 96, 96);
+	inline static const QColor darkWindow = QColor(35, 38, 41);
+	inline static const QColor darkDisableWindow = QColor(100, 100, 100);
+	inline static const QColor darkText = QColor(239, 240, 241);
+	inline static const QColor darkDisableButton = QColor(67, 74, 81);
+	inline static const QColor darkButton = QColor(49, 54, 59);
+	inline static const QColor darkHighlight = QColor(61,174,233);
+	inline static const QColor darkInactiveText = QColor(189, 195, 199);
+	inline static const QColor darkLink = QColor(41, 128, 185);
+	inline static const QColor darkPlaceholderText = QColor(196, 196, 196);
 };

--- a/src/core/SystemColor.cpp
+++ b/src/core/SystemColor.cpp
@@ -4,8 +4,7 @@
 #ifndef Q_OS_MAC
 
 #define systemColor(dark, light) \
-	bool darkTheme = Config::value("dark_theme", false).toBool(); \
-	return darkTheme ? dark : light;
+    return Config::inDarkMode() ? dark : light;
 
 QColor SystemColor::red()
 {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -72,44 +72,6 @@ int main(int argc, char *argv[])
 		app.installTranslator(&translator3);
 	}
 
-	if (Config::value("dark_theme", false).toBool()) {
-#ifndef Q_OS_DARWIN
-		qApp->setStyle(QStyleFactory::create("Fusion"));
-		QPalette darkPalette;
-		QColor disabledColor = QColor(127, 127, 127);
-		darkPalette.setColor(QPalette::Window, QColor(0x19, 0x19, 0x19));
-		darkPalette.setColor(QPalette::WindowText, Qt::white);
-		darkPalette.setColor(QPalette::Base, QColor(0x20, 0x20, 0x20));
-		darkPalette.setColor(QPalette::AlternateBase, QColor(0x27, 0x27, 0x27));
-		darkPalette.setColor(QPalette::ToolTipBase, QColor(0xFE, 0xFE, 0xFE));
-		darkPalette.setColor(QPalette::ToolTipText, QColor(0xFE, 0xFE, 0xFE));
-		darkPalette.setColor(QPalette::Text, QColor(0xFE, 0xFE, 0xFE));
-		darkPalette.setColor(QPalette::Disabled, QPalette::Text, disabledColor);
-		darkPalette.setColor(QPalette::Button, QColor(0x20, 0x20, 0x20));
-		darkPalette.setColor(QPalette::ButtonText, Qt::white);
-		darkPalette.setColor(QPalette::Disabled, QPalette::ButtonText, disabledColor);
-		darkPalette.setColor(QPalette::BrightText, Qt::red);
-		darkPalette.setColor(QPalette::Link, QColor(42, 130, 218));
-		darkPalette.setColor(QPalette::LinkVisited, QColor(42, 130, 218));
-
-		darkPalette.setColor(QPalette::Highlight, QColor(0x77, 0x77, 0x77));
-		darkPalette.setColor(QPalette::HighlightedText, Qt::white);
-		darkPalette.setColor(QPalette::Disabled, QPalette::HighlightedText, disabledColor);
-
-		darkPalette.setColor(QPalette::Light, QColor(0x34, 0x34, 0x34));
-		darkPalette.setColor(QPalette::Midlight, QColor(0x27, 0x27, 0x27));
-		darkPalette.setColor(QPalette::Dark, QColor(0x7, 0x7, 0x7));
-		darkPalette.setColor(QPalette::Mid, QColor(0x14, 0x14, 0x14));
-		darkPalette.setColor(QPalette::Shadow, Qt::black);
-
-		darkPalette.setColor(QPalette::PlaceholderText, QColor(0x53, 0x53, 0x53));
-
-		qApp->setPalette(darkPalette);
-
-		qApp->setStyleSheet("QToolTip { color: #ffffff; background-color: #2a82da; border: 1px solid white; }");
-#endif
-	}
-
 	if (!Var::load()) {
 		QMessageBox::warning(nullptr, QApplication::translate("main", "Error"),
 		                     QApplication::translate("main", "The file 'var.cfg' could not be loaded.\n"

--- a/src/widgets/ConfigWindow.cpp
+++ b/src/widgets/ConfigWindow.cpp
@@ -69,12 +69,13 @@ ConfigWindow::ConfigWindow(QWidget *parent)
 	dependLayout->addWidget(charButton, 5, 3);
 	dependLayout->setColumnStretch(1, 1);
 
-	QGroupBox *theme = new QGroupBox(tr("Theme"), this);
+	QGroupBox *theme = new QGroupBox(tr("Color Scheme"), this);
 
-	darkMode = new QCheckBox(tr("Dark mode"), theme);
+	comboPalette = new QComboBox(this);
+	comboPalette->addItems({tr("System Theme"), tr("Dark Theme"), tr("Light Theme")});
 
 	QGridLayout *themeLayout = new QGridLayout(theme);
-	themeLayout->addWidget(darkMode, 0, 0);
+	themeLayout->addWidget(comboPalette, 0, 0);
 
 	QGroupBox *openGL = new QGroupBox(tr("OpenGL"), this);
 
@@ -235,7 +236,7 @@ void ConfigWindow::fillConfig()
 		charAuto->setChecked(true);
 	}
 
-	darkMode->setChecked(Config::value("dark_theme", false).toBool());
+	comboPalette->setCurrentIndex(Config::value("color-scheme", 0).toInt());
 	disableOGL->setChecked(!Config::value("OpenGL", true).toBool());
 
 	kernelPath->setText(QDir::toNativeSeparators(QDir::cleanPath(kernel_path)));
@@ -407,7 +408,7 @@ void ConfigWindow::resetColor()
 void ConfigWindow::fillCharNameEdit()
 {
 	int charId = listCharNames->currentIndex();
-	if (charId < 0 || charId > 8) {
+	if (charId < 0 || charId >= 9) {
 		return;
 	}
 
@@ -417,7 +418,7 @@ void ConfigWindow::fillCharNameEdit()
 void ConfigWindow::setCharName(const QString &charName)
 {
 	int charId = listCharNames->currentIndex();
-	if (charId < 0 || charId > 8) {
+	if (charId < 0 || charId >= 9) {
 		return;
 	}
 
@@ -444,8 +445,8 @@ void ConfigWindow::accept()
 	Config::setValue("kernel2Path", kernelAuto->isChecked() ? QDir::fromNativeSeparators(kernelPath->text()) : QString());
 	Config::setValue("windowBinPath", windowAuto->isChecked() ? QDir::fromNativeSeparators(windowPath->text()) : QString());
 	Config::setValue("charPath", charAuto->isChecked() ? QDir::fromNativeSeparators(charPath->text()) : QString());
-	if (darkMode->isChecked() != Config::value("dark_theme", false).toBool()) {
-		Config::setValue("dark_theme", darkMode->isChecked());
+	if (comboPalette->currentIndex() != Config::value("color-scheme", 0).toInt()) {
+		Config::setValue("color-scheme", comboPalette->currentIndex());
 		needsRestart = true;
 	}
 	if (!disableOGL->isChecked() != Config::value("OpenGL", true).toBool()) {

--- a/src/widgets/ConfigWindow.h
+++ b/src/widgets/ConfigWindow.h
@@ -41,6 +41,7 @@ private:
 	DialogPreview *windowPreview;
 	QCheckBox *expandedByDefault;
 	QComboBox *encodings;
+	QComboBox *comboPalette;
 	QRgb windowColorTopLeft, windowColorTopRight, windowColorBottomLeft, windowColorBottomRight;
 	QStringList customNames;
 	QPushButton *encodingEdit;

--- a/src/widgets/TextManager.cpp
+++ b/src/widgets/TextManager.cpp
@@ -134,15 +134,14 @@ TextManager::TextManager(QWidget *parent) :
 	action->setMenu(menuVars);
 	toolBar2->addSeparator();
 
-	QString mode = palette().text().color().value() >= QColor(Qt::lightGray).value() ? QStringLiteral("dark") : QStringLiteral("light");
 	menuKeys = new QMenu(this);
-	action = menuKeys->addAction(QIcon(QStringLiteral(":/psxButtons/%1/circle").arg(mode)), tr("Circle"));
+	action = menuKeys->addAction(QIcon(QStringLiteral(":/psxButtons/%1/circle").arg(Config::iconThemeColor())), tr("Circle"));
 	action->setData("{CIRCLE}");
-	action = menuKeys->addAction(QIcon(QStringLiteral(":/psxButtons/%1/triangle").arg(mode)), tr("Triangle"));
+	action = menuKeys->addAction(QIcon(QStringLiteral(":/psxButtons/%1/triangle").arg(Config::iconThemeColor())), tr("Triangle"));
 	action->setData("{TRIANGLE}");
-	action = menuKeys->addAction(QIcon(QStringLiteral(":/psxButtons/%1/square").arg(mode)), tr("Square"));
+	action = menuKeys->addAction(QIcon(QStringLiteral(":/psxButtons/%1/square").arg(Config::iconThemeColor())), tr("Square"));
 	action->setData("{SQUARE}");
-	action = menuKeys->addAction(QIcon(QStringLiteral(":/psxButtons/%1/cross").arg(mode)), tr("Cross"));
+	action = menuKeys->addAction(QIcon(QStringLiteral(":/psxButtons/%1/cross").arg(Config::iconThemeColor())), tr("Cross"));
 	action->setData("{CROSS}");
 	action = toolBar2->addAction(tr("Keys"));
 	action->setMenu(menuKeys);


### PR DESCRIPTION
 - Use System Color Scheme by default 
 - Add Option for Light and Dark theme 
 - Icons are detected based on theme 
   - *Where icons themes have support the fallback theme is set
   - My Window manager is SSD so it picks and draws the window titles and borders.


![2022-08-20_Configuration_1-1](https://user-images.githubusercontent.com/7450820/185751303-3ef289db-9479-46a6-a747-accb4a188b17.png)

![2022-08-20_Configuration_1-2](https://user-images.githubusercontent.com/7450820/185751339-11089b81-2aa4-4b8b-a864-8f6e89ec5b54.png)

![2022-08-20_Configuration_1-4](https://user-images.githubusercontent.com/7450820/185751502-79200c3c-0488-41c4-8489-bba3ee8cbe23.png)
