### PR TITLE
Fix script editor crashes from stale script pointers

### DIFF
--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -458,6 +458,13 @@ int Window::closeFile(bool quit)
 			_lgpWidget = nullptr;
 		}
 
+		// Detach every editor/manager from Field/Section1File objects before the
+		// archive deletes those objects. Several dialogs survive archive changes.
+		disableEditors();
+		_scriptManager->removeCopiedReferences();
+		_scriptManager->clear();
+		searchDialog->setFieldArchive(nullptr);
+
 		if (fieldArchive != nullptr) {
 			delete fieldArchive;
 			fieldArchive = nullptr;
@@ -469,9 +476,6 @@ int Window::closeFile(bool quit)
 		_fieldList->setEnabled(false);
 		_fieldList->blockSignals(false);
 
-		disableEditors();
-		_scriptManager->removeCopiedReferences();
-		_scriptManager->clear();
 		if (_modelManager) {
 			_modelManager->close();
 			_modelManager->deleteLater();
@@ -479,7 +483,6 @@ int Window::closeFile(bool quit)
 		}
 		setWindowModified(false);
 		setWindowTitle();
-		searchDialog->setFieldArchive(nullptr);
 
 		actionSave->setEnabled(false);
 		actionSaveAs->setEnabled(false);
@@ -1041,7 +1044,9 @@ void Window::openField(bool reload)
 		//	modelThread->setField(field);
 		//}
 	}
-	if (_textDialog && (reload || _textDialog->isVisible())) {
+	if (_textDialog) {
+		// TextManager stays connected to ScriptManager::changed even while hidden,
+		// therefore its backing Section1File must always follow the current field.
 		_textDialog->setField(field, reload);
 		_textDialog->setEnabled(true);
 	}

--- a/src/widgets/GrpScriptList.cpp
+++ b/src/widgets/GrpScriptList.cpp
@@ -321,8 +321,6 @@ void GrpScriptList::add()
 
 	const int grpScriptID = qBound(0, selectedID() + 1, int(_scripts->grpScriptCount()));
 
-	// ScriptList/OpcodeList keep pointers into Section1File::_grpScripts.
-	// QList insertion can relocate elements, so detach those pointers first.
 	emit aboutToChange();
 	if (!_scripts->insertGrpScript(grpScriptID, GrpScript())) {
 		return;

--- a/src/widgets/GrpScriptList.cpp
+++ b/src/widgets/GrpScriptList.cpp
@@ -19,6 +19,7 @@
 #include "Data.h"
 #include "core/field/Section1File.h"
 #include <FF7Char>
+#include <algorithm>
 
 GrpScriptList::GrpScriptList(QWidget *parent) :
     QTreeWidget(parent), _scripts(nullptr)
@@ -305,7 +306,8 @@ void GrpScriptList::renameOK(QTreeWidgetItem *item, int column)
 	}
 
 	int groupID = item->text(0).toInt();
-	if (groupID >= 0 && _scripts->grpScript(groupID).name() != newName) {
+	if (groupID >= 0 && groupID < _scripts->grpScriptCount()
+	        && _scripts->grpScript(groupID).name() != newName) {
 		_scripts->grpScript(groupID).setName(newName);
 		emit changed();
 	}
@@ -313,13 +315,19 @@ void GrpScriptList::renameOK(QTreeWidgetItem *item, int column)
 
 void GrpScriptList::add()
 {
-	if (_scripts == nullptr || topLevelItemCount() > _scripts->maxGrpScriptCount()) {
+	if (_scripts == nullptr || topLevelItemCount() >= _scripts->maxGrpScriptCount()) {
 		return;
 	}
 
-	int grpScriptID = selectedID() + 1;
+	const int grpScriptID = qBound(0, selectedID() + 1, int(_scripts->grpScriptCount()));
 
-	_scripts->insertGrpScript(grpScriptID, GrpScript());
+	// ScriptList/OpcodeList keep pointers into Section1File::_grpScripts.
+	// QList insertion can relocate elements, so detach those pointers first.
+	emit aboutToChange();
+	if (!_scripts->insertGrpScript(grpScriptID, GrpScript())) {
+		return;
+	}
+
 	fill();
 	scroll(grpScriptID);
 	emit changed();
@@ -346,7 +354,16 @@ void GrpScriptList::del(bool totalDel)
 	}
 
 	std::sort(selectedIDs.begin(), selectedIDs.end());
-	for (int i = selectedIDs.size() - 1; i >= 0; --i) {
+	selectedIDs.erase(std::remove_if(selectedIDs.begin(), selectedIDs.end(),
+	                                 [this](int id) {
+		return id < 0 || id >= _scripts->grpScriptCount();
+	}), selectedIDs.end());
+	if (selectedIDs.isEmpty()) {
+		return;
+	}
+
+	emit aboutToChange();
+	for (qsizetype i = selectedIDs.size(); i-- > 0;) {
 		_scripts->removeGrpScript(selectedIDs.at(i));
 	}
 
@@ -396,13 +413,26 @@ void GrpScriptList::paste()
 	if (_scripts == nullptr || _grpScriptCopied.isEmpty()) {
 		return;
 	}
+
+	const qsizetype available = _scripts->maxGrpScriptCount() - _scripts->grpScriptCount();
+	const qsizetype pasteCount = qMin(available, _grpScriptCopied.size());
+	if (pasteCount <= 0) {
+		return;
+	}
+
 	int grpScriptID = selectedID() + 1;
 	if (grpScriptID == 0) {
 		grpScriptID = topLevelItemCount(); // Last position
 	}
-	int i = grpScriptID;
-	for (const GrpScript &GScopied : std::as_const(_grpScriptCopied)) {
-		_scripts->insertGrpScript(i++, GScopied);
+	grpScriptID = qBound(0, grpScriptID, int(_scripts->grpScriptCount()));
+
+	emit aboutToChange();
+	int insertAt = grpScriptID;
+	for (qsizetype copiedID = 0; copiedID < pasteCount; ++copiedID) {
+		if (!_scripts->insertGrpScript(insertAt, _grpScriptCopied.at(copiedID))) {
+			break;
+		}
+		++insertAt;
 	}
 
 	fill();
@@ -421,13 +451,23 @@ void GrpScriptList::move(bool direction)
 	if (_scripts == nullptr) {
 		return;
 	}
-	int grpScriptID = selectedID();
-	if (grpScriptID == -1) {
+	const int grpScriptID = selectedID();
+	if (grpScriptID < 0 || grpScriptID >= _scripts->grpScriptCount()) {
 		return;
 	}
+
+	const bool canMove = direction
+	        ? grpScriptID < _scripts->grpScriptCount() - 1
+	        : grpScriptID > 0;
+	if (!canMove) {
+		setFocus();
+		return;
+	}
+
+	emit aboutToChange();
 	if (_scripts->moveGrpScript(grpScriptID, direction)) {
 		fill();
-		scroll(direction ? grpScriptID+1 : grpScriptID-1);
+		scroll(direction ? grpScriptID + 1 : grpScriptID - 1);
 		emit changed();
 	} else {
 		setFocus();

--- a/src/widgets/GrpScriptList.h
+++ b/src/widgets/GrpScriptList.h
@@ -69,6 +69,9 @@ private slots:
 	void upDownEnabled();
 
 signals:
+	// Emitted synchronously before _scripts->_grpScripts is structurally modified.
+	// Consumers holding pointers/references into that container must detach here.
+	void aboutToChange();
 	void changed();
 
 private:

--- a/src/widgets/GrpScriptList.h
+++ b/src/widgets/GrpScriptList.h
@@ -69,8 +69,7 @@ private slots:
 	void upDownEnabled();
 
 signals:
-	// Emitted synchronously before _scripts->_grpScripts is structurally modified.
-	// Consumers holding pointers/references into that container must detach here.
+	// Lets ScriptManager release cached GrpScript/Script pointers before the list changes.
 	void aboutToChange();
 	void changed();
 

--- a/src/widgets/OpcodeList.cpp
+++ b/src/widgets/OpcodeList.cpp
@@ -89,7 +89,7 @@ OpcodeList::OpcodeList(QWidget *parent) :
 	disableTree_A = new QAction(tr("Disable tree"), this);
 	search_A = new QAction(tr("Search opcode..."), this);
 
-	connect(edit_A, &QAction::triggered, this, [this]() { scriptEditor(true); });
+	connect(edit_A, &QAction::triggered, this, &OpcodeList::scriptEditor);
 	connect(add_A, &QAction::triggered, this, &OpcodeList::add);
 	connect(del_A, &QAction::triggered, this, &OpcodeList::del);
 	connect(cut_A, &QAction::triggered, this, &OpcodeList::cut);
@@ -170,8 +170,7 @@ OpcodeList::OpcodeList(QWidget *parent) :
 	setMinimumWidth(_toolBar->sizeHint().width());
 	setMinimumHeight(_toolBar->sizeHint().width());
 
-	connect(this, &OpcodeList::itemDoubleClicked, this,
-	        [this](QTreeWidgetItem *, int) { scriptEditor(true); });
+	connect(this, &OpcodeList::itemDoubleClicked, this, &OpcodeList::scriptEditor);
 	connect(this, &OpcodeList::itemSelectionChanged, this, &OpcodeList::itemSelected);
 	connect(this, &OpcodeList::currentItemChanged, this, &OpcodeList::evidence);
 	connect(QApplication::clipboard(), &QClipboard::changed, this, &OpcodeList::adjustPasteAction);

--- a/src/widgets/OpcodeList.cpp
+++ b/src/widgets/OpcodeList.cpp
@@ -22,6 +22,7 @@
 #include "Data.h"
 #include "core/field/Field.h"
 #include "core/field/Opcode.h"
+#include <algorithm>
 
 OpcodeList::OpcodeList(QWidget *parent) :
     QTreeWidget(parent), _field(nullptr), _grpScript(nullptr), _script(nullptr), errorLine(-1),
@@ -88,7 +89,7 @@ OpcodeList::OpcodeList(QWidget *parent) :
 	disableTree_A = new QAction(tr("Disable tree"), this);
 	search_A = new QAction(tr("Search opcode..."), this);
 
-	connect(edit_A, &QAction::triggered, this, &OpcodeList::scriptEditor);
+	connect(edit_A, &QAction::triggered, this, [this]() { scriptEditor(true); });
 	connect(add_A, &QAction::triggered, this, &OpcodeList::add);
 	connect(del_A, &QAction::triggered, this, &OpcodeList::del);
 	connect(cut_A, &QAction::triggered, this, &OpcodeList::cut);
@@ -169,7 +170,8 @@ OpcodeList::OpcodeList(QWidget *parent) :
 	setMinimumWidth(_toolBar->sizeHint().width());
 	setMinimumHeight(_toolBar->sizeHint().width());
 
-	connect(this, &OpcodeList::itemDoubleClicked, this, &OpcodeList::scriptEditor);
+	connect(this, &OpcodeList::itemDoubleClicked, this,
+	        [this](QTreeWidgetItem *, int) { scriptEditor(true); });
 	connect(this, &OpcodeList::itemSelectionChanged, this, &OpcodeList::itemSelected);
 	connect(this, &OpcodeList::currentItemChanged, this, &OpcodeList::evidence);
 	connect(QApplication::clipboard(), &QClipboard::changed, this, &OpcodeList::adjustPasteAction);
@@ -426,9 +428,13 @@ void OpcodeList::fill(Field *field, const GrpScript *grpScript, Script *script)
 void OpcodeList::fill()
 {
 	previousBG = QBrush();
-	blockSignals(true);
-	QTreeWidget::clear();
-	blockSignals(false);
+	{
+		// Preserve an outer blocked state (ScriptManager::fillOpcodes blocks us).
+		// Calling blockSignals(false) unconditionally here used to re-enable signals
+		// in the middle of a caller's protected refresh.
+		const QSignalBlocker signalBlocker(this);
+		QTreeWidget::clear();
+	}
 
 	if (_field == nullptr || _script == nullptr) {
 		return;
@@ -740,7 +746,8 @@ void OpcodeList::redo()
 
 void OpcodeList::scriptEditor(bool modify)
 {
-	if (_script == nullptr) {
+	if (_field == nullptr || _grpScript == nullptr || _script == nullptr
+	        || _field->scriptsAndTexts() == nullptr) {
 		return;
 	}
 
@@ -760,46 +767,62 @@ void OpcodeList::scriptEditor(bool modify)
 		++opcodeID;
 	}
 
-	ScriptEditor editor(_field, _field->scriptsAndTexts(), *_grpScript, *_script, opcodeID, modify, isInit, this);
+	Opcode opcode;
+	bool needsLabel = false;
 
-	if (editor.exec() == QDialog::Accepted) {
-		Opcode opcode = editor.buildOpcode();
-	
-		if (modify) {
-			_script->setOpcode(opcodeID, opcode);
-		} else {
-			_script->insertOpcode(opcodeID, opcode);
-		}
+	// Extract everything needed from the modal editor, then destroy it before
+	// mutating the live Script and emitting change notifications. Editor pages
+	// retain references to the current GrpScript/Script while the dialog exists.
+	{
+		ScriptEditor editor(_field, _field->scriptsAndTexts(), *_grpScript, *_script,
+		                    opcodeID, modify, isInit, this);
 
-		if (editor.needsLabel()) {
-			OpcodeLABEL label;
-			label._label = quint16(opcode.label());
-			_script->insertOpcode(opcodeID + 1, label);
+		if (editor.exec() != QDialog::Accepted) {
+			return;
 		}
 
-		fill();
-		QTreeWidgetItem *item = findItem(opcodeID);
-		if (item != nullptr) {
-			setCurrentItem(item);
-		}
-		if (modify) {
-			if (editor.needsLabel()) {
-				changeHist(ModifyAndAddLabel, QList<int>() << opcodeID << (opcodeID + 1), QList<Opcode>() << oldVersion);
-			} else {
-				changeHist(Modify, opcodeID, oldVersion);
-			}
-		} else {
-			if (item != nullptr) {
-				scrollToItem(item, QAbstractItemView::EnsureVisible);
-			}
-			if (editor.needsLabel()) {
-				changeHist(Add, QList<int>() << opcodeID << (opcodeID + 1));
-			} else {
-				changeHist(Add, opcodeID);
-			}
-		}
-		emit changed();
+		opcode = editor.buildOpcode();
+		needsLabel = editor.needsLabel();
 	}
+
+	if (modify) {
+		_script->setOpcode(opcodeID, opcode);
+	} else {
+		_script->insertOpcode(opcodeID, opcode);
+	}
+
+	if (needsLabel) {
+		OpcodeLABEL label;
+		label._label = quint16(opcode.label());
+		_script->insertOpcode(opcodeID + 1, label);
+	}
+
+	fill();
+	QTreeWidgetItem *item = findItem(opcodeID);
+	if (item != nullptr) {
+		setCurrentItem(item);
+	}
+
+	if (modify) {
+		if (needsLabel) {
+			changeHist(ModifyAndAddLabel,
+			           QList<int>() << opcodeID << (opcodeID + 1),
+			           QList<Opcode>() << oldVersion);
+		} else {
+			changeHist(Modify, opcodeID, oldVersion);
+		}
+	} else {
+		if (item != nullptr) {
+			scrollToItem(item, QAbstractItemView::EnsureVisible);
+		}
+		if (needsLabel) {
+			changeHist(Add, QList<int>() << opcodeID << (opcodeID + 1));
+		} else {
+			changeHist(Add, opcodeID);
+		}
+	}
+
+	emit changed();
 }
 
 void OpcodeList::del(bool totalDel)
@@ -808,6 +831,11 @@ void OpcodeList::del(bool totalDel)
 		return;
 	}
 	QList<int> selectedIDs = this->selectedIDs();
+	std::sort(selectedIDs.begin(), selectedIDs.end());
+	selectedIDs.erase(std::remove_if(selectedIDs.begin(), selectedIDs.end(),
+	                                 [this](int id) {
+		return id < 0 || id >= _script->size();
+	}), selectedIDs.end());
 	if (selectedIDs.isEmpty()) {
 		return;
 	}
@@ -825,14 +853,11 @@ void OpcodeList::del(bool totalDel)
 	}
 
 	saveExpandedItems();
-	
-	std::sort(selectedIDs.begin(), selectedIDs.end());
-	for (qsizetype i = selectedIDs.size() - 1; i >= 0; --i) {
-		int opId = selectedIDs.at(i);
-		if (opId >= 0 && opId < _script->size()) {
-			oldVersions.prepend(_script->opcode(quint16(opId)));
-			_script->removeOpcode(quint16(opId));
-		}
+
+	for (qsizetype i = selectedIDs.size(); i-- > 0;) {
+		const int opcodeID = selectedIDs.at(i);
+		oldVersions.prepend(_script->opcode(opcodeID));
+		_script->removeOpcode(opcodeID);
 	}
 
 	fill();

--- a/src/widgets/ScriptManager.cpp
+++ b/src/widgets/ScriptManager.cpp
@@ -71,9 +71,8 @@ ScriptManager::ScriptManager(QWidget *parent) :
 	contentLayout->setColumnStretch(2, 9);
 
 	connect(_groupScriptList, &GrpScriptList::aboutToChange, this, [this]() {
-		// GrpScriptList mutates a QList<GrpScript>. ScriptList and OpcodeList cache
-		// pointers into that QList, so they must be detached while those pointers
-		// are still valid, before insert/remove/swap can invalidate them.
+		// OpcodeList::clear() drops its Script/GrpScript pointers; ScriptList::clear()
+		// drops its GrpScript pointer. Do this before the group list can relocate them.
 		const QSignalBlocker scriptSignals(_scriptList);
 		const QSignalBlocker opcodeSignals(_opcodeList);
 		_opcodeList->saveExpandedItems();

--- a/src/widgets/ScriptManager.cpp
+++ b/src/widgets/ScriptManager.cpp
@@ -70,6 +70,16 @@ ScriptManager::ScriptManager(QWidget *parent) :
 	contentLayout->setColumnStretch(1, 1);
 	contentLayout->setColumnStretch(2, 9);
 
+	connect(_groupScriptList, &GrpScriptList::aboutToChange, this, [this]() {
+		// GrpScriptList mutates a QList<GrpScript>. ScriptList and OpcodeList cache
+		// pointers into that QList, so they must be detached while those pointers
+		// are still valid, before insert/remove/swap can invalidate them.
+		const QSignalBlocker scriptSignals(_scriptList);
+		const QSignalBlocker opcodeSignals(_opcodeList);
+		_opcodeList->saveExpandedItems();
+		_opcodeList->clear();
+		_scriptList->clear();
+	});
 	connect(_groupScriptList, &GrpScriptList::changed, this, &ScriptManager::changed);
 	connect(_groupScriptList, &GrpScriptList::itemSelectionChanged, this, &ScriptManager::fillScripts);
 
@@ -149,6 +159,11 @@ void ScriptManager::fillScripts()
 		_scriptList->blockSignals(false);
 		// Select first entry
 		_scriptList->setCurrentRow(0);
+	} else {
+		const QSignalBlocker scriptSignals(_scriptList);
+		const QSignalBlocker opcodeSignals(_opcodeList);
+		_opcodeList->clear();
+		_scriptList->clear();
 	}
 	emit groupScriptCurrentChanged(_groupScriptList->selectedID());
 }
@@ -180,6 +195,9 @@ void ScriptManager::fillOpcodes()
 		_opcodeList->setIsInit(_scriptList->selectedID() == 0);
 		// Scroll to top
 		_opcodeList->scroll(0, false);
+	} else {
+		const QSignalBlocker opcodeSignals(_opcodeList);
+		_opcodeList->clear();
 	}
 }
 

--- a/src/widgets/TextManager.cpp
+++ b/src/widgets/TextManager.cpp
@@ -290,18 +290,27 @@ void TextManager::focusInEvent(QFocusEvent *)
 
 void TextManager::setField(Field *field, bool reload)
 {
-	if (!field
-	        || (!reload && this->scriptsAndTexts == field->scriptsAndTexts())
-	        || !field->scriptsAndTexts()->isOpen()) {
+	Section1File *newScriptsAndTexts = field != nullptr ? field->scriptsAndTexts() : nullptr;
+
+	// TextManager remains connected to ScriptManager::changed even while hidden.
+	// Never leave it retaining data from a deleted/closed field.
+	if (newScriptsAndTexts == nullptr || !newScriptsAndTexts->isOpen()) {
+		clear();
+		return;
+	}
+
+	if (!reload && scriptsAndTexts == newScriptsAndTexts) {
 		return;
 	}
 
 	clear();
-	this->scriptsAndTexts = field->scriptsAndTexts();
+	scriptsAndTexts = newScriptsAndTexts;
 	usedTexts = scriptsAndTexts->listUsedTexts();
 	showList();
-	liste1->setCurrentRow(0);
-	selectText(liste1->item(0));
+	if (liste1->count() > 0) {
+		liste1->setCurrentRow(0);
+		selectText(liste1->item(0));
+	}
 }
 
 void TextManager::clear()
@@ -414,6 +423,14 @@ void TextManager::updateText()
 
 void TextManager::updateFromScripts()
 {
+	// This slot is connected for the lifetime of TextManager. The dialog can be
+	// hidden/cleared while ScriptManager continues to emit changed(), so the
+	// backing Section1File is not guaranteed to be set here.
+	if (scriptsAndTexts == nullptr) {
+		usedTexts.clear();
+		return;
+	}
+
 	usedTexts = scriptsAndTexts->listUsedTexts();
 
 	for (int row = 0; row < liste1->count(); ++row) {


### PR DESCRIPTION
Observed reproduction: Makou Reactor could terminate immediately with no warning while editing script opcodes, including changing the Priority value of opcode 05 (PRQSW).

The Priority value itself is not the root cause. The edit path can expose stale UI pointers retained after the underlying script/group containers or field archive have changed.

This change focuses only on those lifetime issues:
- emit a pre-mutation `GrpScriptList::aboutToChange()` signal before insert/remove/paste/move operations;
- before that group list changes, save the opcode expansion state and clear `OpcodeList` / `ScriptList` so their cached `Script*` / `GrpScript*` pointers are released while still valid;
- clear child script/opcode lists when there is no valid current group/script;
- validate group/opcode selections before structural operations;
- validate the Field / GrpScript / Script pointers before opening the opcode editor;
- destroy the modal ScriptEditor before mutating the live Script and emitting refresh signals;
- detach editors/managers before deleting a field archive;
- keep TextManager synchronized with the active field even while hidden and guard against a null/stale backing Section1File pointer.

Why the pre-mutation notification is needed: `ScriptList` caches a pointer to a `GrpScript`, while `OpcodeList` caches pointers to the current `GrpScript` and `Script`. Those objects live inside `Section1File::_grpScripts`. A structural QList change can relocate/remove them. The normal post-change refill is too late because `OpcodeList::fill()` first calls `saveExpandedItems()` on its previous `_script` before replacing that pointer. Clearing the cached pointers before the list mutation avoids that stale dereference.

The goal is to prevent stale pointer dereferences that can otherwise surface later during an ordinary opcode edit such as changing opcode 05 Priority.

This PR deliberately excludes the separate opcode serialization/bounds hardening so the crash/lifetime fix remains focused and reviewable.
