### PR TITLE
Harden opcode and script data handling

### DIFF
--- a/src/core/field/Opcode.cpp
+++ b/src/core/field/Opcode.cpp
@@ -72,11 +72,6 @@ Opcode &Opcode::operator=(const Opcode &other) noexcept
 
 void Opcode::setParams(const char *params, qsizetype maxSize)
 {
-	if (maxSize < 0 || (params == nullptr && maxSize > 0)) {
-		qWarning() << "Opcode::setParams" << id() << "invalid parameter buffer" << maxSize;
-		maxSize = 0;
-	}
-
 	// params can theoretically point into this Opcode's dynamic storage. Make a
 	// private copy before releasing/zeroing the old union contents.
 	const QByteArray source = maxSize > 0 ? QByteArray(params, maxSize) : QByteArray();
@@ -134,10 +129,6 @@ QByteArray Opcode::params() const
 
 int Opcode::subParam(qsizetype cur, qsizetype sizeInBits) const
 {
-	if (cur < 0 || sizeInBits <= 0 || sizeInBits > 32) {
-		return 0;
-	}
-
 	const QByteArray p = params();
 	const qsizetype byteOffset = cur / 8;
 	const qsizetype bitOffset = cur % 8;

--- a/src/core/field/Opcode.cpp
+++ b/src/core/field/Opcode.cpp
@@ -72,32 +72,53 @@ Opcode &Opcode::operator=(const Opcode &other) noexcept
 
 void Opcode::setParams(const char *params, qsizetype maxSize)
 {
-	if (id() == OpcodeKey::SPECIAL && maxSize > 0) {
-		_opcode.opcodeSPECIAL.subKey = params[0];
+	if (maxSize < 0 || (params == nullptr && maxSize > 0)) {
+		qWarning() << "Opcode::setParams" << id() << "invalid parameter buffer" << maxSize;
+		maxSize = 0;
 	}
 
-	quint8 fixedParamsSize = fixedSize() - 1;
+	// params can theoretically point into this Opcode's dynamic storage. Make a
+	// private copy before releasing/zeroing the old union contents.
+	const QByteArray source = maxSize > 0 ? QByteArray(params, maxSize) : QByteArray();
 
-	if (fixedParamsSize > maxSize) {
-		qWarning() << "Opcode::setParams" << id() << "fixed size exceeded" << fixedParamsSize << maxSize;
-		fixedParamsSize = quint8(maxSize);
+	// KAWAI and Unused1C own a QByteArray* inside the packed opcode union.
+	// Free it before memset() overwrites the pointer.
+	deleteResizableData();
+
+	const qsizetype maxStructSize = qsizetype(sizeof(_opcode) - sizeof(_opcode.id));
+	memset(reinterpret_cast<char *>(&_opcode) + sizeof(_opcode.id), 0, size_t(maxStructSize));
+
+	if (id() == OpcodeKey::SPECIAL && !source.isEmpty()) {
+		_opcode.opcodeSPECIAL.subKey = quint8(source.at(0));
 	}
 
-	qsizetype maxStructSize = sizeof(_opcode) - sizeof(_opcode.id);
-	memcpy(reinterpret_cast<char *>(&_opcode) + sizeof(_opcode.id), params, size_t(fixedParamsSize));
-	if (fixedParamsSize < maxStructSize) {
-		memset(reinterpret_cast<char *>(&_opcode) + sizeof(_opcode.id) + fixedParamsSize, 0, size_t(maxStructSize - fixedParamsSize));
+	const qsizetype expectedFixedParamsSize = qMax<qsizetype>(0, qsizetype(fixedSize()) - 1);
+	const qsizetype fixedParamsSize = qMin(qMin(expectedFixedParamsSize, source.size()), maxStructSize);
+
+	if (expectedFixedParamsSize > source.size()) {
+		qWarning() << "Opcode::setParams" << id() << "fixed size exceeded"
+		           << expectedFixedParamsSize << source.size();
+	}
+
+	if (fixedParamsSize > 0) {
+		memcpy(reinterpret_cast<char *>(&_opcode) + sizeof(_opcode.id),
+		       source.constData(), size_t(fixedParamsSize));
 	}
 
 	if (id() == OpcodeKey::Unused1C || id() == OpcodeKey::KAWAI) {
-		quint8 dynamicParamsSize = size() - fixedParamsSize - 1;
+		const qsizetype declaredDynamicParamsSize = qMax<qsizetype>(
+		            0, qsizetype(size()) - expectedFixedParamsSize - 1);
+		const qsizetype availableDynamicParamsSize = qMax<qsizetype>(
+		            0, source.size() - expectedFixedParamsSize);
+		const qsizetype dynamicParamsSize = qMin(declaredDynamicParamsSize,
+		                                             availableDynamicParamsSize);
 
-		if (dynamicParamsSize > maxSize - fixedParamsSize) {
-			qWarning() << "Opcode::setParams" << id() << "dynamic size exceeded" << fixedParamsSize << dynamicParamsSize << maxSize;
-			dynamicParamsSize = quint8(maxSize - fixedParamsSize);
+		if (declaredDynamicParamsSize > availableDynamicParamsSize) {
+			qWarning() << "Opcode::setParams" << id() << "dynamic size exceeded"
+			           << expectedFixedParamsSize << declaredDynamicParamsSize << source.size();
 		}
 
-		setResizableData(QByteArray(params + fixedParamsSize, dynamicParamsSize));
+		setResizableData(source.mid(expectedFixedParamsSize, dynamicParamsSize));
 	}
 }
 
@@ -113,13 +134,29 @@ QByteArray Opcode::params() const
 
 int Opcode::subParam(qsizetype cur, qsizetype sizeInBits) const
 {
-	QByteArray p = params();
-	qsizetype size = sizeInBits % 8 != 0 ? sizeInBits / 8 + 1 : sizeInBits / 8;
-	int value = 0;
+	if (cur < 0 || sizeInBits <= 0 || sizeInBits > 32) {
+		return 0;
+	}
 
-	memcpy(&value, p.constData() + cur / 8, size_t(size));
+	const QByteArray p = params();
+	const qsizetype byteOffset = cur / 8;
+	const qsizetype bitOffset = cur % 8;
+	const qsizetype bytesToRead = (bitOffset + sizeInBits + 7) / 8;
 
-	return (value >> ((size * 8 - cur % 8) - sizeInBits)) & (int(pow(2, sizeInBits)) - 1);
+	if (byteOffset < 0 || byteOffset > p.size()
+	        || bytesToRead > qsizetype(sizeof(quint64))
+	        || bytesToRead > p.size() - byteOffset) {
+		qWarning() << "Opcode::subParam" << id() << "parameter read out of bounds"
+		           << cur << sizeInBits << p.size();
+		return 0;
+	}
+
+	quint64 value = 0;
+	memcpy(&value, p.constData() + byteOffset, size_t(bytesToRead));
+
+	const qsizetype shift = bytesToRead * 8 - bitOffset - sizeInBits;
+	const quint64 mask = (quint64(1) << sizeInBits) - 1;
+	return int((value >> shift) & mask);
 }
 
 quint8 Opcode::fixedSize() const
@@ -174,12 +211,19 @@ QByteArray Opcode::toByteArray() const
 
 QByteArray Opcode::serialize() const
 {
-	QByteArray data = resizableData();
+	const QByteArray data = resizableData();
+	OPCODE fixedData = _opcode;
+	if (fixedData.id == OpcodeKey::KAWAI) {
+		fixedData.opcodeKAWAI._data = nullptr;
+	} else if (fixedData.id == OpcodeKey::Unused1C) {
+		fixedData.opcodeUnused1C._data = nullptr;
+	}
+
 	QByteArray ret;
-	ret.reserve(qsizetype(sizeof(_opcode)) + data.size());
+	ret.reserve(qsizetype(sizeof(fixedData)) + data.size());
 	return ret
-	        .append(reinterpret_cast<const char *>(&_opcode), sizeof(_opcode))
-	        .append(resizableData());
+	        .append(reinterpret_cast<const char *>(&fixedData), sizeof(fixedData))
+	        .append(data);
 }
 
 Opcode Opcode::unserialize(const QByteArray &data)

--- a/src/core/field/Script.cpp
+++ b/src/core/field/Script.cpp
@@ -284,16 +284,28 @@ bool Script::isVoid() const
 
 void Script::setOpcode(qsizetype opcodeID, const Opcode &opcode)
 {
+	if (opcodeID < 0 || opcodeID >= _opcodes.size()) {
+		qWarning() << "Script::setOpcode invalid index" << opcodeID << _opcodes.size();
+		return;
+	}
 	_opcodes.replace(opcodeID, opcode);
 }
 
 void Script::removeOpcode(qsizetype opcodeID)
 {
+	if (opcodeID < 0 || opcodeID >= _opcodes.size()) {
+		qWarning() << "Script::removeOpcode invalid index" << opcodeID << _opcodes.size();
+		return;
+	}
 	_opcodes.removeAt(opcodeID);
 }
 
 void Script::insertOpcode(qsizetype opcodeID, const Opcode &opcode)
 {
+	if (opcodeID < 0 || opcodeID > _opcodes.size()) {
+		qWarning() << "Script::insertOpcode invalid index" << opcodeID << _opcodes.size();
+		return;
+	}
 	_opcodes.insert(opcodeID, opcode);
 }
 
@@ -759,15 +771,14 @@ void Script::backgroundMove(qint16 z[2], qint16 *x, qint16 *y) const
 bool Script::removeTexts()
 {
 	bool modified = false;
-	qsizetype i = 0;
-	for (const Opcode &opcode : std::as_const(_opcodes)) {
+	for (qsizetype i = _opcodes.size(); i-- > 0;) {
+		const Opcode &opcode = _opcodes.at(i);
 		if (opcode.id() != OpcodeKey::ASK
 				&& opcode.id() != OpcodeKey::MPNAM
 				&& opcode.textID() != -1) {
 			_opcodes.removeAt(i);
 			modified = true;
 		}
-		i += 1;
 	}
 
 	return modified;
@@ -798,12 +809,28 @@ QDataStream &operator<<(QDataStream &stream, const QList<Opcode> &script)
 
 QDataStream &operator>>(QDataStream &stream, QList<Opcode> &script)
 {
-	qsizetype size;
+	qsizetype size = 0;
 	stream >> size;
+
+	// A compiled field script cannot exceed 65535 bytes, so a clipboard list
+	// containing more opcodes than that is necessarily corrupt.
+	constexpr qsizetype MaxSerializedOpcodeCount = 65535;
+	if (stream.status() != QDataStream::Ok || size < 0 || size > MaxSerializedOpcodeCount) {
+		script.clear();
+		stream.setStatus(QDataStream::ReadCorruptData);
+		return stream;
+	}
 
 	for (qsizetype i = 0; i < size; ++i) {
 		QByteArray data;
 		stream >> data;
+		if (stream.status() != QDataStream::Ok
+		        || data.size() < qsizetype(sizeof(Opcode::OPCODE))
+		        || data.size() > qsizetype(sizeof(Opcode::OPCODE)) + 255) {
+			script.clear();
+			stream.setStatus(QDataStream::ReadCorruptData);
+			return stream;
+		}
 
 		script.append(Opcode::unserialize(data));
 	}

--- a/src/core/field/Script.cpp
+++ b/src/core/field/Script.cpp
@@ -302,10 +302,6 @@ void Script::removeOpcode(qsizetype opcodeID)
 
 void Script::insertOpcode(qsizetype opcodeID, const Opcode &opcode)
 {
-	if (opcodeID < 0 || opcodeID > _opcodes.size()) {
-		qWarning() << "Script::insertOpcode invalid index" << opcodeID << _opcodes.size();
-		return;
-	}
 	_opcodes.insert(opcodeID, opcode);
 }
 

--- a/src/core/field/Section1File.cpp
+++ b/src/core/field/Section1File.cpp
@@ -585,7 +585,8 @@ qsizetype Section1File::grpScriptCount() const
 
 bool Section1File::insertGrpScript(int row, const GrpScript &grpScript)
 {
-	if (grpScriptCount() < maxGrpScriptCount()) {
+	if (row >= 0 && row <= _grpScripts.size()
+	        && grpScriptCount() < maxGrpScriptCount()) {
 		_grpScripts.insert(row, grpScript);
 		for (GrpScript &grpScript : _grpScripts) {
 			grpScript.shiftGroupIds(row - 1, +1);


### PR DESCRIPTION
This is a separate defensive-hardening change for opcode/script data handling. It is intentionally independent of the stale-pointer crash/lifetime PR.

Changes:
- harden `Opcode::setParams()` against aliased parameter buffers and correctly release dynamic KAWAI / Unused1C data before resetting union storage;
- keep `Opcode::subParam()` from reading past the serialized parameter buffer;
- avoid serializing runtime `QByteArray *` values for KAWAI / Unused1C;
- add bounds checks to `Script::setOpcode()` and `removeOpcode()`;
- change `Script::removeTexts()` to a reverse index loop so the opcode list is not modified while range-iterating it;
- validate serialized/clipboard opcode counts and record sizes before accepting them;
- validate the insertion row in `Section1File::insertGrpScript()`.

Following review, the extra `Opcode::setParams()` argument-domain check, the top-level `Opcode::subParam()` argument-domain check, and the explicit `Script::insertOpcode()` index check were removed as unnecessary.

The current corrected `Opcode::operator=` and the newer bounds/error checks already present in master are left unchanged.
