### PR TITLE
Always Load en ff7tk if no lang is defined

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -75,8 +75,9 @@ int main(int argc, char *argv[])
 	} else {
 		Config::setValue("lang", QVariant());
 	}
-	if (!app.installTranslator(ff7tkInfo::translations().value(lang))) {
-		qDebug() << "Unable to load ff7tk translation";
+
+	if (!app.installTranslator(ff7tkInfo::translations().value(lang.isEmpty() ? "en" : lang))) {
+			qDebug() << "Unable to load ff7tk translation";
 	}
 
 	if (!Var::load()) {


### PR DESCRIPTION
 FF7Tk should always load a translation for the its stored purals English is now loaded if no lang is selected