### PR TITLE
Fix Battle Mode flag editor loading

### DIFF
--- a/src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp
+++ b/src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.cpp
@@ -181,11 +181,14 @@ void ScriptEditorGenericList::delLastRow()
 	emit opcodeChanged();
 }
 
-void ScriptEditorGenericList::addRow(int value, int minValue, int maxValue, int type)
+void ScriptEditorGenericList::addRow(int value, int minValue, int maxValue, int type, const QString &name)
 {
 	QList<QStandardItem *> items;
 	QStandardItem *standardItem;
-	standardItem = new QStandardItem(paramName(type));
+	standardItem = new QStandardItem(name.isEmpty() ? paramName(type) : name);
+	if (!name.isEmpty()) {
+		standardItem->setToolTip(name);
+	}
 	standardItem->setEditable(false);
 	items.append(standardItem);
 
@@ -282,14 +285,10 @@ void ScriptEditorGenericList::fillModel()
 				maxValue = int(pow(2, paramSize)) - 1;
 				minValue = 0;
 			}			
-			addRow(value, minValue, maxValue, paramType);
-
-			if (opcode().id() == OpcodeKey::BTLMD || opcode().id() == OpcodeKey::BTMD2) {
-				QStandardItem *nameItem = model->item(i, 0);
-				const QString name = battleModeParamName(opcode().id(), i);
-				nameItem->setText(name);
-				nameItem->setToolTip(name);
-			}
+			const bool isBattleMode = opcode().id() == OpcodeKey::BTLMD
+			        || opcode().id() == OpcodeKey::BTMD2;
+			const QString name = isBattleMode ? battleModeParamName(opcode().id(), i) : QString();
+			addRow(value, minValue, maxValue, paramType, name);
 
 			cur += paramSize;
 		}

--- a/src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.h
+++ b/src/widgets/ScriptEditorWidgets/ScriptEditorGenericList.h
@@ -46,7 +46,7 @@ private slots:
 
 private:
 	void build() override;
-	void addRow(int value, int minValue, int maxValue, int type);
+	void addRow(int value, int minValue, int maxValue, int type, const QString &name = QString());
 	void fillModel();
 	QByteArray parseModel(bool *isLabel);
 	QList<int> paramTypes(int id);


### PR DESCRIPTION
Fix the Battle Mode flag editor loading regression introduced by the Battle Mode label update.

The Battle Mode label code changed the first-column `QStandardItem` after `addRow()` had already inserted it into `QStandardItemModel`. Those post-insertion `setText()` / `setToolTip()` calls can emit `itemChanged` while the 16/32-row model is still being populated, causing the editor's working opcode to be rebuilt from an incomplete model and clearing flags.

This change avoids the re-entrant edit path without blocking model signals:

- `addRow()` accepts an optional display name;
- Battle Mode names/tooltips are assigned while the item is being constructed, before `model->appendRow()`;
- the post-insertion item lookup and `setText()` / `setToolTip()` calls are removed.

Both BTLMD and BTMD2 use this shared path. Other generic opcodes keep the previous behavior through the default empty name.

No flag mapping, opcode serialization, binary layout, or summary logic is changed.
