### PR TITLE
build: Adjust how Translations are built

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -155,11 +155,12 @@ jobs:
         sudo add-apt-repository -y universe
         sudo apt install -y libfuse2 libxkbcommon-x11-0 libxcb-cursor0
         cmake --build ${{ env.makoureactor_build_path }} --target install -j3
+        mkdir -p ${{env.makoureactor_appbundle_path}}/usr/share/ff7tk/translations
+        cp ${{env.ff7tk_installation_path}}/share/ff7tk/translations/*.qm ${{env.makoureactor_appbundle_path}}/usr/share/ff7tk/translations
         mkdir -p ${{env.makoureactor_appbundle_path}}/usr/share/makoureactor/translations
-        cp ${{env.makoureactor_installation_path}}/share/makoureactor/translations/*.qm ${{env.makoureactor_appbundle_path}}/usr/share/makoureactor/translations/
+        cp ${{env.makoureactor_installation_path}}/share/makoureactor/translations/*.qm ${{env.makoureactor_appbundle_path}}/usr/share/makoureactor/translations
         mkdir -p ${{env.makoureactor_appbundle_path}}/usr/plugins/iconengines
         cp ${{ env.qt_installation_path }}/Qt/${{ matrix.qt }}/gcc_64/plugins/iconengines/libqsvgicon.so ${{env.makoureactor_appbundle_path}}/usr/plugins/iconengines/libqsvgicon.so
-
         export VERSION=continuous
         export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:${{ env.ff7tk_installation_path }}/lib
         export PATH=$PATH:${{ env.qt_installation_path }}/Qt/${{ matrix.qt }}/gcc_64/libexec
@@ -204,7 +205,7 @@ jobs:
         rm libff7tk*.deb
     - name: Build
       run: |
-        cmake -S. -Bbuild -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -DQT_DEFAULT_MAJOR_VERSION=6 -DCPACK_DEBIAN_PACKAGE_RELEASE=${{github.run_attempt}}~${{matrix.config.name}} -DBUNDLE_FF7TK_QM=OFF
+        cmake -S. -Bbuild -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -DQT_DEFAULT_MAJOR_VERSION=6 -DCPACK_DEBIAN_PACKAGE_RELEASE=${{github.run_attempt}}~${{matrix.config.name}}
         cmake --build build
         cpack -G DEB -C Release --config build/CPackConfig.cmake
     - name: Upload

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,6 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 option(GUI "Build the gui executable" ON)
 option(CLI "Build the cli executable" OFF)
-option(BUNDLE_FF7TK_QM "Include FF7tk QM Files in bundle" ON)
 
 add_compile_definitions(
     QT_DISABLE_DEPRECATED_BEFORE=0x050F00
@@ -505,20 +504,6 @@ elseif (WIN32)
     set(EXTRA_RESOURCES_CLI "${EXTRA_RESOURCES_GUI}")
 endif()
 
-function(add_translations target)
-    set(oneValueArgs QM_FILES_OUTPUT_VARIABLE)
-    set(multiValueArgs TS_FILES)
-    cmake_parse_arguments(arg "" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
-    set(qm_files "")
-    qt_add_translations(${target}
-        TS_FILES ${TS_FILES}
-        LUPDATE_OPTIONS -locations none
-        QM_FILES_OUTPUT_VARIABLE qm_files)
-    set("${arg_QM_FILES_OUTPUT_VARIABLE}" "${qm_files}" PARENT_SCOPE)
-    # Force lupdate
-    add_dependencies(${target}_lrelease ${target}_lupdate)
-endfunction()
-
 # GUI
 if(GUI)
     qt_add_executable(${GUI_TARGET} MANUAL_FINALIZATION MACOSX_BUNDLE WIN32 ${PROJECT_SOURCES} ${RESOURCES} ${EXTRA_RESOURCES_GUI})
@@ -558,9 +543,8 @@ if(GUI)
         set_target_properties(${GUI_TARGET} PROPERTIES OUTPUT_NAME "${PROJECT_NAME}")
     endif()
 
-    add_translations(${GUI_TARGET}
-        TS_FILES ${TS_FILES}
-        QM_FILES_OUTPUT_VARIABLE QM_FILES)
+    add_subdirectory(translations)
+
 endif()
 
 # CLI
@@ -620,7 +604,6 @@ else()
     install(FILES ${CMAKE_SOURCE_DIR}/src/qt/images/logo-shinra.png DESTINATION share/icons/hicolor/256x256/apps RENAME io.github.myst6re.makoureactor.png)
     install(FILES ${CMAKE_SOURCE_DIR}/deploy/linux/io.github.myst6re.makoureactor.desktop DESTINATION share/applications)
     install(FILES ${CMAKE_SOURCE_DIR}/deploy/linux/io.github.myst6re.makoureactor.metainfo.xml DESTINATION share/metainfo)
-    install(FILES ${QM_FILES} DESTINATION share/makoureactor/translations)
     if(GUI)
         install(TARGETS ${GUI_TARGET} RUNTIME)
     endif()

--- a/deploy/CMakeLists.txt
+++ b/deploy/CMakeLists.txt
@@ -1,14 +1,3 @@
-# Deploy translations
-if(APPLE)
-    set(TRANSLATIONS_PATH ${PROJECT_NAME}.app/Contents/MacOS/translations)
-elseif(WIN32)
-    set(TRANSLATIONS_PATH translations)
-else()
-    set(TRANSLATIONS_PATH share/makoureactor/translations)
-endif()
-
-install(FILES ${QM_FILES} DESTINATION "${TRANSLATIONS_PATH}")
-
 # Deploy ff7tk
 if(VCPKG_TOOLCHAIN)
     cmake_path(SET _ff7tk_ROOT "${ff7tk_DIR}/../..")
@@ -56,10 +45,6 @@ if(WIN32)
     install(FILES ${FF7TK_DEPENDS} DESTINATION ".")
 endif()
 
-list(TRANSFORM LANGS REPLACE ".+" "${_ff7tk_ROOT}/share/ff7tk/translations/ff7tk_\\0.qm" OUTPUT_VARIABLE FF7TK_QM_FILES)
-if(BUNDLE_FF7TK_QM)
-    install(FILES ${FF7TK_QM_FILES} DESTINATION "${TRANSLATIONS_PATH}")
-endif()
 # Deploy Qt using macdeployqt and windeployqt scripts
 if((APPLE AND GUI) OR WIN32)
     install(CODE "set(_target_file_dir \"${QT_DEPLOY_TMP_DIR}\")")

--- a/translations/CMakeLists.txt
+++ b/translations/CMakeLists.txt
@@ -1,0 +1,38 @@
+set_directory_properties(PROPERTIES CLEAN_NO_CUSTOM 1)
+
+if(APPLE)
+    set(TRANSLATIONS_PATH ${PROJECT_NAME}.app/Contents/MacOS/translations)
+elseif(WIN32)
+    set(TRANSLATIONS_PATH translations)
+else()
+    set(TRANSLATIONS_PATH share/makoureactor/translations)
+endif()
+
+find_package(Qt6 ${REQUIRED_QT_VERSION} REQUIRED NO_MODULE COMPONENTS
+    Core
+    LinguistTools
+)
+
+set ( makoureactor_TRS
+    Makou_Reactor_fr.ts
+    Makou_Reactor_ja.ts
+)
+
+qt_create_translation(APP_QM_FILES ${CMAKE_SOURCE_DIR} ${makoureactor_TRS} OPTIONS -no-ui-lines -locations none)
+add_custom_target(app_translations ALL DEPENDS ${APP_QM_FILES})
+install(FILES ${APP_QM_FILES} DESTINATION "${TRANSLATIONS_PATH}")
+
+if(WIN32 OR APPLE)
+    file(REAL_PATH "${ff7tk_DIR}/../../../" ff7tk_ROOT )
+    find_path(_ff7tk_I18N_PATH NAMES translations PATHS "${ff7tk_ROOT}" PATH_SUFFIXES "/share/ff7tk" NO_DEFAULT_PATH REQUIRED)
+    file(REAL_PATH "${_ff7tk_I18N_PATH}/translations" ff7tk_I18N_PATH)
+    install(FILES ${ff7tk_I18N_PATH}/ff7tk_fr.qm DESTINATION "${TRANSLATIONS_PATH}")
+    install(FILES ${ff7tk_I18N_PATH}/ff7tk_ja.qm DESTINATION "${TRANSLATIONS_PATH}")
+    if(APPLE)
+        file(REAL_PATH "${_qt_bin_dir}/../" QT_ROOT_DIR)
+        find_file(_QT_QM_FILE NAMES qtbase_fr.qm PATHS ${QT_ROOT_DIR} PATH_SUFFIXES "translations" "share/qt/translations" REQUIRED)
+        get_filename_component(MAC_QT_LANG_PATH "${_QT_QM_FILE}" DIRECTORY)
+        install(FILES ${MAC_QT_LANG_PATH}/qtbase_fr.qm DESTINATION ${TRANSLATIONS_PATH} RENAME qt_fr.qm)
+        install(FILES ${MAC_QT_LANG_PATH}/qtbase_ja.qm DESTINATION ${TRANSLATIONS_PATH} RENAME qt_ja.qm)
+    endif()
+endif()


### PR DESCRIPTION
- Removes Cmake Option `BUNDLE_FF7TK_QM` 
   - FF7tk translations are installed always for windows and mac platforms.
   - AppImage step installs them
- Deploy Qt Translations in App bundle
- use qt_create_translation to update / release translations
- move translations logic to `translations/CMakeLists.txt`