### PR TITLE
Update names for text preview

### DIFF
--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -1633,6 +1633,7 @@ void Window::textManager(int textID, int from, int size, bool activate)
 		connect(_textDialog, &TextManager::modified, this, [&] {setModified(true);});
 		connect(_textDialog, &TextManager::opcodeModified, _scriptManager, &ScriptManager::refreshOpcode);
 		connect(_scriptManager, &ScriptManager::changed, _textDialog, &TextManager::updateFromScripts);
+		connect(actionJp_txt, &QAction::triggered, _textDialog, &TextManager::updateNames);
 	}
 
 	if (field && field->scriptsAndTexts()->isOpen()) {

--- a/src/widgets/TextManager.cpp
+++ b/src/widgets/TextManager.cpp
@@ -427,6 +427,11 @@ void TextManager::updateFromScripts()
 	}
 }
 
+void TextManager::updateNames()
+{
+	textPreview->updateNames();
+}
+
 void TextManager::gotoText(int textID, qsizetype from, qsizetype size)
 {
 	for (int i=0; i<liste1->count(); ++i) {

--- a/src/widgets/TextManager.h
+++ b/src/widgets/TextManager.h
@@ -39,6 +39,7 @@ signals:
 	void opcodeModified(int groupID, int scriptID, int opcodeID);
 public slots:
 	void updateFromScripts();
+	void updateNames();
 private slots:
 	void selectText(QListWidgetItem *item, QListWidgetItem *previous = nullptr);
 	void showList();

--- a/src/widgets/TextPreview.cpp
+++ b/src/widgets/TextPreview.cpp
@@ -22,6 +22,7 @@
 
 #include <FF7Text>
 #include <FF7Char>
+#include <ff7tkInfo>
 
 QTimer TextPreview::timer;
 int TextPreview::curFrame10 = 0;
@@ -51,10 +52,11 @@ TextPreview::TextPreview(QWidget *parent) :
 void TextPreview::fillNames()
 {
 	FF7Text::setJapanese(Config::value("jp_txt", false).toBool());
-	qDebug() << FF7Text::isJapanese();
+	QString lang = Config::value("jp_txt", false).toBool() ? QStringLiteral("ja") : QStringLiteral("en");
 	for (int i=0; i<12; ++i) {
 		if(i < 9)
-			names.append(FF7Text::toFF7(Config::value(QStringLiteral("customCharName%1").arg(i), FF7Char::defaultName(i)).toString()));
+			names.append(FF7Text::toFF7(Config::value(QStringLiteral("customCharName%1").arg(i)
+													, ff7tkInfo::translations().value(lang)->translate("FF7Char", FF7Char::defaultName(i).toLatin1())).toString()));
 		else
 			names.append(FF7Text::toFF7(tr("Member %1").arg(QString::number(i-8))));
 	}


### PR DESCRIPTION
- Allow `TextPreview` to update names when the jp_txt config value is changed
- Fixes: TextPreview not showing name when encoding does not match loaded language