### PR TITLE
Clarify Battle Mode (1) and (2) flag descriptions

### DIFF
--- a/src/core/field/Opcode.cpp
+++ b/src/core/field/Opcode.cpp
@@ -2581,42 +2581,56 @@ QString Opcode::toStringBTMD2(const Section1File *scriptsAndTexts, const OpcodeB
 {
 	Q_UNUSED(scriptsAndTexts)
 	QStringList modes;
+	auto flagNumber = [](quint8 bit) {
+		return int(bit / 8) * 8 + 8 - int(bit % 8);
+	};
 
 	for (quint8 i = 0; i < 32; ++i) {
 		if ((opcode.battleMode >> i) & 1) {
 			switch (i) {
+			case 0:
+			case 4:
+			case 9:
+			case 10:
+			case 11:
+			case 12:
+			case 13:
+			case 14:
+			case 15:
+				modes.append(Opcode::tr("Unused (%1)").arg(flagNumber(i), 2, 10, QLatin1Char('0')));
+				break;
 			case 1:
-				modes.append(Opcode::tr("Countdown"));
+				modes.append(Opcode::tr("Enable countdown timer"));
 				break;
 			case 2:
-				modes.append(Opcode::tr("Pre-emptive attack"));
+				modes.append(Opcode::tr("Preemptive attack"));
 				break;
 			case 3:
-				modes.append(Opcode::tr("The party cannot escape the battle"));
+				modes.append(Opcode::tr("Cannot escape from battle"));
 				break;
 			case 5:
-				modes.append(Opcode::tr("Do not play the battle victory music"));
+				modes.append(Opcode::tr("Do not play victory fanfare music"));
 				break;
 			case 6:
-				modes.append(Opcode::tr("Activates the battle arena"));
+				modes.append(Opcode::tr("Activate Battle Arena"));
 				break;
 			case 7:
-				modes.append(Opcode::tr("Do not show battle rewards"));
+				modes.append(Opcode::tr("Disable rewards"));
 				break;
 			case 8:
-				modes.append(Opcode::tr("The party members do not perform their victory celebrations at the end of battle"));
+				modes.append(Opcode::tr("Disable victory celebration"));
 				break;
 			case 16:
-				modes.append(Opcode::tr("Disable game over"));
+				modes.append(Opcode::tr("Disable Game Over"));
 				break;
 			default:
-				modes.append(QString("%1?").arg(i));
+				modes.append(Opcode::tr("Unusable (%1)").arg(flagNumber(i), 2, 10, QLatin1Char('0')));
 				break;
 			}
 		}
 	}
 
-	return Opcode::tr("Battle mode: %1")
+	return Opcode::tr("Battle mode (2): %1")
 	        .arg(modes.isEmpty() ? Opcode::tr("None") : modes.join(", "));
 }
 
@@ -3580,38 +3594,54 @@ QString Opcode::toStringBTLMD(const Section1File *scriptsAndTexts, const OpcodeB
 {
 	Q_UNUSED(scriptsAndTexts)
 	QStringList modes;
+	auto flagNumber = [](quint8 bit) {
+		return int(bit / 8) * 8 + 8 - int(bit % 8);
+	};
+
 	for (quint8 i = 0; i < 16; ++i) {
 		if ((opcode.battleMode >> i) & 1) {
 			switch (i) {
+			case 0:
+				modes.append(Opcode::tr("Unused (%1)").arg(flagNumber(i), 2, 10, QLatin1Char('0')));
+				break;
+			case 9:
+			case 10:
+			case 11:
+			case 12:
+			case 13:
+			case 14:
+			case 15:
+				modes.append(Opcode::tr("Unusable (%1)").arg(flagNumber(i), 2, 10, QLatin1Char('0')));
+				break;
 			case 1:
-				modes.append(Opcode::tr("Countdown"));
+				modes.append(Opcode::tr("Enable countdown timer"));
 				break;
 			case 2:
-				modes.append(Opcode::tr("Pre-emptive attack"));
+				modes.append(Opcode::tr("Preemptive attack"));
 				break;
 			case 3:
-				modes.append(Opcode::tr("The party cannot escape the battle"));
+				modes.append(Opcode::tr("Cannot escape from battle"));
+				break;
+			case 4:
+				modes.append(Opcode::tr("Unused (%1)").arg(flagNumber(i), 2, 10, QLatin1Char('0')));
 				break;
 			case 5:
-				modes.append(Opcode::tr("Do not play the battle victory music"));
+				modes.append(Opcode::tr("Do not play victory fanfare music"));
 				break;
 			case 6:
-				modes.append(Opcode::tr("Activates the battle arena"));
+				modes.append(Opcode::tr("Activate Battle Arena"));
 				break;
 			case 7:
-				modes.append(Opcode::tr("Do not show battle rewards"));
+				modes.append(Opcode::tr("Disable rewards"));
 				break;
 			case 8:
-				modes.append(Opcode::tr("Disable game over"));
-				break;
-			default:
-				modes.append(QString("%1?").arg(i));
+				modes.append(Opcode::tr("Disable Game Over"));
 				break;
 			}
 		}
 	}
 
-	return Opcode::tr("Battle mode: %1")
+	return Opcode::tr("Battle mode (1): %1")
 	        .arg(modes.isEmpty() ? Opcode::tr("None") : modes.join(", "));
 }
 

--- a/src/widgets/ScriptEditor.cpp
+++ b/src/widgets/ScriptEditor.cpp
@@ -764,7 +764,7 @@ void ScriptEditor::buildList(int id)
 		comboBox->addItem(tr("Last Map ID"), QList<QVariant>() << 0x6E);
 		comboBox->addItem(tr("Start Battle"), QList<QVariant>() << 0x70);
 		comboBox->addItem(tr("Battle On/Off"), QList<QVariant>() << 0x71);
-		comboBox->addItem(tr("Battle mode"), QList<QVariant>() << 0x72);
+		comboBox->addItem(tr("Battle mode (1)"), QList<QVariant>() << 0x72);
 		comboBox->addItem(tr("Battle mode (2)"), QList<QVariant>() << 0x22);
 		comboBox->addItem(tr("Map Jump On/Off"), QList<QVariant>() << 0xD2);
 		comboBox->addItem(tr("Character movability On/Off"), QList<QVariant>() << 0x33);

--- a/src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp
+++ b/src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp
@@ -205,7 +205,51 @@ void ScriptEditorGenericList::fillModel()
 
 	int paramSize, paramType, cur = 0, maxValue, minValue, value=0;
 	QList<int> paramTypes = this->paramTypes(opcode().id());
-	
+
+	// Battle-mode flags are displayed MSB-first within each serialized byte.
+	// BTLMD feeds its second byte to the field-side Game Over state; only
+	// row 16 is the intended flag. BTMD2 uses its first two bytes for the
+	// effective battle-mode word and row 24 for Disable Game Over.
+	auto battleModeParamName = [this](int opcodeID, quint8 index) -> QString {
+		switch (index) {
+		case 0:
+			return tr("Disable rewards");
+		case 1:
+			return tr("Activate Battle Arena");
+		case 2:
+			return tr("Do not play victory fanfare music");
+		case 3:
+			return tr("Unused");
+		case 4:
+			return tr("Cannot escape from battle");
+		case 5:
+			return tr("Preemptive attack");
+		case 6:
+			return tr("Enable countdown timer");
+		default:
+			break;
+		}
+
+		if (opcodeID == OpcodeKey::BTLMD) {
+			if (index == 7) {
+				return tr("Unused");
+			}
+			return index == 15 ? tr("Disable Game Over") : tr("Unusable");
+		}
+
+		if (index <= 14) {
+			return tr("Unused");
+		}
+		if (index == 15) {
+			return tr("Disable victory celebration");
+		}
+		if (index == 23) {
+			return tr("Disable Game Over");
+		}
+
+		return tr("Unusable");
+	};
+
 	if (opcode().id() == OpcodeKey::LABEL) {
 		addRow(int(opcode().op().opcodeLABEL._label), 0, int(pow(2, 15)) - 1, label);
 	} else if (paramTypes.isEmpty()) {
@@ -239,6 +283,14 @@ void ScriptEditorGenericList::fillModel()
 				minValue = 0;
 			}			
 			addRow(value, minValue, maxValue, paramType);
+
+			if (opcode().id() == OpcodeKey::BTLMD || opcode().id() == OpcodeKey::BTMD2) {
+				QStandardItem *nameItem = model->item(i, 0);
+				const QString name = battleModeParamName(opcode().id(), i);
+				nameItem->setText(name);
+				nameItem->setToolTip(name);
+			}
+
 			cur += paramSize;
 		}
 	}

--- a/translations/Makou_Reactor_fr.ts
+++ b/translations/Makou_Reactor_fr.ts
@@ -2417,11 +2417,11 @@ Certains scripts peuvent y faire référence !</translation>
         <translation>%1 les combats aléatoires</translation>
     </message>
     <message>
-        <source>The party cannot escape the battle</source>
+        <source>Cannot escape from battle</source>
         <translation>Impossible de fuir</translation>
     </message>
     <message>
-        <source>Do not show battle rewards</source>
+        <source>Disable rewards</source>
         <translation>Ne pas afficher d&apos;écran de récompense</translation>
     </message>
     <message>
@@ -3027,19 +3027,18 @@ Certains scripts peuvent y faire référence !</translation>
         <translation>Lancer un mini-jeu : %5 (Après le jeu aller à l&apos;écran %1 (X=%2, Y=%3, triangle id=%4))</translation>
     </message>
     <message>
-        <source>Pre-emptive attack</source>
+        <source>Preemptive attack</source>
         <oldsource>Attaque préventive</oldsource>
         <translation>Attaque préventive</translation>
     </message>
     <message>
-        <source>Disable game over</source>
+        <source>Disable Game Over</source>
         <oldsource>Désactiver Game Over</oldsource>
         <translation>Désactiver Game Over</translation>
     </message>
     <message>
-        <source>Battle mode: %1</source>
-        <oldsource>Mode de combat : %1</oldsource>
-        <translation>Mode de combat : %1</translation>
+        <source>Battle mode (1): %1</source>
+        <translation>Mode de combat (1) : %1</translation>
     </message>
     <message>
         <source>Stores the result of the last battle in %1</source>
@@ -3231,19 +3230,19 @@ Certains scripts peuvent y faire référence !</translation>
         <translation>Lancer le tutoriel n°%1</translation>
     </message>
     <message>
-        <source>Countdown</source>
+        <source>Enable countdown timer</source>
         <translation>Compte à rebours</translation>
     </message>
     <message>
-        <source>Do not play the battle victory music</source>
+        <source>Do not play victory fanfare music</source>
         <translation>Ne pas jouer Fanfare</translation>
     </message>
     <message>
-        <source>Activates the battle arena</source>
+        <source>Activate Battle Arena</source>
         <translation>Active l&apos;arène de combat du Gold Saucer</translation>
     </message>
     <message>
-        <source>The party members do not perform their victory celebrations at the end of battle</source>
+        <source>Disable victory celebration</source>
         <translation>Les personnages ne font pas leur animation de victoire</translation>
     </message>
     <message>
@@ -4140,6 +4139,19 @@ Certains scripts peuvent y faire référence !</translation>
     <message>
         <source>Copy partially palette (2) (sourceTile=%1, targetTile=%2, sourcePal=%3, targetPal=%4, first color=%5)</source>
         <translation>Copier un morceau de palette (2) (sourceTile=%1, targetTile=%2, sourcePal=%3, ciblePal=%4, première couleur=%5)</translation>
+    </message>
+
+    <message>
+        <source>Battle mode (2): %1</source>
+        <translation>Mode de combat (2) : %1</translation>
+    </message>
+    <message>
+        <source>Unused (%1)</source>
+        <translation>Inutilisé (%1)</translation>
+    </message>
+    <message>
+        <source>Unusable (%1)</source>
+        <translation>Inutilisable (%1)</translation>
     </message>
 </context>
 <context>
@@ -5742,13 +5754,11 @@ id=%2
         <translation type="vanished">Changer d&apos;écran</translation>
     </message>
     <message>
-        <source>Battle mode</source>
-        <oldsource>Mode de combat</oldsource>
-        <translation>Mode de combat</translation>
+        <source>Battle mode (1)</source>
+        <translation>Mode de combat (1)</translation>
     </message>
     <message>
         <source>Battle mode (2)</source>
-        <oldsource>Mode de combat (2)</oldsource>
         <translation>Mode de combat (2)</translation>
     </message>
     <message>
@@ -6378,6 +6388,47 @@ id=%2
     <message>
         <source>???</source>
         <translation>???</translation>
+    </message>
+
+    <message>
+        <source>Disable rewards</source>
+        <translation>Ne pas afficher d&apos;écran de récompense</translation>
+    </message>
+    <message>
+        <source>Activate Battle Arena</source>
+        <translation>Active l&apos;arène de combat du Gold Saucer</translation>
+    </message>
+    <message>
+        <source>Do not play victory fanfare music</source>
+        <translation>Ne pas jouer Fanfare</translation>
+    </message>
+    <message>
+        <source>Unused</source>
+        <translation>Inutilisé</translation>
+    </message>
+    <message>
+        <source>Cannot escape from battle</source>
+        <translation>Impossible de fuir</translation>
+    </message>
+    <message>
+        <source>Preemptive attack</source>
+        <translation>Attaque préventive</translation>
+    </message>
+    <message>
+        <source>Enable countdown timer</source>
+        <translation>Activer le compte à rebours</translation>
+    </message>
+    <message>
+        <source>Disable victory celebration</source>
+        <translation>Les personnages ne font pas leur animation de victoire</translation>
+    </message>
+    <message>
+        <source>Unusable</source>
+        <translation>Inutilisable</translation>
+    </message>
+    <message>
+        <source>Disable Game Over</source>
+        <translation>Désactiver Game Over</translation>
     </message>
 </context>
 <context>

--- a/translations/Makou_Reactor_ja.ts
+++ b/translations/Makou_Reactor_ja.ts
@@ -2745,40 +2745,40 @@ Some scripts can refer to it!</source>
         <translation>解説 No.%1</translation>
     </message>
     <message>
-        <source>Countdown</source>
+        <source>Enable countdown timer</source>
         <translation>カウントダウン</translation>
     </message>
     <message>
-        <source>Pre-emptive attack</source>
+        <source>Preemptive attack</source>
         <translation>先制攻撃</translation>
     </message>
     <message>
-        <source>The party cannot escape the battle</source>
+        <source>Cannot escape from battle</source>
         <translation>パーティはバトルから逃走不能</translation>
     </message>
     <message>
-        <source>Do not play the battle victory music</source>
+        <source>Do not play victory fanfare music</source>
         <translation>バトル勝利時の BGM を再生しない</translation>
     </message>
     <message>
-        <source>Activates the battle arena</source>
+        <source>Activate Battle Arena</source>
         <translation>バトル アリーナの有効化</translation>
     </message>
     <message>
-        <source>Do not show battle rewards</source>
+        <source>Disable rewards</source>
         <translation>バトル後の AP/EXP/ギル/アイテム 精算画面を表示しない</translation>
     </message>
     <message>
-        <source>The party members do not perform their victory celebrations at the end of battle</source>
+        <source>Disable victory celebration</source>
         <translation>バトル後のメンバーの決めポーズをやめる</translation>
     </message>
     <message>
-        <source>Disable game over</source>
+        <source>Disable Game Over</source>
         <translation>ゲーム オーバーを無効化</translation>
     </message>
     <message>
-        <source>Battle mode: %1</source>
-        <translation>バトル モード : %1</translation>
+        <source>Battle mode (1): %1</source>
+        <translation>バトル モード (1) : %1</translation>
     </message>
     <message>
         <source>None</source>
@@ -3667,6 +3667,19 @@ Some scripts can refer to it!</source>
     <message>
         <source>Copy partially palette (2) (sourceTile=%1, targetTile=%2, sourcePal=%3, targetPal=%4, first color=%5)</source>
         <translation type="unfinished"></translation>
+    </message>
+
+    <message>
+        <source>Battle mode (2): %1</source>
+        <translation>バトル モード (2) : %1</translation>
+    </message>
+    <message>
+        <source>Unused (%1)</source>
+        <translation>未使用 (%1)</translation>
+    </message>
+    <message>
+        <source>Unusable (%1)</source>
+        <translation>使用不可 (%1)</translation>
     </message>
 </context>
 <context>
@@ -5026,12 +5039,12 @@ Make sure it is valid or delete it.</source>
         <translation>バトルをオン/オフ</translation>
     </message>
     <message>
-        <source>Battle mode</source>
-        <translation>バトル モード</translation>
+        <source>Battle mode (1)</source>
+        <translation>バトル モード (1)</translation>
     </message>
     <message>
         <source>Battle mode (2)</source>
-        <translation>バトル モード</translation>
+        <translation>バトル モード (2)</translation>
     </message>
     <message>
         <source>Map Jump On/Off</source>
@@ -5833,6 +5846,47 @@ Make sure it is valid or delete it.</source>
     <message>
         <source>???</source>
         <translation>???</translation>
+    </message>
+
+    <message>
+        <source>Disable rewards</source>
+        <translation>バトル後の AP/EXP/ギル/アイテム 精算画面を表示しない</translation>
+    </message>
+    <message>
+        <source>Activate Battle Arena</source>
+        <translation>バトル アリーナの有効化</translation>
+    </message>
+    <message>
+        <source>Do not play victory fanfare music</source>
+        <translation>バトル勝利時の BGM を再生しない</translation>
+    </message>
+    <message>
+        <source>Unused</source>
+        <translation>未使用</translation>
+    </message>
+    <message>
+        <source>Cannot escape from battle</source>
+        <translation>バトルから逃走不能</translation>
+    </message>
+    <message>
+        <source>Preemptive attack</source>
+        <translation>先制攻撃</translation>
+    </message>
+    <message>
+        <source>Enable countdown timer</source>
+        <translation>カウントダウンタイマーを有効化</translation>
+    </message>
+    <message>
+        <source>Disable victory celebration</source>
+        <translation>バトル後のメンバーの決めポーズをやめる</translation>
+    </message>
+    <message>
+        <source>Unusable</source>
+        <translation>使用不可</translation>
+    </message>
+    <message>
+        <source>Disable Game Over</source>
+        <translation>ゲーム オーバーを無効化</translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
Fixes #60.

Clarifies both Field Battle Mode opcodes so their arguments and script summaries reflect the effective battle-mode values used by the game, without changing either opcode's binary format.

The original opcodes remain available:
- `BTLMD` / `0x72` remains the 16-bit raw opcode and is shown as **Battle mode (1)**.
- `BTMD2` / `0x22` remains the 32-bit raw opcode and is shown as **Battle mode (2)**.

### Battle mode (1)

01  Disable rewards
02  Activate Battle Arena
03  Do not play victory fanfare music
04  Unused
05  Cannot escape from battle
06  Preemptive attack
07  Enable countdown timer
08  Unused
09-15  Unusable
16  Disable Game Over

The first eight positions correspond to the same effective battle-mode bits as Battle mode (2). Position 08 is therefore labelled `Unused`, rather than `Unusable`: it represents the existing 0x01 battle-mode bit, but that bit has no known effect. Positions 09-15 are the unusable part of the second raw byte; position 16 is the intended Disable Game Over value.

### Battle mode (2)

01  Disable rewards
02  Activate Battle Arena
03  Do not play victory fanfare music
04  Unused
05  Cannot escape from battle
06  Preemptive attack
07  Enable countdown timer
08-15  Unused
16  Disable victory celebration
17-23  Unusable
24  Disable Game Over
25-32  Unusable

The Arguments column now uses these names instead of the generic `Flag` label.

The script/opcode overview is also updated. It now distinguishes **Battle mode (1)** from **Battle mode (2)** and uses the same descriptions. Unused/unusable positions include their displayed position number in the overview, e.g. `Unused (08)` or `Unusable (17)`, so multiple unknown/nonfunctional bits remain distinguishable.

French and Japanese translation entries are updated as well.

No parsing, serialization, opcode size, or stored bit value is changed by this PR.
