### PR TITLE
docs: Remove the vcpkg section

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,16 +39,6 @@ instructions below.
 
 ### Windows
 
-#### vcpkg
-
-> **Please note:**
->
-> Makou Reactor will now use vcpkg as a package manager to resolve dependencies. Failing to follow these steps will fail your builds.
-
-0. Clone the [vcpkg](https://vcpkg.io) project in the root folder of your `C:` drive ( `git clone https://github.com/Microsoft/vcpkg.git` )
-1. Go inside the `C:\vcpkg` folder and double click `bootstrap-vcpkg.bat`
-2. Open a `cmd` window in `C:\vcpkg` and run the following command: `vcpkg integrate install`
-
 #### Qt + Qt Creator
 
 0. Download the online installer from https://www.qt.io/download-qt-installer


### PR DESCRIPTION
As we're using it as a submodule, no more custom steps are required