### PR TITLE
Fix PSX raw sector EDC/ECC generation

### DIFF
--- a/.vcpkg/ports/ff7tk/portfile.cmake
+++ b/.vcpkg/ports/ff7tk/portfile.cmake
@@ -11,6 +11,195 @@ vcpkg_from_github(
   HEAD_REF master
 )
 
+# Replace a complete source region using symbol markers rather than matching
+# the original function body. This is deliberately insensitive to CRLF/LF and
+# harmless upstream whitespace differences.
+function(_mr_replace_region FILE_PATH START_MARKER END_MARKER REPLACEMENT)
+  file(READ "${FILE_PATH}" _text)
+  string(FIND "${_text}" "${START_MARKER}" _start)
+  if(_start EQUAL -1)
+    message(FATAL_ERROR "ff7tk PSX fix: start marker not found: ${START_MARKER}")
+  endif()
+
+  string(FIND "${_text}" "${END_MARKER}" _end)
+  if(_end EQUAL -1 OR _end LESS _start)
+    message(FATAL_ERROR "ff7tk PSX fix: end marker not found after start: ${END_MARKER}")
+  endif()
+
+  string(LENGTH "${_text}" _text_len)
+  math(EXPR _suffix_len "${_text_len} - ${_end}")
+  string(SUBSTRING "${_text}" 0 ${_start} _prefix)
+  string(SUBSTRING "${_text}" ${_end} ${_suffix_len} _suffix)
+  file(WRITE "${FILE_PATH}" "${_prefix}${REPLACEMENT}${_suffix}")
+endfunction()
+
+set(_iso_cpp "${SOURCE_PATH}/src/formats/IsoArchive.cpp")
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/psx-cdrom-edc-ecc.h"
+     DESTINATION "${SOURCE_PATH}/src/formats")
+
+# Add the helper include without depending on source line endings.
+file(READ "${_iso_cpp}" _iso_text)
+string(FIND "${_iso_text}" "#include \"psx-cdrom-edc-ecc.h\"" _helper_include)
+if(_helper_include EQUAL -1)
+  string(FIND "${_iso_text}" "#include <QtEndian>" _qtendian_include)
+  if(_qtendian_include EQUAL -1)
+    message(FATAL_ERROR "ff7tk PSX fix: QtEndian include marker not found")
+  endif()
+  string(REPLACE "#include <QtEndian>"
+                 "#include <QtEndian>\n#include \"psx-cdrom-edc-ecc.h\""
+                 _iso_text "${_iso_text}")
+  file(WRITE "${_iso_cpp}" "${_iso_text}")
+endif()
+
+_mr_replace_region("${_iso_cpp}"
+  "qint64 IsoArchiveIO::writeIso(const char *data, qint64 maxSize)"
+  "qint64 IsoArchiveIO::writeIso(const QByteArray &byteArray)"
+[=[qint64 IsoArchiveIO::writeIso(const char *data, qint64 maxSize)
+{
+    qint64 write = 0, writeTotal = 0, seqLen;
+
+    if (!seekIso(isoPos(pos()))) {
+        return 0;
+    }
+
+    const qint64 startIsoPos = posIso();
+
+    seqLen = std::min(SECTOR_SIZE_HEADER + SECTOR_SIZE_DATA - (pos() % SECTOR_SIZE), maxSize);
+    while ((write = this->write(data, seqLen)) > 0) {
+        data += write;
+        maxSize -= write;
+        writeTotal += write;
+        seqLen = std::min(qint64(SECTOR_SIZE_DATA), maxSize);
+        if (pos() % SECTOR_SIZE >= SECTOR_SIZE_HEADER + SECTOR_SIZE_DATA
+                && !seek(pos() + SECTOR_SIZE_HEADER + SECTOR_SIZE_FOOTER)) {
+            break;
+        }
+    }
+
+    if (writeTotal > 0) {
+        const quint32 firstSector = quint32(startIsoPos / SECTOR_SIZE_DATA);
+        const quint32 lastSector = quint32((startIsoPos + writeTotal - 1) / SECTOR_SIZE_DATA);
+        for (quint32 sector = firstSector; sector <= lastSector; ++sector) {
+            if (!ff7tk_psx_cd::repairSector(*this, sector)) {
+                return -1;
+            }
+        }
+    }
+
+    return write < 0 ? write : writeTotal;
+}
+]=])
+
+_mr_replace_region("${_iso_cpp}"
+  "bool IsoArchiveIO::writeSector(const QByteArray &data, quint8 type, quint8 mode)"
+  "IsoFileIO::IsoFileIO(IsoArchiveIO *io, const IsoFile *infos, QObject *parent)"
+[=[bool IsoArchiveIO::writeSector(const QByteArray &data, quint8 type, quint8 mode)
+{
+    const qint64 dataSize = data.size();
+    const quint32 sectorCur = currentSector();
+    QByteArray sectorData;
+
+    Q_ASSERT(pos() % SECTOR_SIZE == 0);
+    Q_ASSERT(dataSize <= SECTOR_SIZE_DATA);
+    if (pos() % SECTOR_SIZE != 0 || dataSize < 0 || dataSize > SECTOR_SIZE_DATA || mode != 2) {
+        return false;
+    }
+
+    sectorData = buildHeader(sectorCur, type, mode);
+    sectorData.append(data);
+    if (dataSize != SECTOR_SIZE_DATA) {
+        sectorData.append(QByteArray(SECTOR_SIZE_DATA - dataSize, '\x00'));
+    }
+
+    // Reserve the complete raw-sector tail and generate the correct XA
+    // Form-1 EDC/P/Q ECC (or Form-2 EDC when the submode requests Form 2).
+    sectorData.append(QByteArray(SECTOR_SIZE_FOOTER, '\x00'));
+    if (!ff7tk_psx_cd::updateSectorEdcEcc(sectorData)) {
+        return false;
+    }
+
+    return write(sectorData) == SECTOR_SIZE;
+}
+
+]=])
+
+_mr_replace_region("${_iso_cpp}"
+  "bool IsoArchive::copySectors(IsoArchiveIO *out, qint64 sectorCount, ArchiveObserver *control, bool repair)"
+  "bool IsoArchive::writeFile(QIODevice *in, quint32 sectorCount, ArchiveObserver *control)"
+[=[bool IsoArchive::copySectors(IsoArchiveIO *out, qint64 sectorCount, ArchiveObserver *control, bool repair)
+{
+    if (sectorCount < 0) {
+        qWarning() << "IsoArchive::copySectors sectorCount < 0" << sectorCount;
+        setError(Archive::InvalidError);
+        return false;
+    }
+    Q_ASSERT(out->pos() % SECTOR_SIZE == 0);
+    Q_ASSERT(_io.pos() % SECTOR_SIZE == 0);
+
+    for (qint64 i = 0; i < sectorCount; ++i) {
+        if (control && control->observerWasCanceled()) {
+            setError(Archive::AbortError);
+            return false;
+        }
+
+        QByteArray data = _io.read(SECTOR_SIZE);
+        if (data.size() != SECTOR_SIZE) {
+            qWarning() << "IsoArchive::copySectors read error" << data.size() << SECTOR_SIZE;
+            setError(Archive::ReadError, _io.errorString());
+            return false;
+        }
+
+        const bool written = repair
+                ? ff7tk_psx_cd::writeRelocatedSector(*out, data)
+                : out->write(data) == SECTOR_SIZE;
+        if (!written) {
+            qWarning() << "IsoArchive::copySectors write error";
+            setError(Archive::WriteError, out->errorString());
+            return false;
+        }
+
+        if (control) {
+            control->setObserverValue(int(out->currentSector()));
+        }
+    }
+
+    return true;
+}
+
+]=])
+
+# The volume descriptor size update bypasses writeIso upstream. Route these two
+# payload writes through writeIso so the raw sector EDC/ECC is regenerated.
+file(READ "${_iso_cpp}" _iso_text)
+set(_old_volume_write1 "destinationIO->write((char*)&volume_space_size, 4);")
+set(_old_volume_write2 "destinationIO->write((char*)&volume_space_size2, 4);")
+string(FIND "${_iso_text}" "${_old_volume_write1}" _vol1)
+string(FIND "${_iso_text}" "${_old_volume_write2}" _vol2)
+if(_vol1 EQUAL -1 OR _vol2 EQUAL -1)
+  message(FATAL_ERROR "ff7tk PSX fix: volume descriptor write markers not found")
+endif()
+string(REPLACE "${_old_volume_write1}"
+               "destinationIO->writeIso((char*)&volume_space_size, 4);"
+               _iso_text "${_iso_text}")
+string(REPLACE "${_old_volume_write2}"
+               "destinationIO->writeIso((char*)&volume_space_size2, 4);"
+               _iso_text "${_iso_text}")
+file(WRITE "${_iso_cpp}" "${_iso_text}")
+
+# Sanity-check the transformed source before invoking ff7tk's CMake build.
+file(READ "${_iso_cpp}" _iso_after)
+foreach(_marker
+    "#include \"psx-cdrom-edc-ecc.h\""
+    "const qint64 startIsoPos = posIso();"
+    "ff7tk_psx_cd::updateSectorEdcEcc(sectorData)"
+    "ff7tk_psx_cd::writeRelocatedSector(*out, data)"
+    "destinationIO->writeIso((char*)&volume_space_size, 4);")
+  string(FIND "${_iso_after}" "${_marker}" _marker_pos)
+  if(_marker_pos EQUAL -1)
+    message(FATAL_ERROR "ff7tk PSX fix: transformed source missing marker: ${_marker}")
+  endif()
+endforeach()
+
 vcpkg_cmake_configure(
   SOURCE_PATH ${SOURCE_PATH}
   OPTIONS

--- a/.vcpkg/ports/ff7tk/psx-cdrom-edc-ecc.h
+++ b/.vcpkg/ports/ff7tk/psx-cdrom-edc-ecc.h
@@ -1,0 +1,214 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// CD-ROM raw-sector EDC/ECC helpers for the Makou Reactor ff7tk overlay.
+#pragma once
+
+#include <array>
+#include <cstring>
+
+namespace ff7tk_psx_cd {
+
+constexpr int Mode1EdcOffset = 2064;
+constexpr int Mode2Form1EdcOffset = 2072;
+constexpr int Mode2Form2EdcOffset = 2348;
+constexpr int EccPOffset = 2076;
+constexpr int EccQOffset = 2248;
+
+inline const std::array<quint32, 256> &edcTable()
+{
+    static const std::array<quint32, 256> table = []() {
+        std::array<quint32, 256> result{};
+        for (quint32 i = 0; i < 256; ++i) {
+            quint32 value = i;
+            for (int bit = 0; bit < 8; ++bit) {
+                value = (value >> 1) ^ ((value & 1U) ? 0xD8018001U : 0U);
+            }
+            result[i] = value;
+        }
+        return result;
+    }();
+    return table;
+}
+
+inline quint32 computeEdc(const quint8 *data, qsizetype size)
+{
+    const auto &table = edcTable();
+    quint32 edc = 0;
+    for (qsizetype i = 0; i < size; ++i) {
+        edc = (edc >> 8) ^ table[(edc ^ data[i]) & 0xffU];
+    }
+    return edc;
+}
+
+struct EccTables {
+    std::array<quint8, 256> forward{};
+    std::array<quint8, 256> backward{};
+
+    EccTables()
+    {
+        for (int i = 0; i < 256; ++i) {
+            const int doubled = (i << 1) ^ ((i & 0x80) ? 0x11d : 0);
+            forward[i] = quint8(doubled);
+            backward[i ^ doubled] = quint8(i);
+        }
+    }
+};
+
+inline const EccTables &eccTables()
+{
+    static const EccTables tables;
+    return tables;
+}
+
+inline void computeEcc(const quint8 *source, quint32 majorCount, quint32 minorCount,
+                       quint32 majorMultiplier, quint32 minorIncrement, quint8 *destination)
+{
+    const auto &tables = eccTables();
+    const quint32 size = majorCount * minorCount;
+
+    for (quint32 major = 0; major < majorCount; ++major) {
+        quint32 index = (major >> 1) * majorMultiplier + (major & 1U);
+        quint8 eccA = 0;
+        quint8 eccB = 0;
+
+        for (quint32 minor = 0; minor < minorCount; ++minor) {
+            const quint8 value = source[index];
+            index += minorIncrement;
+            if (index >= size) {
+                index -= size;
+            }
+            eccA ^= value;
+            eccB ^= value;
+            eccA = tables.forward[eccA];
+        }
+
+        eccA = tables.backward[tables.forward[eccA] ^ eccB];
+        destination[major] = eccA;
+        destination[major + majorCount] = eccA ^ eccB;
+    }
+}
+
+inline void writeEdcLittleEndian(quint8 *destination, quint32 edc)
+{
+    destination[0] = quint8(edc);
+    destination[1] = quint8(edc >> 8);
+    destination[2] = quint8(edc >> 16);
+    destination[3] = quint8(edc >> 24);
+}
+
+inline bool hasCdRomSync(const quint8 *sector)
+{
+    if (sector[0] != 0 || sector[11] != 0) {
+        return false;
+    }
+    for (int i = 1; i < 11; ++i) {
+        if (sector[i] != 0xff) {
+            return false;
+        }
+    }
+    return true;
+}
+
+// Recompute integrity fields for a sector whose payload has actually changed.
+// Untouched sectors are never passed through this function by the ff7tk changes.
+inline bool updateSectorEdcEcc(QByteArray &sectorData)
+{
+    if (sectorData.size() != SECTOR_SIZE) {
+        return false;
+    }
+
+    auto *sector = reinterpret_cast<quint8 *>(sectorData.data());
+    if (!hasCdRomSync(sector)) {
+        return true; // Audio/non-data: nothing to regenerate.
+    }
+
+    const quint8 mode = sector[15];
+    if (mode == 1) {
+        const quint32 edc = computeEdc(sector, Mode1EdcOffset);
+        writeEdcLittleEndian(sector + Mode1EdcOffset, edc);
+        std::memset(sector + Mode1EdcOffset + 4, 0, 8);
+        computeEcc(sector + 12, 86, 24, 2, 86, sector + EccPOffset);
+        computeEcc(sector + 12, 52, 43, 86, 88, sector + EccQOffset);
+        return true;
+    }
+
+    if (mode != 2) {
+        return true;
+    }
+
+    // XA repeats the four-byte subheader at 16..19 and 20..23.
+    if (std::memcmp(sector + 16, sector + 20, 4) != 0) {
+        return true; // Plain Mode 2, not XA Form 1/2.
+    }
+
+    // XA Mode 2 Form 2: 2324 user bytes + EDC, no P/Q ECC.
+    if ((sector[18] & 0x20U) != 0) {
+        const quint32 edc = computeEdc(sector + 16, Mode2Form2EdcOffset - 16);
+        writeEdcLittleEndian(sector + Mode2Form2EdcOffset, edc);
+        return true;
+    }
+
+    // XA Mode 2 Form 1: EDC covers bytes 16..2071.
+    const quint32 edc = computeEdc(sector + 16, Mode2Form1EdcOffset - 16);
+    writeEdcLittleEndian(sector + Mode2Form1EdcOffset, edc);
+
+    // P/Q ECC is position-independent for XA Form 1: bytes 12..15 are
+    // treated as zero while parity is calculated.
+    quint8 addressAndMode[4];
+    std::memcpy(addressAndMode, sector + 12, sizeof(addressAndMode));
+    std::memset(sector + 12, 0, sizeof(addressAndMode));
+    computeEcc(sector + 12, 86, 24, 2, 86, sector + EccPOffset);
+    computeEcc(sector + 12, 52, 43, 86, 88, sector + EccQOffset);
+    std::memcpy(sector + 12, addressAndMode, sizeof(addressAndMode));
+
+    return true;
+}
+
+inline bool repairSector(IsoArchiveIO &io, quint32 num)
+{
+    const qint64 previousPos = io.pos();
+    const qint64 sectorPos = qint64(num) * SECTOR_SIZE;
+
+    if (!io.seek(sectorPos)) {
+        return false;
+    }
+
+    QByteArray sectorData = io.read(SECTOR_SIZE);
+    bool ok = sectorData.size() == SECTOR_SIZE && updateSectorEdcEcc(sectorData);
+    if (ok) {
+        ok = io.seek(sectorPos) && io.write(sectorData) == SECTOR_SIZE;
+    }
+
+    if (!io.seek(previousPos)) {
+        ok = false;
+    }
+    return ok;
+}
+
+// Relocate an existing raw sector. For PS1 XA Mode 2 sectors the EDC/ECC does
+// not depend on the MSF address, so preserve its original integrity bytes
+// exactly (including any intentional anomaly). Mode 1 does include the address
+// in EDC, so it must be regenerated after moving.
+inline bool writeRelocatedSector(IsoArchiveIO &io, QByteArray sectorData)
+{
+    if (sectorData.size() != SECTOR_SIZE || io.pos() % SECTOR_SIZE != 0) {
+        return false;
+    }
+
+    auto *sector = reinterpret_cast<quint8 *>(sectorData.data());
+    if (hasCdRomSync(sector) && (sector[15] == 1 || sector[15] == 2)) {
+        const quint8 mode = sector[15];
+        const QByteArray address = IsoArchiveIO::int2Header(io.currentSector());
+        if (address.size() != 3) {
+            return false;
+        }
+        std::memcpy(sector + 12, address.constData(), 3);
+
+        if (mode == 1 && !updateSectorEdcEcc(sectorData)) {
+            return false;
+        }
+    }
+
+    return io.write(sectorData) == SECTOR_SIZE;
+}
+
+} // namespace ff7tk_psx_cd

--- a/src/widgets/AboutDialog.cpp
+++ b/src/widgets/AboutDialog.cpp
@@ -33,14 +33,14 @@ AboutDialog::AboutDialog(QWidget *parent)
 	desc1->setOpenExternalLinks(true);
 	
 	QLabel *desc2 = new QLabel(tr("Contributors:<ul style=\"margin:0\"><li>Sithlord48</li>"
-	                              "<li>TrueOdin</li><li>dangarfield</li><li>vegetass4</li><li>nickrum</li></ul>"), this);
+	                              "<li>TrueOdin</li><li>dangarfield</li><li>vegetass4</li><li>nickrum</li>"
+	                              "<li>DLPB</li></ul>"), this);
 	desc2->setTextInteractionFlags(Qt::LinksAccessibleByMouse | Qt::LinksAccessibleByKeyboard);
 	desc2->setTextFormat(Qt::RichText);
 	desc2->setOpenExternalLinks(true);
 
 	QLabel *desc3 = new QLabel(tr("Thanks to:<ul style=\"margin:0\"><li>Squall78</li>"
-	                              "<li>Synergy Blades</li><li>Akari</li><li>Asa</li><li>Aali</li>"
-	                              "<li>DLPB</li></ul>"), this);
+	                              "<li>Synergy Blades</li><li>Akari</li><li>Asa</li><li>Aali</li></ul>"), this);
 	desc3->setTextInteractionFlags(Qt::LinksAccessibleByMouse | Qt::LinksAccessibleByKeyboard);
 	desc3->setTextFormat(Qt::RichText);
 	desc3->setOpenExternalLinks(true);

--- a/translations/Makou_Reactor_fr.ts
+++ b/translations/Makou_Reactor_fr.ts
@@ -12,12 +12,12 @@
         <translation type="vanished">Merci à&amp;nbsp;:&lt;ul style=&quot;margin:0&quot;&gt;&lt;li&gt;Squall78&lt;/li&gt;&lt;li&gt;Synergy Blades&lt;/li&gt;&lt;li&gt;TrueOdin&lt;/li&gt;&lt;li&gt;Akari&lt;/li&gt;&lt;li&gt;Asa&lt;/li&gt;&lt;li&gt;Aali&lt;/li&gt;&lt;li&gt;DLPB&lt;/li&gt;&lt;/ul&gt;</translation>
     </message>
     <message>
-        <source>Contributors:&lt;ul style=&quot;margin:0&quot;&gt;&lt;li&gt;Sithlord48&lt;/li&gt;&lt;li&gt;TrueOdin&lt;/li&gt;&lt;li&gt;dangarfield&lt;/li&gt;&lt;li&gt;vegetass4&lt;/li&gt;&lt;li&gt;nickrum&lt;/li&gt;&lt;/ul&gt;</source>
-        <translation>Constributeurs&amp;nbsp;:&lt;ul style=&quot;margin:0&quot;&gt;&lt;li&gt;Sithlord48&lt;/li&gt;&lt;li&gt;TrueOdin&lt;/li&gt;&lt;li&gt;dangarfield&lt;/li&gt;&lt;li&gt;vegetass4&lt;/li&gt;&lt;li&gt;nickrum&lt;/li&gt;&lt;/ul&gt;</translation>
+        <source>Contributors:&lt;ul style=&quot;margin:0&quot;&gt;&lt;li&gt;Sithlord48&lt;/li&gt;&lt;li&gt;TrueOdin&lt;/li&gt;&lt;li&gt;dangarfield&lt;/li&gt;&lt;li&gt;vegetass4&lt;/li&gt;&lt;li&gt;nickrum&lt;/li&gt;&lt;li&gt;DLPB&lt;/li&gt;&lt;/ul&gt;</source>
+        <translation>Constributeurs&amp;nbsp;:&lt;ul style=&quot;margin:0&quot;&gt;&lt;li&gt;Sithlord48&lt;/li&gt;&lt;li&gt;TrueOdin&lt;/li&gt;&lt;li&gt;dangarfield&lt;/li&gt;&lt;li&gt;vegetass4&lt;/li&gt;&lt;li&gt;nickrum&lt;/li&gt;&lt;li&gt;DLPB&lt;/li&gt;&lt;/ul&gt;</translation>
     </message>
     <message>
-        <source>Thanks to:&lt;ul style=&quot;margin:0&quot;&gt;&lt;li&gt;Squall78&lt;/li&gt;&lt;li&gt;Synergy Blades&lt;/li&gt;&lt;li&gt;Akari&lt;/li&gt;&lt;li&gt;Asa&lt;/li&gt;&lt;li&gt;Aali&lt;/li&gt;&lt;li&gt;DLPB&lt;/li&gt;&lt;/ul&gt;</source>
-        <translation>Merci à&amp;nbsp;:&lt;ul style=&quot;margin:0&quot;&gt;&lt;li&gt;Squall78&lt;/li&gt;&lt;li&gt;Synergy Blades&lt;/li&gt;&lt;li&gt;Akari&lt;/li&gt;&lt;li&gt;Asa&lt;/li&gt;&lt;li&gt;Aali&lt;/li&gt;&lt;li&gt;DLPB&lt;/li&gt;&lt;/ul&gt;</translation>
+        <source>Thanks to:&lt;ul style=&quot;margin:0&quot;&gt;&lt;li&gt;Squall78&lt;/li&gt;&lt;li&gt;Synergy Blades&lt;/li&gt;&lt;li&gt;Akari&lt;/li&gt;&lt;li&gt;Asa&lt;/li&gt;&lt;li&gt;Aali&lt;/li&gt;&lt;/ul&gt;</source>
+        <translation>Merci à&amp;nbsp;:&lt;ul style=&quot;margin:0&quot;&gt;&lt;li&gt;Squall78&lt;/li&gt;&lt;li&gt;Synergy Blades&lt;/li&gt;&lt;li&gt;Akari&lt;/li&gt;&lt;li&gt;Asa&lt;/li&gt;&lt;li&gt;Aali&lt;/li&gt;&lt;/ul&gt;</translation>
     </message>
 </context>
 <context>

--- a/translations/Makou_Reactor_ja.ts
+++ b/translations/Makou_Reactor_ja.ts
@@ -8,11 +8,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Contributors:&lt;ul style=&quot;margin:0&quot;&gt;&lt;li&gt;Sithlord48&lt;/li&gt;&lt;li&gt;TrueOdin&lt;/li&gt;&lt;li&gt;dangarfield&lt;/li&gt;&lt;li&gt;vegetass4&lt;/li&gt;&lt;li&gt;nickrum&lt;/li&gt;&lt;/ul&gt;</source>
+        <source>Contributors:&lt;ul style=&quot;margin:0&quot;&gt;&lt;li&gt;Sithlord48&lt;/li&gt;&lt;li&gt;TrueOdin&lt;/li&gt;&lt;li&gt;dangarfield&lt;/li&gt;&lt;li&gt;vegetass4&lt;/li&gt;&lt;li&gt;nickrum&lt;/li&gt;&lt;li&gt;DLPB&lt;/li&gt;&lt;/ul&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Thanks to:&lt;ul style=&quot;margin:0&quot;&gt;&lt;li&gt;Squall78&lt;/li&gt;&lt;li&gt;Synergy Blades&lt;/li&gt;&lt;li&gt;Akari&lt;/li&gt;&lt;li&gt;Asa&lt;/li&gt;&lt;li&gt;Aali&lt;/li&gt;&lt;li&gt;DLPB&lt;/li&gt;&lt;/ul&gt;</source>
+        <source>Thanks to:&lt;ul style=&quot;margin:0&quot;&gt;&lt;li&gt;Squall78&lt;/li&gt;&lt;li&gt;Synergy Blades&lt;/li&gt;&lt;li&gt;Akari&lt;/li&gt;&lt;li&gt;Asa&lt;/li&gt;&lt;li&gt;Aali&lt;/li&gt;&lt;/ul&gt;</source>
         <translation type="unfinished"></translation>
     </message>
 </context>


### PR DESCRIPTION
Fixes #51.

Saving a modified FF7 PSX BIN can leave rebuilt raw sectors with invalid integrity data.

ff7tk v1.3.1 builds 2352-byte sectors with a 280-byte zero footer, and `writeIso()` changes the 2048-byte ISO payload without regenerating the raw-sector EDC/ECC. The existing `copySectors(..., repair=true)` path also reconstructs a sector from only its 2048-byte user-data area.

This updates Makou Reactor's local ff7tk vcpkg overlay while continuing to download pristine ff7tk v1.3.1.

Changes:
- add a CD-ROM EDC/ECC helper;
- regenerate EDC + P/Q ECC for modified XA Mode 2 Form 1 sectors;
- regenerate EDC for modified XA Mode 2 Form 2 sectors (no P/Q);
- support Mode 1 EDC/ECC generation;
- repair every raw sector affected by `writeIso()`;
- route Primary Volume Descriptor volume-size writes through `writeIso()`;
- preserve complete 2352-byte sectors when relocating existing data;
- update the destination MSF address when a raw data sector moves;
- preserve existing Mode 2 XA EDC/ECC when relocation only changes MSF;
- regenerate Mode 1 integrity after relocation because its address participates in the integrity calculation;
- leave untouched sectors byte-for-byte unchanged rather than doing a whole-disc repair pass.

This is intended to preserve unusual/protection sectors that Makou does not modify while ensuring sectors whose payload Makou changes contain matching integrity data.

Also moves DLPB from the About dialog's `Thanks to` list to `Contributors`, with the French/Japanese translation source entries kept in sync.

Tested with an FF7 PSX image saved from Makou Reactor; the resulting image boots correctly in an emulator.
