### PR TITLE
Add local variable usage scope to Variable Manager

### DIFF
--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -990,6 +990,9 @@ void Window::openField(bool reload)
 
 	int mapId = _fieldList->currentMapId();
 	if (mapId < 0) {
+		if (varDialog) {
+			varDialog->setCurrentField(nullptr);
+		}
 		disableEditors();
 		return;
 	}
@@ -1018,6 +1021,9 @@ void Window::openField(bool reload)
 
 	// Get and set field
 	field = fieldArchive->field(mapId, true, true);
+	if (varDialog) {
+		varDialog->setCurrentField(field);
+	}
 	if (!field) {
 		if (fieldArchive->isPC()) {
 			_fieldStackedWidget->setCurrentIndex(1);
@@ -1581,6 +1587,7 @@ void Window::varManager()
 	if (!varDialog) {
 		varDialog = new VarManager(fieldArchive, this);
 	}
+	varDialog->setCurrentField(field);
 	varDialog->show();
 }
 

--- a/src/widgets/VarManager.cpp
+++ b/src/widgets/VarManager.cpp
@@ -17,11 +17,12 @@
  ****************************************************************************/
 #include "VarManager.h"
 #include "core/field/FieldArchive.h"
+#include "core/Config.h"
 #include "core/Var.h"
 #include "../Data.h"
 
 VarManager::VarManager(FieldArchive *fieldArchive, QWidget *parent)
-	: QWidget(parent, Qt::Tool)
+	: QWidget(parent, Qt::Tool), fieldArchive(nullptr), currentField(nullptr)
 {
 	setWindowTitle(tr("Variable manager"));
 
@@ -72,11 +73,18 @@ VarManager::VarManager(FieldArchive *fieldArchive, QWidget *parent)
 
 	QHBoxLayout *layout3 = new QHBoxLayout();
 
-	searchButton = new QPushButton(tr("Addresses Used"), this);
+	searchScope = new QComboBox(this);
+	searchScope->addItem(tr("Global used"), GlobalUsedScope);
+	searchScope->addItem(tr("Local used"), LocalUsedScope);
+
+	const int savedScope = Config::value("varManagerSearchScope", int(GlobalUsedScope)).toInt();
+	const int savedScopeIndex = searchScope->findData(savedScope);
+	searchScope->setCurrentIndex(savedScopeIndex >= 0 ? savedScopeIndex : 0);
+
 	ok = new QPushButton(QIcon::fromTheme(QStringLiteral("document-save")), tr("Save"), this);
 	ok->setEnabled(false);
 
-	layout3->addWidget(searchButton);
+	layout3->addWidget(searchScope);
 	layout3->addStretch();
 	layout3->addWidget(ok);
 
@@ -104,15 +112,55 @@ VarManager::VarManager(FieldArchive *fieldArchive, QWidget *parent)
 	connect(name, &QLineEdit::returnPressed, this, &VarManager::renameVar);
 	connect(rename, &QPushButton::clicked, this, &VarManager::renameVar);
 	connect(ok, &QPushButton::clicked, this, &VarManager::save);
-	connect(searchButton, &QPushButton::clicked, this, &VarManager::search);
+	connect(searchScope, &QComboBox::currentIndexChanged, this, &VarManager::searchScopeChanged);
 
 	adjustSize();
+	const int naturalWidth = width();
+	liste2->setColumnWidth(1, liste2->columnWidth(1) * 5 / 2);
+	resize(naturalWidth * 2, height());
 }
 
 void VarManager::setFieldArchive(FieldArchive *fieldArchive)
 {
 	this->fieldArchive = fieldArchive;
-	searchButton->setEnabled(fieldArchive != nullptr);
+	searchScope->setEnabled(fieldArchive != nullptr);
+
+	if (!fieldArchive) {
+		currentField = nullptr;
+		clearUsageResults();
+		return;
+	}
+
+	if (isVisible()) {
+		search();
+	}
+}
+
+void VarManager::setCurrentField(Field *field)
+{
+	if (currentField == field) {
+		return;
+	}
+
+	currentField = field;
+
+	// Field-list navigation only refreshes usage results in Local used mode.
+	if (searchScope->currentData().toInt() != LocalUsedScope) {
+		return;
+	}
+
+	if (!currentField) {
+		clearUsageResults();
+		return;
+	}
+
+	// During archive replacement, the field can be selected before
+	// setFieldArchive() receives the new archive. Avoid scanning until then.
+	if (isVisible() && fieldArchive) {
+		search();
+	} else {
+		clearUsageResults();
+	}
 }
 
 QPair<quint8, quint8> VarManager::banksFromRow(int row)
@@ -270,22 +318,67 @@ void VarManager::save()
 
 void VarManager::search()
 {
-	QMessageBox mess(QMessageBox::Information, tr("Searching"), tr("Searching, it may take a minute..."));
-	mess.setWindowModality(Qt::ApplicationModal);
-	mess.setWindowFlags(Qt::Dialog | Qt::WindowCloseButtonHint | Qt::MSWindowsFixedSizeDialogHint);
-	mess.setStandardButtons(QMessageBox::NoButton);
-	mess.show();
-	QTimer t(this);
-	connect(&t, &QTimer::timeout, this, &VarManager::processEvents);
-	t.start(700);
-	allVars = fieldArchive->searchAllVars(_fieldNames);
-	quint8 b = quint8(bank->value());
+	clearUsageResults();
 
-	for (quint16 address=0; address<256; ++address) {
-		colorizeItem(liste2->topLevelItem(address), FF7Var(qint8(b), quint8(address), FF7Var::VarSize()));
+	if (searchScope->currentData().toInt() == LocalUsedScope) {
+		if (!currentField) {
+			return;
+		}
+
+		currentField->scriptsAndTexts()->searchAllVars(allVars);
+	} else {
+		if (!fieldArchive) {
+			return;
+		}
+
+		QMessageBox mess(QMessageBox::Information, tr("Searching"), tr("Searching, it may take a minute..."));
+		mess.setWindowModality(Qt::ApplicationModal);
+		mess.setWindowFlags(Qt::Dialog | Qt::WindowCloseButtonHint | Qt::MSWindowsFixedSizeDialogHint);
+		mess.setStandardButtons(QMessageBox::NoButton);
+		mess.show();
+
+		QTimer t(this);
+		connect(&t, &QTimer::timeout, this, &VarManager::processEvents);
+		t.start(700);
+
+		allVars = fieldArchive->searchAllVars(_fieldNames);
+
+		t.stop();
 	}
 
-	t.stop();
+	refreshUsageResults();
+}
+
+void VarManager::searchScopeChanged()
+{
+	Config::setValue("varManagerSearchScope", searchScope->currentData().toInt());
+	search();
+}
+
+void VarManager::clearUsageResults()
+{
+	allVars.clear();
+	_fieldNames.clear();
+	refreshUsageResults();
+}
+
+void VarManager::refreshUsageResults()
+{
+	if (!liste2 || liste2->topLevelItemCount() == 0) {
+		return;
+	}
+
+	quint8 b = quint8(bank->value());
+
+	for (quint16 address = 0; address < 256; ++address) {
+		colorizeItem(liste2->topLevelItem(address), FF7Var(qint8(b), quint8(address), FF7Var::VarSize()));
+	}
+}
+
+void VarManager::showEvent(QShowEvent *event)
+{
+	QWidget::showEvent(event);
+	search();
 }
 
 void VarManager::processEvents() const

--- a/src/widgets/VarManager.h
+++ b/src/widgets/VarManager.h
@@ -21,6 +21,7 @@
 #include "core/field/Opcode.h"
 
 class FieldArchive;
+class Field;
 
 class VarManager : public QWidget
 {
@@ -28,6 +29,9 @@ class VarManager : public QWidget
 public:
 	explicit VarManager(FieldArchive *fieldArchive, QWidget *parent = nullptr);
 	void setFieldArchive(FieldArchive *fieldArchive);
+	void setCurrentField(Field *field);
+protected:
+	void showEvent(QShowEvent *event) override;
 private slots:
 	void scrollToList1(int);
 	void scrollToList2(int);
@@ -37,14 +41,22 @@ private slots:
 	void renameVar();
 	void save();
 	void search();
+	void searchScopeChanged();
 	void processEvents() const;
 
 private:
+	enum SearchScope {
+		GlobalUsedScope = 0,
+		LocalUsedScope = 1
+	};
+
 	QTreeWidgetItem *findList2Item(int);
 	void fillList1();
 	void fillList2();
 	void findVar(const FF7Var &var, bool &foundR, bool &foundW, QSet<FF7Var::VarSize> &varSize);
 	void colorizeItem(QTreeWidgetItem *item, const FF7Var &var);
+	void clearUsageResults();
+	void refreshUsageResults();
 	static quint8 itemAddress(QTreeWidgetItem *item);
 	static int rowFromBank(quint8 bank);
 	static QPair<quint8, quint8> banksFromRow(int row);
@@ -56,12 +68,14 @@ private:
 	QLineEdit *name;
 	QPushButton *rename;
 
-	QPushButton *searchButton, *ok;
+	QPushButton *ok;
+	QComboBox *searchScope;
 
 	QListWidget *liste1;
 	QTreeWidget *liste2;
 
 	FieldArchive *fieldArchive;
+	Field *currentField;
 	QList<FF7Var> allVars;
 	QMap<FF7Var, QSet<QString> > _fieldNames;
 };

--- a/translations/Makou_Reactor_fr.ts
+++ b/translations/Makou_Reactor_fr.ts
@@ -7565,9 +7565,12 @@ Le supprimer remplacera les appels à ce tutoriel par des appels au tutoriel qui
         <translation>Adresse</translation>
     </message>
     <message>
-        <source>Addresses Used</source>
-        <oldsource>Adresses utilisées</oldsource>
-        <translation>Adresses utilisées</translation>
+        <source>Global used</source>
+        <translation>Utilisées globalement</translation>
+    </message>
+    <message>
+        <source>Local used</source>
+        <translation>Utilisées localement</translation>
     </message>
     <message>
         <source>Error</source>

--- a/translations/Makou_Reactor_ja.ts
+++ b/translations/Makou_Reactor_ja.ts
@@ -6949,10 +6949,12 @@ Are you sure you want to continue?</source>
         <translation type="unfinished">アドレス</translation>
     </message>
     <message>
-        <source>Addresses Used</source>
-        <oldsource>Adresses utilisées</oldsource>
-        <translatorcomment>Adresses used</translatorcomment>
-        <translation type="unfinished">アドレスに適用</translation>
+        <source>Global used</source>
+        <translation>全フィールドで使用</translation>
+    </message>
+    <message>
+        <source>Local used</source>
+        <translation>現在のフィールドで使用</translation>
     </message>
     <message>
         <source>Error</source>


### PR DESCRIPTION
Fixes #223. Updates the Variable Manager variable-usage display with Global used and Local used scopes. Removes the separate Addresses Used button, remembers the selected scope, runs the selected search when the Variable Manager opens, refreshes Local used when the selected field changes without rescanning Global used, widens the Variable Manager window and Nickname column, and adds French and Japanese translations. Global used retains the existing archive-wide search. Local used scans only the currently selected field using the existing per-field variable search implementation.